### PR TITLE
Make examples work again

### DIFF
--- a/examples/module-loader/src/bundle/hand_written.rs
+++ b/examples/module-loader/src/bundle/hand_written.rs
@@ -1,4 +1,4 @@
-use rquickjs::{Created, Ctx, JsFn, Loaded, Module, ModuleDef, Native, Result};
+use rquickjs::{Created, Ctx, Func, Loaded, Module, ModuleDef, Native, Result};
 
 pub struct NativeModule;
 
@@ -13,7 +13,7 @@ impl ModuleDef for NativeModule {
     fn eval<'js>(_ctx: Ctx<'js>, module: &Module<'js, Loaded<Native>>) -> Result<()> {
         module.set("n", 123)?;
         module.set("s", "abc")?;
-        module.set("f", JsFn::new("f", |a: f64, b: f64| (a + b) * 0.5))?;
+        module.set("f", Func::new("f", |a: f64, b: f64| (a + b) * 0.5))?;
         Ok(())
     }
 }

--- a/examples/module-loader/src/main.rs
+++ b/examples/module-loader/src/main.rs
@@ -14,6 +14,7 @@ fn main() {
     let resolver = (
         BuiltinResolver::default()
             .with_module("bundle/script_module")
+            .with_module("native_module")
             .with_module("bundle/native_module"),
         FileResolver::default()
             .with_path("./")
@@ -22,7 +23,9 @@ fn main() {
     );
     let loader = (
         BuiltinLoader::default().with_module("bundle/script_module", SCRIPT_MODULE),
-        ModuleLoader::default().with_module("bundle/native_module", NativeModule),
+        ModuleLoader::default()
+            .with_module("native_module", NativeModule)
+            .with_module("bundle/native_module", NativeModule),
         ScriptLoader::default(),
         NativeLoader::default(),
     );

--- a/examples/native-module/src/hand_written.rs
+++ b/examples/native-module/src/hand_written.rs
@@ -1,4 +1,4 @@
-use rquickjs::{Created, Ctx, JsFn, Loaded, Module, ModuleDef, Native, Result};
+use rquickjs::{Created, Ctx, Func, Loaded, Module, ModuleDef, Native, Result};
 
 pub struct NativeModule;
 
@@ -13,7 +13,7 @@ impl ModuleDef for NativeModule {
     fn eval<'js>(_ctx: Ctx<'js>, module: &Module<'js, Loaded<Native>>) -> Result<()> {
         module.set("n", 123)?;
         module.set("s", "abc")?;
-        module.set("f", JsFn::new("f", |a: f64, b: f64| (a + b) * 0.5))?;
+        module.set("f", Func::new("f", |a: f64, b: f64| (a + b) * 0.5))?;
         Ok(())
     }
 }


### PR DESCRIPTION
Hello!

Firstly I must say that at a quick glance, this seems to be a much more comprehensive and promising effort than the other QuickJS bindings available on crates. Kudos to you!

Right now, it seems that the examples are broken on `master`. I have managed to make them work again to my best understanding, but I'm not sure if the way I did it in `examples/module-loader/src/main.rs` is the best. Some help would be appreciated.

Thanks!