### PR TITLE
Fix or suppress new rustc/clippy lints

### DIFF
--- a/rquickjs-core/Cargo.toml
+++ b/rquickjs-core/Cargo.toml
@@ -179,6 +179,7 @@ features = ["attributes"]
 path = "../"
 
 [dev-dependencies]
+approx = "0.5.0"
 trybuild = "1.0.23"
 
 [package.metadata.docs.rs]

--- a/rquickjs-core/src/class.rs
+++ b/rquickjs-core/src/class.rs
@@ -587,6 +587,8 @@ macro_rules! class_def {
 mod test {
     use crate::*;
 
+    use approx::assert_abs_diff_eq;
+
     #[test]
     fn class_basics() {
         struct Foo(pub StdString);
@@ -691,7 +693,7 @@ mod test {
                     "#,
                 )
                 .unwrap();
-            assert_eq!(res, 6.0);
+            assert_abs_diff_eq!(res, 6.0);
 
             let res: f64 = ctx
                 .eval(
@@ -710,7 +712,7 @@ mod test {
                     "#,
                 )
                 .unwrap();
-            assert_eq!(res, 17.0);
+            assert_abs_diff_eq!(res, 17.0);
         });
     }
 

--- a/rquickjs-core/src/lib.rs
+++ b/rquickjs-core/src/lib.rs
@@ -99,7 +99,7 @@ pub use loader::{
 pub use loader::NativeLoader;
 
 #[cfg(test)]
-pub(crate) fn test_with<'js, F, R>(func: F) -> R
+pub(crate) fn test_with<F, R>(func: F) -> R
 where
     F: FnOnce(Ctx) -> R,
 {

--- a/rquickjs-core/src/loader.rs
+++ b/rquickjs-core/src/loader.rs
@@ -109,7 +109,7 @@ impl LoaderHolder {
         let base = base.to_str()?;
         let name = name.to_str()?;
 
-        let name = opaque.resolver.resolve(ctx, &base, &name)?;
+        let name = opaque.resolver.resolve(ctx, base, name)?;
 
         // We should transfer ownership of this string to QuickJS
         Ok(unsafe { qjs::js_strndup(ctx.ctx, name.as_ptr() as _, name.as_bytes().len() as _) })
@@ -126,7 +126,7 @@ impl LoaderHolder {
         let name = CStr::from_ptr(name);
         let loader = &mut *(opaque as *mut LoaderOpaque);
 
-        Self::normalize(loader, ctx, &base, &name).unwrap_or_else(|error| {
+        Self::normalize(loader, ctx, base, name).unwrap_or_else(|error| {
             error.throw(ctx);
             ptr::null_mut()
         })
@@ -152,7 +152,7 @@ impl LoaderHolder {
         let name = CStr::from_ptr(name);
         let loader = &mut *(opaque as *mut LoaderOpaque);
 
-        Self::load(loader, ctx, &name).unwrap_or_else(|error| {
+        Self::load(loader, ctx, name).unwrap_or_else(|error| {
             error.throw(ctx);
             ptr::null_mut()
         })

--- a/rquickjs-core/src/loader/native_loader.rs
+++ b/rquickjs-core/src/loader/native_loader.rs
@@ -49,7 +49,7 @@ impl Loader<Native> for NativeLoader {
     fn load<'js>(&mut self, ctx: Ctx<'js>, path: &str) -> Result<Module<'js, Loaded<Native>>> {
         use dlopen::raw::Library;
 
-        if !check_extensions(&path, &self.extensions) {
+        if !check_extensions(path, &self.extensions) {
             return Err(Error::new_loading(path));
         }
 

--- a/rquickjs-core/src/loader/script_loader.rs
+++ b/rquickjs-core/src/loader/script_loader.rs
@@ -34,7 +34,7 @@ impl Default for ScriptLoader {
 
 impl Loader<Script> for ScriptLoader {
     fn load<'js>(&mut self, ctx: Ctx<'js>, path: &str) -> Result<Module<'js, Loaded<Script>>> {
-        if !check_extensions(&path, &self.extensions) {
+        if !check_extensions(path, &self.extensions) {
             return Err(Error::new_loading(path));
         }
 

--- a/rquickjs-core/src/result.rs
+++ b/rquickjs-core/src/result.rs
@@ -135,7 +135,7 @@ impl Error {
 
     /// Returns whether the error is a quickjs generated exception.
     pub fn is_exception(&self) -> bool {
-        matches!(self, Error::Exception{..})
+        matches!(self, Error::Exception { .. })
     }
 
     /// Create from JS conversion error

--- a/rquickjs-core/src/value/array.rs
+++ b/rquickjs-core/src/value/array.rs
@@ -229,6 +229,7 @@ mod test {
     }
 
     #[test]
+    #[allow(clippy::bool_assert_comparison)]
     fn into_iter() {
         test_with(|ctx| {
             let val: Array = ctx

--- a/rquickjs-core/src/value/object.rs
+++ b/rquickjs-core/src/value/object.rs
@@ -72,7 +72,7 @@ impl<'js> Object<'js> {
     where
         T: ObjectDef,
     {
-        T::init(self.0.ctx, &self)
+        T::init(self.0.ctx, self)
     }
 
     /// Create an object using `ObjectDef`

--- a/rquickjs-macro/src/bind/class.rs
+++ b/rquickjs-macro/src/bind/class.rs
@@ -193,12 +193,12 @@ impl Binder {
             return;
         }
 
-        self.identify(&ident);
+        self.identify(ident);
 
         let name = name.unwrap_or_else(|| ident.to_string());
 
         self.with_dir(ident, |this| {
-            this.with_item::<BindClass, _>(&ident, &name, |this| {
+            this.with_item::<BindClass, _>(ident, &name, |this| {
                 this.update_class(ident, &name, has_refs, cloneable);
 
                 use Fields::*;
@@ -243,12 +243,12 @@ impl Binder {
             return;
         }
 
-        self.identify(&ident);
+        self.identify(ident);
 
         let name = name.unwrap_or_else(|| ident.to_string());
 
         self.with_dir(ident, |this| {
-            this.with_item::<BindClass, _>(&ident, &name, |this| {
+            this.with_item::<BindClass, _>(ident, &name, |this| {
                 this.update_class(ident, &name, has_refs, cloneable);
 
                 // TODO support for variant fields
@@ -375,12 +375,12 @@ impl Binder {
             return;
         };
 
-        self.identify(&ident);
+        self.identify(ident);
 
         let name = name.unwrap_or_else(|| ident.to_string());
 
         self.with_dir(ident, |this| {
-            this.with_item::<BindClass, _>(&ident, &name, |this| {
+            this.with_item::<BindClass, _>(ident, &name, |this| {
                 this.update_class(ident, &name, has_refs, cloneable);
 
                 this.bind_impl_items(items);

--- a/rquickjs-macro/src/derive/attrs.rs
+++ b/rquickjs-macro/src/derive/attrs.rs
@@ -160,7 +160,7 @@ impl DataType {
             })
         }
 
-        let has_js_lt = has_lifetime(&params, "js");
+        let has_js_lt = has_lifetime(params, "js");
 
         let params = params.iter().map(|param| match param {
             GenericParam::Type(dp) => quote!(#dp),
@@ -514,6 +514,7 @@ mod test {
     macro_rules! tests {
         ($c:ident { $($s:tt)* } ($var:ident) { $($d:tt)* }; $($r:tt)*) => {
             #[test]
+            #[allow(clippy::redundant_closure_call)]
             fn $c() {
                 let input = syn::parse_quote! { $($s)* };
                 let output = DataType::from_derive_input(&input).unwrap();

--- a/rquickjs-macro/src/derive/has_refs.rs
+++ b/rquickjs-macro/src/derive/has_refs.rs
@@ -22,7 +22,7 @@ impl HasRefs {
 
         use Data::*;
         let body = match &input.data {
-            Struct(fields) => self.expand_fields(ident, None, &fields),
+            Struct(fields) => self.expand_fields(ident, None, fields),
             Enum(variants) => {
                 let bodies = variants.iter().map(|variant| {
                     self.expand_fields(ident, Some(&variant.ident), &variant.fields)

--- a/rquickjs-macro/src/derive/into_js.rs
+++ b/rquickjs-macro/src/derive/into_js.rs
@@ -29,7 +29,7 @@ impl IntoJs {
 
         use Data::*;
         let body = match &input.data {
-            Struct(fields) => self.expand_struct_fields(input, &fields, &ref_of),
+            Struct(fields) => self.expand_struct_fields(input, fields, &ref_of),
             Enum(variants) => {
                 let bodies = variants
                     .iter()
@@ -292,7 +292,7 @@ impl IntoJs {
             }
         };
 
-        if matches!(enum_repr, Untagged {..}) {
+        if matches!(enum_repr, Untagged { .. }) {
             quote! { #pattern => #body, }
         } else {
             quote! { #pattern => (#name, #body), }

--- a/rquickjs-sys/src/lib.rs
+++ b/rquickjs-sys/src/lib.rs
@@ -1,6 +1,7 @@
 #![allow(non_upper_case_globals)]
 #![allow(non_camel_case_types)]
 #![allow(non_snake_case)]
+#![allow(deref_nullptr)]
 #![allow(clippy::unreadable_literal)]
 #![allow(clippy::missing_safety_doc)]
 #![allow(clippy::upper_case_acronyms)]


### PR DESCRIPTION
Fixed or suppressed a number of warnings and errors that were reported when checking the library with a recent version of rustc.

Fixed:

- `float_cmp`: `approx` is added as a dev-dependency and used to handle float asserts.
- Unused `'js` lifetime in `test_with`: removed the lifetime parameter in favor of the implicit HRTB on the closure.
- References immediately dereferenced by the compiler

Suppressed:

- Warnings about UB in bindgen generated code: see https://github.com/rust-lang/rust-bindgen/issues/1651
- `clippy::bool_assert_comparison` in a test: more readable along with the other asserts of different types.
- `clippy::redundant_closure_call`: allowed on the side of caution because I don't understand the purpose of those tests.