### PR TITLE
[WIP] Value conversion

### DIFF
--- a/src/value/array.rs
+++ b/src/value/array.rs
@@ -3,7 +3,6 @@ use crate::{
     Ctx, FromJs, Object, Result, Value,
 };
 use rquickjs_sys as qjs;
-use std::ffi::CStr;
 
 /// Rust representation of a javascript object optimized as an array.
 ///
@@ -34,8 +33,7 @@ impl<'js> Array<'js> {
     pub fn len(&self) -> usize {
         let v = self.0.as_js_value();
         unsafe {
-            let prop = CStr::from_bytes_with_nul(b"length\0").unwrap();
-            let val = qjs::JS_GetPropertyStr(self.0.ctx.ctx, v, prop.as_ptr());
+            let val = qjs::JS_GetPropertyStr(self.0.ctx.ctx, v, b"length\0".as_ptr() as *const _);
             assert!(qjs::JS_IsInt(val));
             qjs::JS_VALUE_GET_INT!(val) as usize
         }

--- a/src/value/array.rs
+++ b/src/value/array.rs
@@ -1,8 +1,12 @@
 use crate::{
     value::{self, rf::JsObjectRef},
-    Ctx, FromJs, Object, Result, Value,
+    Ctx, FromJs, Object, Result, ToJs, Value,
 };
 use rquickjs_sys as qjs;
+use std::{
+    iter::{IntoIterator, Iterator},
+    marker::PhantomData,
+};
 
 /// Rust representation of a javascript object optimized as an array.
 ///
@@ -44,13 +48,76 @@ impl<'js> Array<'js> {
         self.len() == 0
     }
 
-    /// Get the value at a index in the javascript array.
+    /// Get the value at an index in the javascript array.
     pub fn get<V: FromJs<'js>>(&self, idx: u32) -> Result<V> {
+        let obj = self.0.as_js_value();
+        let val = unsafe {
+            let val = qjs::JS_GetPropertyUint32(self.0.ctx.ctx, obj, idx);
+            Value::from_js_value(self.0.ctx, val)
+        }?;
+        V::from_js(self.0.ctx, val)
+    }
+
+    /// Set the value at an index in the javascript array.
+    pub fn set<V: ToJs<'js>>(&self, idx: u32, val: V) -> Result<()> {
+        let obj = self.0.as_js_value();
+        let val = val.to_js(self.0.ctx)?.into_js_value();
         unsafe {
-            let v = self.0.as_js_value();
-            let val = qjs::JS_GetPropertyUint32(self.0.ctx.ctx, v, idx);
-            let val = Value::from_js_value(self.0.ctx, val)?;
-            V::from_js(self.0.ctx, val)
+            if -1 == qjs::JS_SetPropertyUint32(self.0.ctx.ctx, obj, idx, val) {
+                return Err(value::get_exception(self.0.ctx));
+            }
+        }
+        Ok(())
+    }
+
+    /// Get iterator over elments of an array
+    pub fn iter<T: FromJs<'js>>(&self) -> ArrayIter<'js, T> {
+        let count = self.len() as u32;
+        ArrayIter {
+            array: self.clone(),
+            index: 0,
+            count,
+            marker: PhantomData,
+        }
+    }
+}
+
+/// The iterator for an array
+pub struct ArrayIter<'js, T> {
+    array: Array<'js>,
+    index: u32,
+    count: u32,
+    marker: PhantomData<T>,
+}
+
+impl<'js, T> Iterator for ArrayIter<'js, T>
+where
+    T: FromJs<'js>,
+{
+    type Item = Result<T>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.index < self.count {
+            let res = self.array.get(self.index);
+            self.index += 1;
+            Some(res)
+        } else {
+            None
+        }
+    }
+}
+
+impl<'js> IntoIterator for Array<'js> {
+    type Item = Result<Value<'js>>;
+    type IntoIter = ArrayIter<'js, Value<'js>>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        let count = self.len() as u32;
+        ArrayIter {
+            array: self,
+            index: 0,
+            count,
+            marker: PhantomData,
         }
     }
 }
@@ -100,6 +167,47 @@ mod test {
                 .unwrap();
             let object = val.into_object();
             assert_eq!(object.get::<_, i32>(0).unwrap(), 1);
+        })
+    }
+
+    #[test]
+    fn into_iter() {
+        let rt = Runtime::new().unwrap();
+        let ctx = Context::full(&rt).unwrap();
+        ctx.with(|ctx| {
+            let val: Array = ctx
+                .eval(
+                    r#"
+                      [1,'abcd',true]
+                    "#,
+                )
+                .unwrap();
+            let elems: Vec<_> = val.into_iter().collect::<Result<_>>().unwrap();
+            assert_eq!(elems.len(), 3);
+            assert_eq!(elems[0], Value::Int(1));
+            assert_eq!(StdString::from_js(ctx, elems[1].clone()).unwrap(), "abcd");
+            assert_eq!(elems[2], Value::Bool(true));
+        })
+    }
+
+    #[test]
+    fn iter() {
+        let rt = Runtime::new().unwrap();
+        let ctx = Context::full(&rt).unwrap();
+        ctx.with(|ctx| {
+            let val: Array = ctx
+                .eval(
+                    r#"
+                      ["a", 'b', '', "cdef"]
+                    "#,
+                )
+                .unwrap();
+            let elems: Vec<StdString> = val.iter().collect::<Result<_>>().unwrap();
+            assert_eq!(elems.len(), 4);
+            assert_eq!(elems[0], "a");
+            assert_eq!(elems[1], "b");
+            assert_eq!(elems[2], "");
+            assert_eq!(elems[3], "cdef");
         })
     }
 }

--- a/src/value/convert/atom.rs
+++ b/src/value/convert/atom.rs
@@ -1,6 +1,30 @@
-use super::ToAtom;
-use crate::{value::*, Ctx};
+use super::{FromAtom, ToAtom};
+use crate::{value::*, Ctx, Result};
 use std::string::String as StdString;
+
+impl<'js> FromAtom<'js> for Atom<'js> {
+    fn from_atom(atom: Atom<'js>) -> Result<Self> {
+        Ok(atom)
+    }
+}
+
+impl<'js> FromAtom<'js> for Value<'js> {
+    fn from_atom(atom: Atom<'js>) -> Result<Self> {
+        atom.to_value()
+    }
+}
+
+impl<'js> FromAtom<'js> for String<'js> {
+    fn from_atom(atom: Atom<'js>) -> Result<Self> {
+        atom.to_js_string()
+    }
+}
+
+impl<'js> FromAtom<'js> for StdString {
+    fn from_atom(atom: Atom<'js>) -> Result<Self> {
+        atom.to_string()
+    }
+}
 
 impl<'js> ToAtom<'js> for Atom<'js> {
     fn to_atom(self, _: Ctx<'js>) -> Atom<'js> {
@@ -33,28 +57,18 @@ impl<'js> ToAtom<'js> for u32 {
 }
 
 macro_rules! impl_for_to_js(
-    ($ty:ident, $Var:ident) => {
-        impl<'js> ToAtom<'js> for $ty{
-            fn to_atom(self, ctx: Ctx<'js>) -> Atom<'js>{
-                Atom::from_value(ctx,&Value::$Var(self))
+    ($ty:ty, $Var:ident) => {
+        impl<'js> ToAtom<'js> for $ty {
+            fn to_atom(self, ctx: Ctx<'js>) -> Atom<'js> {
+                Atom::from_value(ctx, &Value::$Var(self))
             }
         }
     }
 );
 
-macro_rules! impl_for_to_js_lt(
-    ($ty:ident, $Var:ident) => {
-        impl<'js> ToAtom<'js> for $ty<'js>{
-            fn to_atom(self, ctx: Ctx<'js>) -> Atom<'js>{
-                Atom::from_value(ctx,&Value::$Var(self))
-            }
-        }
-    }
-);
-
-impl_for_to_js_lt!(String, String);
-impl_for_to_js_lt!(Object, Object);
-impl_for_to_js_lt!(Array, Array);
-impl_for_to_js_lt!(Function, Function);
+impl_for_to_js!(String<'js>, String);
+impl_for_to_js!(Object<'js>, Object);
+impl_for_to_js!(Array<'js>, Array);
+impl_for_to_js!(Function<'js>, Function);
 impl_for_to_js!(i32, Int);
 impl_for_to_js!(bool, Bool);

--- a/src/value/convert/mod.rs
+++ b/src/value/convert/mod.rs
@@ -16,7 +16,7 @@ pub trait FromJs<'js>: Sized {
 pub trait FromJsMulti<'js>: Sized {
     fn from_js_multi(ctx: Ctx<'js>, value: MultiValue<'js>) -> Result<Self>;
 
-    fn len() -> i64;
+    const LEN: i32;
 }
 
 /// For converting rust values to javascript values

--- a/src/value/convert/mod.rs
+++ b/src/value/convert/mod.rs
@@ -19,6 +19,11 @@ pub trait FromJsMulti<'js>: Sized {
     const LEN: i32;
 }
 
+/// Trait for converting values from atoms.
+pub trait FromAtom<'js>: Sized {
+    fn from_atom(atom: Atom<'js>) -> Result<Self>;
+}
+
 /// For converting rust values to javascript values
 pub trait ToJs<'js> {
     fn to_js(self, ctx: Ctx<'js>) -> Result<Value<'js>>;

--- a/src/value/convert/mod.rs
+++ b/src/value/convert/mod.rs
@@ -1,4 +1,4 @@
-use crate::{context::Ctx, Atom, MultiValue, Result, Value};
+use crate::{context::Ctx, Atom, MultiValue, MultiValueJs, Result, Value};
 mod atom;
 mod from;
 mod multi;
@@ -32,7 +32,7 @@ pub trait ToJs<'js> {
 /// For converting multiple of value to javascript
 /// Mostly used for converting the arguments of a function from rust to javascript
 pub trait ToJsMulti<'js> {
-    fn to_js_multi(self, ctx: Ctx<'js>) -> Result<Vec<Value>>;
+    fn to_js_multi(self, ctx: Ctx<'js>) -> Result<MultiValueJs<'js>>;
 }
 
 /// Trait for converting values to atoms.

--- a/src/value/convert/mod.rs
+++ b/src/value/convert/mod.rs
@@ -1,4 +1,4 @@
-use crate::{context::Ctx, Atom, MultiValue, MultiValueJs, Result, Value};
+use crate::{context::Ctx, Atom, MultiValue, MultiValueJs, RestValues, Result, Value};
 mod atom;
 mod from;
 mod multi;

--- a/src/value/convert/multi.rs
+++ b/src/value/convert/multi.rs
@@ -1,5 +1,6 @@
-use super::{FromJs, FromJsMulti, MultiValue, MultiValueJs, ToJs, ToJsMulti};
-use crate::{Ctx, Result, Value};
+use super::{FromJs, FromJsMulti, MultiValue, MultiValueJs, RestValues, ToJs, ToJsMulti, Value};
+use crate::{Ctx, Result};
+use std::iter::{empty, once};
 
 impl<'js> ToJsMulti<'js> for MultiValueJs<'js> {
     fn to_js_multi(self, _: Ctx<'js>) -> Result<MultiValueJs<'js>> {
@@ -29,11 +30,38 @@ impl<'js> FromJsMulti<'js> for () {
     const LEN: i32 = 0;
 }
 
+impl<'js, X> ToJsMulti<'js> for RestValues<X>
+where
+    X: ToJs<'js>,
+{
+    fn to_js_multi(self, ctx: Ctx<'js>) -> Result<MultiValueJs<'js>> {
+        let rest: Vec<_> = self.into();
+        let iter = rest.into_iter().map(|value| value.to_js(ctx));
+        Ok(iter.collect::<Result<Vec<_>>>()?.into())
+    }
+}
+
+impl<'js, X> FromJsMulti<'js> for RestValues<X>
+where
+    X: FromJs<'js>,
+{
+    fn from_js_multi(ctx: Ctx<'js>, mut value: MultiValue<'js>) -> Result<Self> {
+        Ok(value
+            .iter()
+            .map(|value| X::from_js(ctx, value))
+            .collect::<Result<Vec<_>>>()?
+            .into())
+    }
+
+    const LEN: i32 = 0;
+}
+
 macro_rules! impl_from_to_js_multi {
     ($($($t:ident)*;)*) => {
         $(
             impl<'js, $($t,)*> ToJsMulti<'js> for ($($t,)*)
-            where $($t: ToJs<'js>,)*
+            where
+                $($t: ToJs<'js>,)*
             {
                 #[allow(non_snake_case)]
                 fn to_js_multi(self, ctx: Ctx<'js>) -> Result<MultiValueJs<'js>>{
@@ -44,8 +72,25 @@ macro_rules! impl_from_to_js_multi {
                 }
             }
 
+            impl<'js, $($t,)* X> ToJsMulti<'js> for ($($t,)* RestValues<X>)
+            where
+                $($t: ToJs<'js>,)*
+                X: ToJs<'js>,
+            {
+                #[allow(non_snake_case)]
+                fn to_js_multi(self, ctx: Ctx<'js>) -> Result<MultiValueJs<'js>>{
+                    let ($($t,)* X) = self;
+                    let iter = empty();
+                    $(let iter = iter.chain(once($t.to_js(ctx))));*;
+                    let rest: Vec<_> = X.into();
+                    let iter = iter.chain(rest.into_iter().map(|value| value.to_js(ctx)));
+                    Ok(iter.collect::<Result<Vec<_>>>()?.into())
+                }
+            }
+
             impl<'js, $($t,)*> FromJsMulti<'js> for ($($t,)*)
-            where $($t: FromJs<'js>,)*
+            where
+                $($t: FromJs<'js>,)*
             {
                 #[allow(non_snake_case)]
                 fn from_js_multi(ctx: Ctx<'js>, mut value: MultiValue<'js>) -> Result<Self> {
@@ -56,6 +101,27 @@ macro_rules! impl_from_to_js_multi {
                                 .unwrap_or(Value::Undefined);
                             $t::from_js(ctx,v)?
                         },)*
+                    ))
+                }
+
+                const LEN: i32 = impl_from_to_js_multi!(@count $($t),*);
+            }
+
+            impl<'js, $($t,)* X> FromJsMulti<'js> for ($($t,)* RestValues<X>)
+            where
+                $($t: FromJs<'js>,)*
+                X: FromJs<'js>,
+            {
+                #[allow(non_snake_case)]
+                fn from_js_multi(ctx: Ctx<'js>, mut value: MultiValue<'js>) -> Result<Self> {
+                    let mut iter = value.iter();
+                    Ok((
+                        $({
+                            let value = iter.next()
+                                .unwrap_or_else(|| Value::Undefined);
+                            $t::from_js(ctx, value)?
+                        },)*
+                        iter.map(|value| X::from_js(ctx, value)).collect::<Result<Vec<_>>>()?.into()
                     ))
                 }
 

--- a/src/value/convert/multi.rs
+++ b/src/value/convert/multi.rs
@@ -158,12 +158,120 @@ impl_from_to_js_multi! {
 
 #[cfg(test)]
 mod test {
-    use super::*;
+    use crate::*;
 
     #[test]
     fn from_js_multi_len() {
         assert_eq!(<((),)>::LEN, 1);
         assert_eq!(<((), ())>::LEN, 2);
         assert_eq!(<((), (), ())>::LEN, 3);
+    }
+
+    #[test]
+    fn call_js_fn_with_var_args() {
+        let rt = Runtime::new().unwrap();
+        let ctx = Context::full(&rt).unwrap();
+        let res: Vec<i8> = ctx.with(|ctx| {
+            let func: Function = ctx
+                .eval(
+                    r#"
+                  (...x) => [x.length, ...x]
+                "#,
+                )
+                .unwrap();
+            func.call(RestValues::from(vec![1, 2, 3])).unwrap()
+        });
+        assert_eq!(res.len(), 4);
+        assert_eq!(res[0], 3);
+        assert_eq!(res[1], 1);
+        assert_eq!(res[2], 2);
+        assert_eq!(res[3], 3);
+    }
+
+    #[test]
+    fn call_js_fn_with_rest_args() {
+        let rt = Runtime::new().unwrap();
+        let ctx = Context::full(&rt).unwrap();
+        let res: Vec<i8> = ctx.with(|ctx| {
+            let func: Function = ctx
+                .eval(
+                    r#"
+                  (a, b, ...x) => [a, b, x.length, ...x]
+                "#,
+                )
+                .unwrap();
+            func.call((-2, -1, RestValues::from(vec![1, 2]))).unwrap()
+        });
+        assert_eq!(res.len(), 5);
+        assert_eq!(res[0], -2);
+        assert_eq!(res[1], -1);
+        assert_eq!(res[2], 2);
+        assert_eq!(res[3], 1);
+        assert_eq!(res[4], 2);
+    }
+
+    #[test]
+    fn call_rust_fn_with_var_args() {
+        let rt = Runtime::new().unwrap();
+        let ctx = Context::full(&rt).unwrap();
+        let res: Vec<i8> = ctx.with(|ctx| {
+            let func = Function::new(
+                ctx,
+                "test_fn",
+                |_ctx, _this: Value, args: RestValues<i8>| -> Result<_> {
+                    use std::iter::once;
+                    Ok(once(args.len() as i8)
+                        .chain(args.iter().cloned())
+                        .collect::<Vec<_>>())
+                },
+            )
+            .unwrap();
+            ctx.globals().set("test_fn", func).unwrap();
+            ctx.eval(
+                r#"
+                  test_fn(1, 2, 3)
+                "#,
+            )
+            .unwrap()
+        });
+        assert_eq!(res.len(), 4);
+        assert_eq!(res[0], 3);
+        assert_eq!(res[1], 1);
+        assert_eq!(res[2], 2);
+        assert_eq!(res[3], 3);
+    }
+
+    #[test]
+    fn call_rust_fn_with_rest_args() {
+        let rt = Runtime::new().unwrap();
+        let ctx = Context::full(&rt).unwrap();
+        let res: Vec<i8> = ctx.with(|ctx| {
+            let func = Function::new(
+                ctx,
+                "test_fn",
+                |_ctx, _this: Value, (arg1, arg2, args): (i8, i8, RestValues<i8>)| -> Result<_> {
+                    use std::iter::once;
+                    Ok(once(arg1)
+                        .chain(once(arg2))
+                        .chain(once(args.len() as i8))
+                        .chain(args.iter().cloned())
+                        .collect::<Vec<_>>())
+                },
+            )
+            .unwrap();
+            ctx.globals().set("test_fn", func).unwrap();
+            ctx.eval(
+                r#"
+                  test_fn(-2, -1, 1, 2)
+                "#,
+            )
+            .unwrap()
+        });
+        assert_eq!(res.len(), 5);
+        assert_eq!(res[0], -2);
+        assert_eq!(res[1], -1);
+        assert_eq!(res[2], 2);
+        assert_eq!(res[3], 1);
+        assert_eq!(res[4], 2);
     }
 }

--- a/src/value/convert/multi.rs
+++ b/src/value/convert/multi.rs
@@ -1,15 +1,15 @@
-use super::{FromJs, FromJsMulti, MultiValue, ToJs, ToJsMulti};
+use super::{FromJs, FromJsMulti, MultiValue, MultiValueJs, ToJs, ToJsMulti};
 use crate::{Ctx, Result, Value};
 
-impl<'js> ToJsMulti<'js> for Vec<Value<'js>> {
-    fn to_js_multi(self, _: Ctx<'js>) -> Result<Vec<Value<'js>>> {
+impl<'js> ToJsMulti<'js> for MultiValueJs<'js> {
+    fn to_js_multi(self, _: Ctx<'js>) -> Result<MultiValueJs<'js>> {
         Ok(self)
     }
 }
 
 impl<'js, T: ToJs<'js>> ToJsMulti<'js> for T {
-    fn to_js_multi(self, ctx: Ctx<'js>) -> Result<Vec<Value<'js>>> {
-        Ok(vec![self.to_js(ctx)?])
+    fn to_js_multi(self, ctx: Ctx<'js>) -> Result<MultiValueJs<'js>> {
+        Ok(vec![self.to_js(ctx)?].into())
     }
 }
 
@@ -36,11 +36,11 @@ macro_rules! impl_from_to_js_multi {
             where $($t: ToJs<'js>,)*
             {
                 #[allow(non_snake_case)]
-                fn to_js_multi(self, ctx: Ctx<'js>) -> Result<Vec<Value<'js>>>{
+                fn to_js_multi(self, ctx: Ctx<'js>) -> Result<MultiValueJs<'js>>{
                     let ($($t,)*) = self;
                     Ok(vec![
                         $($t.to_js(ctx)?,)*
-                    ])
+                    ].into())
                 }
             }
 

--- a/src/value/convert/multi.rs
+++ b/src/value/convert/multi.rs
@@ -18,9 +18,7 @@ impl<'js> FromJsMulti<'js> for MultiValue<'js> {
         Ok(value)
     }
 
-    fn len() -> i64 {
-        -1
-    }
+    const LEN: i32 = -1;
 }
 
 impl<'js> FromJsMulti<'js> for () {
@@ -28,9 +26,7 @@ impl<'js> FromJsMulti<'js> for () {
         Ok(())
     }
 
-    fn len() -> i64 {
-        0
-    }
+    const LEN: i32 = 0;
 }
 
 macro_rules! impl_to_js_multi{
@@ -66,9 +62,7 @@ macro_rules! impl_from_js_multi{
                 ))
             }
 
-            fn len() -> i64{
-                $num
-            }
+            const LEN: i32 = $num;
         }
     }
 }

--- a/src/value/convert/to.rs
+++ b/src/value/convert/to.rs
@@ -1,34 +1,14 @@
 use super::ToJs;
-use crate::{Array, Ctx, Function, Object, Result, String, Value};
-use std::string::String as StdString;
+use crate::{Array, Ctx, Function, IteratorJs, Object, Result, String, ToAtom, Value};
+use std::{
+    collections::{BTreeMap, BTreeSet, HashMap, HashSet, LinkedList, VecDeque},
+    result::Result as StdResult,
+    string::String as StdString,
+};
 
 impl<'js> ToJs<'js> for Value<'js> {
     fn to_js(self, _: Ctx<'js>) -> Result<Value<'js>> {
         Ok(self)
-    }
-}
-
-impl<'js> ToJs<'js> for String<'js> {
-    fn to_js(self, _: Ctx<'js>) -> Result<Value<'js>> {
-        Ok(Value::String(self))
-    }
-}
-
-impl<'js> ToJs<'js> for Object<'js> {
-    fn to_js(self, _: Ctx<'js>) -> Result<Value<'js>> {
-        Ok(Value::Object(self))
-    }
-}
-
-impl<'js> ToJs<'js> for Function<'js> {
-    fn to_js(self, _: Ctx<'js>) -> Result<Value<'js>> {
-        Ok(Value::Function(self))
-    }
-}
-
-impl<'js> ToJs<'js> for Array<'js> {
-    fn to_js(self, _: Ctx<'js>) -> Result<Value<'js>> {
-        Ok(Value::Array(self))
     }
 }
 
@@ -46,14 +26,150 @@ impl<'js, 'a> ToJs<'js> for &'a str {
     }
 }
 
-impl<'js> ToJs<'js> for i32 {
-    fn to_js(self, _: Ctx<'js>) -> Result<Value<'js>> {
-        Ok(Value::Int(self))
-    }
-}
-
 impl<'js> ToJs<'js> for () {
     fn to_js(self, _: Ctx<'js>) -> Result<Value<'js>> {
         Ok(Value::Undefined)
     }
+}
+
+impl<'js, T> ToJs<'js> for Option<T>
+where
+    T: ToJs<'js>,
+{
+    fn to_js(self, ctx: Ctx<'js>) -> Result<Value<'js>> {
+        Ok(match self {
+            Some(value) => value.to_js(ctx)?,
+            _ => Value::Undefined,
+        })
+    }
+}
+
+impl<'js, T, E> ToJs<'js> for StdResult<T, E>
+where
+    T: ToJs<'js>,
+    E: ToJs<'js>,
+{
+    fn to_js(self, ctx: Ctx<'js>) -> Result<Value<'js>> {
+        Ok(match self {
+            Ok(value) => value.to_js(ctx)?,
+            Err(error) => error.to_js(ctx)?,
+        })
+    }
+}
+
+macro_rules! tojs_impls {
+    // for JS Value sub-types
+    ($($type:ident,)*) => {
+        $(
+            impl<'js> ToJs<'js> for $type<'js> {
+                fn to_js(self, _: Ctx<'js>) -> Result<Value<'js>> {
+                    Ok(Value::$type(self))
+                }
+            }
+        )*
+    };
+
+    // for list-like Rust types
+    (list: $($type:ident,)*) => {
+        $(
+            impl<'js, T> ToJs<'js> for $type<T>
+            where
+                T: ToJs<'js>,
+            {
+                fn to_js(self, ctx: Ctx<'js>) -> Result<Value<'js>> {
+                    self.into_iter()
+                        .collect_js::<Array>(ctx)
+                        .map(Value::Array)
+                }
+            }
+        )*
+    };
+
+    // for map-like Rust types
+    (map: $($type:ident,)*) => {
+        $(
+            impl<'js, K, V> ToJs<'js> for $type<K, V>
+            where
+                K: ToAtom<'js>,
+                V: ToJs<'js>,
+            {
+                fn to_js(self, ctx: Ctx<'js>) -> Result<Value<'js>> {
+                    self.into_iter()
+                        .collect_js::<Object>(ctx)
+                        .map(Value::Object)
+                }
+            }
+        )*
+    };
+
+    // for primitive types
+    ($($type:ty: $jstype:ident,)*) => {
+        $(
+            impl<'js> ToJs<'js> for $type {
+                fn to_js(self, _: Ctx<'js>) -> Result<Value<'js>> {
+                    Ok(Value::$jstype(self as _))
+                }
+            }
+        )*
+    };
+
+    // for primitive types which needs error-prone casting (ex. u32 -> i32)
+    ($($type:ty => $totype:ty: $jstype:ident,)*) => {
+        $(
+            impl<'js> ToJs<'js> for $type {
+                fn to_js(self, _: Ctx<'js>) -> Result<Value<'js>> {
+                    use std::convert::TryFrom;
+                    let val = <$totype>::try_from(self).map_err(|_| {
+                        $crate::Error::ToJsConversion {
+                            from: stringify!($type),
+                            to: stringify!($totype),
+                            message: None,
+                        }
+                    })?;
+                    Ok(Value::$jstype(val as _))
+                }
+            }
+        )*
+    };
+}
+
+tojs_impls! {
+    String,
+    Array,
+    Object,
+    Function,
+}
+
+tojs_impls! {
+    list:
+    VecDeque,
+    LinkedList,
+    HashSet,
+    BTreeSet,
+}
+
+tojs_impls! {
+    map:
+    HashMap,
+    BTreeMap,
+}
+
+tojs_impls! {
+    bool: Bool,
+
+    i8: Int,
+    i16: Int,
+    i32: Int,
+
+    u8: Int,
+    u16: Int,
+
+    f32: Float,
+    f64: Float,
+}
+
+tojs_impls! {
+    i64 => i32: Int,
+    u32 => i32: Int,
+    u64 => i32: Int,
 }

--- a/src/value/convert/to.rs
+++ b/src/value/convert/to.rs
@@ -142,6 +142,7 @@ tojs_impls! {
 
 tojs_impls! {
     list:
+    Vec,
     VecDeque,
     LinkedList,
     HashSet,

--- a/src/value/function/mod.rs
+++ b/src/value/function/mod.rs
@@ -114,7 +114,7 @@ impl<'js> Function<'js> {
                 ctx.ctx,
                 func,
                 name.as_ptr(),
-                F::Args::len() as c_int,
+                F::Args::LEN as c_int,
                 qjs::JSCFunctionEnum_JS_CFUNC_generic,
                 0,
             );

--- a/src/value/function/mod.rs
+++ b/src/value/function/mod.rs
@@ -2,12 +2,7 @@ use crate::{
     value::rf::JsObjectRef, Ctx, FromJs, FromJsMulti, Object, Result, ToJs, ToJsMulti, Value,
 };
 use rquickjs_sys as qjs;
-use std::{
-    ffi::{CStr, CString},
-    mem,
-    os::raw::c_int,
-    ptr,
-};
+use std::{ffi::CString, mem, os::raw::c_int, ptr};
 
 mod ffi;
 
@@ -161,9 +156,8 @@ impl<'js> Function<'js> {
         let class_id = ctx.get_opaque().func_class;
         let rt = qjs::JS_GetRuntime(ctx.ctx);
         if qjs::JS_IsRegisteredClass(rt, class_id) == 0 {
-            let class_name = CStr::from_bytes_with_nul(b"RustFunc\0").unwrap();
             let class_def = qjs::JSClassDef {
-                class_name: class_name.as_ptr(),
+                class_name: b"RustFunc\0".as_ptr() as *const _,
                 finalizer: Some(ffi::cb_finalizer),
                 gc_mark: None,
                 call: Some(ffi::cb_call),

--- a/src/value/mod.rs
+++ b/src/value/mod.rs
@@ -22,7 +22,7 @@ pub use atom::*;
 pub(crate) mod rf;
 use rf::{JsObjectRef, JsStringRef, JsSymbolRef};
 mod multi;
-pub use multi::{MultiValue, ValueIter};
+pub use multi::{MultiValue, MultiValueJs, ValueIter};
 
 /// The `FromIterator` trait to use with `Ctx`
 pub trait FromIteratorJs<'js, A>: Sized {

--- a/src/value/mod.rs
+++ b/src/value/mod.rs
@@ -22,7 +22,7 @@ pub use atom::*;
 pub(crate) mod rf;
 use rf::{JsObjectRef, JsStringRef, JsSymbolRef};
 mod multi;
-pub use multi::{MultiValue, MultiValueJs, ValueIter};
+pub use multi::{MultiValue, MultiValueJs, RestValues, ValueIter};
 
 /// The `FromIterator` trait to use with `Ctx`
 pub trait FromIteratorJs<'js, A>: Sized {

--- a/src/value/multi.rs
+++ b/src/value/multi.rs
@@ -181,3 +181,39 @@ impl<'js> DerefMut for MultiValueJs<'js> {
         &mut self.0
     }
 }
+
+/// Rest values
+#[derive(Clone, Default)]
+pub struct RestValues<T>(Vec<T>);
+
+impl<T> RestValues<T> {
+    pub fn new() -> Self {
+        Self(Vec::new())
+    }
+}
+
+impl<T> From<Vec<T>> for RestValues<T> {
+    fn from(vec: Vec<T>) -> Self {
+        Self(vec)
+    }
+}
+
+impl<T> Into<Vec<T>> for RestValues<T> {
+    fn into(self) -> Vec<T> {
+        self.0
+    }
+}
+
+impl<T> Deref for RestValues<T> {
+    type Target = Vec<T>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl<T> DerefMut for RestValues<T> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}

--- a/src/value/multi.rs
+++ b/src/value/multi.rs
@@ -3,6 +3,7 @@ use rquickjs_sys as qjs;
 use std::{
     iter::{ExactSizeIterator, FusedIterator},
     mem,
+    ops::{Deref, DerefMut},
 };
 
 /// An iterator over a list of js values
@@ -56,7 +57,7 @@ impl<'js> Drop for ValueIter<'js> {
     }
 }
 
-/// An list of Js values.
+/// An list of values given from JS
 ///
 /// Handed to callbacks as arguments.
 pub struct MultiValue<'js> {
@@ -140,5 +141,43 @@ impl<'js> MultiValue<'js> {
 impl<'js> Drop for MultiValue<'js> {
     fn drop(&mut self) {
         mem::drop(self.iter())
+    }
+}
+
+/// An list of values to pass to JS
+///
+/// Passed to functions as arguments when calling.
+#[derive(Clone, Default)]
+pub struct MultiValueJs<'js>(Vec<Value<'js>>);
+
+impl<'js> MultiValueJs<'js> {
+    pub fn new() -> Self {
+        Self(Vec::new())
+    }
+}
+
+impl<'js> From<Vec<Value<'js>>> for MultiValueJs<'js> {
+    fn from(vec: Vec<Value<'js>>) -> Self {
+        Self(vec)
+    }
+}
+
+impl<'js> Into<Vec<Value<'js>>> for MultiValueJs<'js> {
+    fn into(self) -> Vec<Value<'js>> {
+        self.0
+    }
+}
+
+impl<'js> Deref for MultiValueJs<'js> {
+    type Target = Vec<Value<'js>>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl<'js> DerefMut for MultiValueJs<'js> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
     }
 }

--- a/src/value/object.rs
+++ b/src/value/object.rs
@@ -1,8 +1,13 @@
 use crate::{
     value::{self, rf::JsObjectRef},
-    Ctx, FromJs, Result, ToAtom, ToJs, Value,
+    Atom, Ctx, FromAtom, FromJs, Result, ToAtom, ToJs, Value,
 };
 use rquickjs_sys as qjs;
+use std::{
+    iter::{IntoIterator, Iterator},
+    marker::PhantomData,
+    mem,
+};
 
 /// Rust representation of a javascript object.
 #[derive(Debug, PartialEq, Clone)]
@@ -60,7 +65,7 @@ impl<'js> Object<'js> {
         Ok(())
     }
 
-    /// Remove a member of this objects
+    /// Remove a member of an object
     pub fn remove<K: ToAtom<'js>>(&self, key: K) -> Result<()> {
         let atom = key.to_atom(self.0.ctx);
         unsafe {
@@ -77,6 +82,55 @@ impl<'js> Object<'js> {
         Ok(())
     }
 
+    /// Get own property names of an object
+    pub fn own_keys<K: FromAtom<'js>>(
+        &self,
+        enumerable_only: bool,
+    ) -> Result<ObjectKeysIter<'js, K>> {
+        let mut enums = mem::MaybeUninit::uninit();
+        let mut count = mem::MaybeUninit::uninit();
+
+        let (enums, count) = unsafe {
+            let mut flags = qjs::JS_GPN_STRING_MASK as i32;
+            if enumerable_only {
+                flags |= qjs::JS_GPN_ENUM_ONLY as i32;
+            }
+            if qjs::JS_GetOwnPropertyNames(
+                self.0.ctx.ctx,
+                enums.as_mut_ptr(),
+                count.as_mut_ptr(),
+                self.0.as_js_value(),
+                flags,
+            ) < 0
+            {
+                return Err(value::get_exception(self.0.ctx));
+            }
+            let enums = enums.assume_init();
+            let count = count.assume_init();
+            (enums, count)
+        };
+
+        Ok(ObjectKeysIter {
+            ctx: self.0.ctx,
+            enums,
+            count,
+            index: 0,
+            marker: PhantomData,
+        })
+    }
+
+    /// Get own properties of an object
+    pub fn own_props<K: FromAtom<'js>, V: FromJs<'js>>(
+        &self,
+        enumerable_only: bool,
+    ) -> Result<ObjectIter<'js, K, V>> {
+        Ok(ObjectIter {
+            own_keys: Ok(self.own_keys(enumerable_only)?).into(),
+            object: self.clone(),
+            marker: PhantomData,
+        })
+    }
+
     /// Check if the object is a function.
     pub fn is_function(&self) -> bool {
         unsafe { qjs::JS_IsFunction(self.0.ctx.ctx, self.0.as_js_value()) != 0 }
@@ -90,6 +144,88 @@ impl<'js> Object<'js> {
     /// Check if the object is as error.
     pub fn is_error(&self) -> bool {
         unsafe { qjs::JS_IsError(self.0.ctx.ctx, self.0.as_js_value()) != 0 }
+    }
+}
+
+/// The iterator for an object own keys
+pub struct ObjectKeysIter<'js, K> {
+    ctx: Ctx<'js>,
+    enums: *mut qjs::JSPropertyEnum,
+    index: u32,
+    count: u32,
+    marker: PhantomData<K>,
+}
+
+impl<'js, K> Iterator for ObjectKeysIter<'js, K>
+where
+    K: FromAtom<'js>,
+{
+    type Item = Result<K>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.index < self.count {
+            let elem = unsafe { &*self.enums.offset(self.index as isize) };
+            self.index += 1;
+            let atom = unsafe { Atom::from_atom_val(self.ctx, elem.atom) };
+            return Some(FromAtom::from_atom(atom));
+        }
+        None
+    }
+}
+
+impl<'js, K> Drop for ObjectKeysIter<'js, K> {
+    fn drop(&mut self) {
+        // This is safe because iterator cannot outlife ctx
+        unsafe { qjs::js_free(self.ctx.ctx, self.enums as *mut _) }
+    }
+}
+
+/// The iterator for an object own properties
+pub struct ObjectIter<'js, K, V> {
+    own_keys: Option<Result<ObjectKeysIter<'js, Atom<'js>>>>,
+    object: Object<'js>,
+    marker: PhantomData<(K, V)>,
+}
+
+impl<'js, K, V> Iterator for ObjectIter<'js, K, V>
+where
+    K: FromAtom<'js>,
+    V: FromJs<'js>,
+{
+    type Item = Result<(K, V)>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        match &mut self.own_keys {
+            None => return None,
+            Some(Ok(own_keys)) => {
+                return match own_keys.next() {
+                    Some(Ok(atom)) => Some(
+                        K::from_atom(atom.clone())
+                            .and_then(|key| self.object.get(atom).map(|val| (key, val))),
+                    ),
+                    Some(Err(error)) => Some(Err(error)),
+                    _ => None,
+                }
+            }
+            _ => (),
+        }
+        match self.own_keys.take() {
+            Some(Err(error)) => Some(Err(error)),
+            _ => unreachable!(),
+        }
+    }
+}
+
+impl<'js> IntoIterator for Object<'js> {
+    type Item = Result<(Atom<'js>, Value<'js>)>;
+    type IntoIter = ObjectIter<'js, Atom<'js>, Value<'js>>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        ObjectIter {
+            own_keys: self.own_keys(true).into(),
+            object: self,
+            marker: PhantomData,
+        }
     }
 }
 
@@ -159,6 +295,97 @@ mod test {
             assert!(val.get::<_, Object>("func_2").unwrap().is_function());
             assert!(!val.get::<_, Object>("obj_1").unwrap().is_function());
             assert!(!val.get::<_, Object>("obj_1").unwrap().is_array());
+        })
+    }
+
+    #[test]
+    fn own_keys_iter() {
+        let rt = Runtime::new().unwrap();
+        let ctx = Context::full(&rt).unwrap();
+        ctx.with(|ctx| {
+            let val: Object = ctx
+                .eval(
+                    r#"
+                   ({
+                     123: 123,
+                     str: "abc",
+                     arr: [],
+                     '': undefined,
+                   })
+                "#,
+                )
+                .unwrap();
+            let keys = val
+                .own_keys(true)
+                .unwrap()
+                .collect::<Result<Vec<StdString>>>()
+                .unwrap();
+            assert_eq!(keys.len(), 4);
+            assert_eq!(keys[0], "123");
+            assert_eq!(keys[1], "str");
+            assert_eq!(keys[2], "arr");
+            assert_eq!(keys[3], "");
+        })
+    }
+
+    #[test]
+    fn own_props_iter() {
+        let rt = Runtime::new().unwrap();
+        let ctx = Context::full(&rt).unwrap();
+        ctx.with(|ctx| {
+            let val: Object = ctx
+                .eval(
+                    r#"
+                   ({
+                     123: "",
+                     str: "abc",
+                     '': "def",
+                   })
+                "#,
+                )
+                .unwrap();
+            let pairs = val
+                .own_props(true)
+                .unwrap()
+                .collect::<Result<Vec<(StdString, StdString)>>>()
+                .unwrap();
+            assert_eq!(pairs.len(), 3);
+            assert_eq!(pairs[0].0, "123");
+            assert_eq!(pairs[0].1, "");
+            assert_eq!(pairs[1].0, "str");
+            assert_eq!(pairs[1].1, "abc");
+            assert_eq!(pairs[2].0, "");
+            assert_eq!(pairs[2].1, "def");
+        })
+    }
+
+    #[test]
+    fn into_iter() {
+        let rt = Runtime::new().unwrap();
+        let ctx = Context::full(&rt).unwrap();
+        ctx.with(|ctx| {
+            let val: Object = ctx
+                .eval(
+                    r#"
+                   ({
+                     123: 123,
+                     str: "abc",
+                     arr: [],
+                     '': undefined,
+                   })
+                "#,
+                )
+                .unwrap();
+            let pairs = val.into_iter().collect::<Result<Vec<_>>>().unwrap();
+            assert_eq!(pairs.len(), 4);
+            assert_eq!(pairs[0].0.clone().to_string().unwrap(), "123");
+            assert_eq!(pairs[0].1, Value::Int(123));
+            assert_eq!(pairs[1].0.clone().to_string().unwrap(), "str");
+            assert_eq!(StdString::from_js(ctx, pairs[1].1.clone()).unwrap(), "abc");
+            assert_eq!(pairs[2].0.clone().to_string().unwrap(), "arr");
+            assert_eq!(Array::from_js(ctx, pairs[2].1.clone()).unwrap().len(), 0);
+            assert_eq!(pairs[3].0.clone().to_string().unwrap(), "");
+            assert_eq!(pairs[3].1, Value::Undefined);
         })
     }
 }


### PR DESCRIPTION
- [x] Missing `Array` set method
- [x] `Iterator` trait impl
  - [x] for `Array`
  - [x] for `Object` keys
  - [x] for `Object` props (kv-pairs)
- [x] `FromIteratorJs` trait to work with `Ctx`
- [x] `IteratorJs` trait which extends `Iterator` trait to support `Ctx`
  - [x] `IteratorJs::collect_js(ctx)` method to create `Array` and `Object` from iterator easy
- [x] `FromIteratorJs` impl
  - [x] for `Array`
  - [x] for `Object`
- [x] `ToJs` trait impls
  - [x] for primitive types
  - [x] for `Option`
  - [x] for `Result`
  - [x] for list-like collections
    - [x] for `Vec`
      The implementation conflicts with `ToJsMulti`.
      - [x] Add `MultiValueJs` as newtype for `Vec<Value>`
    - [x] for `VecDeque`
    - [x] for `LinkedList`
  - [x] for map-like collections
    - [x] for `HashMap`
    - [x] for `HashSet`
    - [x] for `BTreeMap`
    - [x] for `BTreeSet`
- [x] `FromJs` trait impls
  - [x] for primitive types
  - [x] for `Option`
  - [x] for `Result`
  - [x] for list-like collections
    - [x] for `Vec`
    - [x] for `VecDeque`
    - [x] for `LinkedList`
  - [x] for map-like collections
    - [x] for `HashMap`
    - [x] for `HashSet`
    - [x] for `BTreeMap`
    - [x] for `BTreeSet`
- [x] Support for variable number of multiple values using `RestValues` wrapper
  - [x] `FromJsMulti` trait impls
    - [x] for `RestValues<T>`
    - [x] for `(A, B, C, ..., RestValues<T>)`
  - [x] `ToJsMulti` trait impls
    - [x] for `RestValues<T>`
    - [x] for `(A, B, C, ..., RestValues<T>)`