### PR TITLE
Fix loss of reference count in Module::eval

### DIFF
--- a/rquickjs-core/src/value/module.rs
+++ b/rquickjs-core/src/value/module.rs
@@ -375,7 +375,7 @@ impl<'js, S> Module<'js, Loaded<S>> {
     pub fn eval(self) -> Result<Module<'js, Evaluated>> {
         let ctx = self.0.ctx;
         unsafe {
-            let ret = qjs::JS_EvalFunction(ctx.ctx, self.0.value);
+            let ret = qjs::JS_EvalFunction(ctx.ctx, qjs::JS_DupValue(self.0.value));
             handle_exception(ctx, ret)?;
         }
         Ok(Module(self.0, PhantomData))


### PR DESCRIPTION
`JS_EvalFunction` expects to take ownership of the value reference passed in, but `Module::eval` does not call `JS_DupValue` on the inner value when calling it. This breaks the internal invariants of QuickJS and causes an abort when the Rust Module value is dropped.

A valgrind run after this indicates that no memory leaks were introduced by this change.

Close #33