### PR TITLE
Update quickjs version

### DIFF
--- a/rquickjs-core/Cargo.toml
+++ b/rquickjs-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rquickjs-core"
-version = "0.1.1"
+version = "0.1.2"
 authors = ["Mees Delzenne <mees.delzenne@gmail.com>", "K. <kayo@illumium.org>"]
 edition = "2018"
 license = "MIT"
@@ -43,7 +43,7 @@ version = "^1"
 optional = true
 
 [dependencies.rquickjs-sys]
-version = "0.1.0"
+version = "0.1.1"
 path = "../rquickjs-sys"
 
 [dependencies.tokio-rs]

--- a/rquickjs-core/src/value/object.rs
+++ b/rquickjs-core/src/value/object.rs
@@ -72,7 +72,7 @@ impl<'js> Object<'js> {
     where
         T: ObjectDef,
     {
-        T::init(self.0.ctx, &self)
+        T::init(self.0.ctx, self)
     }
 
     /// Create an object using `ObjectDef`

--- a/rquickjs-macro/src/lib.rs
+++ b/rquickjs-macro/src/lib.rs
@@ -1,7 +1,7 @@
 #[cfg(test)]
 macro_rules! abort {
     ($err:expr) => { panic!($err); };
-    ($fmt:literal $($tts:tt)*) => { panic!("{}", format!($fmt $($tts)*)); };
+    ($fmt:literal $($tts:tt)*) => { panic!("{}", format!($fmt $($tts)*)) };
     ($span:expr, $($tts:tt)*) => { { let _ = $span; panic!("{}", format!($($tts)*)); } };
 }
 
@@ -15,23 +15,23 @@ macro_rules! error {
 #[cfg(test)]
 macro_rules! warning {
     ($err:expr) => { panic!($err); };
-    ($fmt:literal $($tts:tt)*) => { eprintln!("{}", format!($fmt $($tts)*)); };
+    ($fmt:literal $($tts:tt)*) => { eprintln!("{}", format!($fmt $($tts)*)) };
     ($span:expr, $($tts:tt)*) => { { let _ = $span; eprintln!("{}", format!($($tts)*)); } };
 }
 
 #[cfg(not(test))]
 macro_rules! abort {
-    ($($tokens:tt)*) => { proc_macro_error::abort!($($tokens)*); };
+    ($($tokens:tt)*) => { proc_macro_error::abort!($($tokens)*) };
 }
 
 #[cfg(not(test))]
 macro_rules! error {
-    ($($tokens:tt)*) => { proc_macro_error::emit_error!($($tokens)*); };
+    ($($tokens:tt)*) => { proc_macro_error::emit_error!($($tokens)*) };
 }
 
 #[cfg(not(test))]
 macro_rules! warning {
-    ($($tokens:tt)*) => { proc_macro_error::emit_warning!($($tokens)*); };
+    ($($tokens:tt)*) => { proc_macro_error::emit_warning!($($tokens)*) };
 }
 
 #[cfg(test)]

--- a/rquickjs-sys/Cargo.toml
+++ b/rquickjs-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rquickjs-sys"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["Mees Delzenne <mees.delzenne@gmail.com>"]
 edition = "2018"
 license = "MIT"

--- a/rquickjs-sys/build.rs
+++ b/rquickjs-sys/build.rs
@@ -69,7 +69,7 @@ fn main() {
 
     let mut defines = vec![
         ("_GNU_SOURCE".into(), None),
-        ("CONFIG_VERSION".into(), Some("\"2020-01-19\"")),
+        ("CONFIG_VERSION".into(), Some("\"2021-03-27\"")),
         ("CONFIG_BIGNUM".into(), None),
     ];
 

--- a/rquickjs-sys/src/bindings/x86_64-unknown-linux-gnu.rs
+++ b/rquickjs-sys/src/bindings/x86_64-unknown-linux-gnu.rs
@@ -405,6 +405,9 @@ extern "C" {
     pub fn JS_SetMaxStackSize(rt: *mut JSRuntime, stack_size: size_t);
 }
 extern "C" {
+    pub fn JS_UpdateStackTop(rt: *mut JSRuntime);
+}
+extern "C" {
     pub fn JS_NewRuntime2(
         mf: *const JSMallocFunctions,
         opaque: *mut ::std::os::raw::c_void,


### PR DESCRIPTION
This branch includes changes to update rquickjs to a newer version of quickjs.

Also includes some minor fixes to deal with warnings generated in newer versions of the rust compiler.