### PR TITLE
[WIP] Add Context::lock

### DIFF
--- a/core/src/context.rs
+++ b/core/src/context.rs
@@ -142,14 +142,14 @@ impl Context {
         }
     }
 
-    /// Transforms a [`Context`] in a [`OwnedCtxGuard`] for manipulating and using javascript
+    /// Transforms a [`Context`] into an [`OwnedCtxGuard`] for manipulating and using javascript
     /// objects and scripts, blocking the current thread until it is able to do so.
     ///
     /// This function will block the local thread until it is available to acquire
     /// the lock. Upon returning, the thread is the only thread with the lock
     /// held. An RAII guard is returned to allow scoped unlock of the lock. When
     /// the guard goes out of scope, the runtime will be unlocked.
-    pub fn owned_lock(self) -> OwnedContextGuard {
+    pub fn lock_owned(self) -> OwnedContextGuard {
         let guard = self.rt.inner.lock();
         guard.update_stack_top();
         ContextGuard {

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -45,7 +45,9 @@ pub use runtime::Tokio;
 pub use runtime::{Executor, ExecutorSpawner, Idle};
 pub use runtime::{MemoryUsage, Runtime};
 mod context;
-pub use context::{intrinsic, Context, ContextBuilder, Ctx, CtxGuard, Intrinsic, MultiWith};
+pub use context::{
+    intrinsic, Context, ContextBuilder, Ctx, CtxGuard, Intrinsic, MultiWith, OwnedCtxGuard,
+};
 mod value;
 pub use value::*;
 mod persistent;

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -46,7 +46,7 @@ pub use runtime::{Executor, ExecutorSpawner, Idle};
 pub use runtime::{MemoryUsage, Runtime};
 mod context;
 pub use context::{
-    intrinsic, Context, ContextBuilder, Ctx, CtxGuard, Intrinsic, MultiWith, OwnedCtxGuard,
+    intrinsic, Context, ContextBuilder, ContextGuard, Ctx, Intrinsic, MultiWith, OwnedContextGuard,
 };
 mod value;
 pub use value::*;

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -45,7 +45,7 @@ pub use runtime::Tokio;
 pub use runtime::{Executor, ExecutorSpawner, Idle};
 pub use runtime::{MemoryUsage, Runtime};
 mod context;
-pub use context::{intrinsic, Context, ContextBuilder, Ctx, Intrinsic, MultiWith};
+pub use context::{intrinsic, Context, ContextBuilder, Ctx, CtxGuard, Intrinsic, MultiWith};
 mod value;
 pub use value::*;
 mod persistent;

--- a/core/src/persistent.rs
+++ b/core/src/persistent.rs
@@ -108,9 +108,10 @@ impl<T> Persistent<T> {
     /// Save the value of an arbitrary type
     pub fn save<'js>(ctx: Ctx<'js>, val: T) -> Persistent<T::Target>
     where
-        T: AsRef<Value<'js>> + Outlive<'static>,
+        T: Into<Value<'js>> + Outlive<'static>,
     {
-        let value = val.as_ref().value;
+        let val = val.into();
+        let value = val.value;
         mem::forget(val);
         let rt = unsafe { qjs::JS_GetRuntime(ctx.ctx) };
 


### PR DESCRIPTION
This change adds `Context::lock`, which can be useful in some scenarios.

Eg. an async function like the one below can't use the `::with` function.

```rust
    pub async fn fold<'a>(
        &self,
        fn_name: &str,
        global_context: &serde_json::Value,
        stream: impl Stream<Item = Item>,
    ) -> anyhow::Result<serde_json::Value> {
        let guard = self.context.lock();
        let ctx = guard.get();

        let globals = ctx.globals();
        globals.set("context", JsonValueRef(global_context))?;

        let js_fn = globals.get::<_, rquickjs::Function>(fn_name)?;
        let mut user_arg = rquickjs::Value::new_undefined(ctx);
        futures::pin_mut!(stream);
        while let Some(item) = stream.next().await {
            user_arg = js_fn.call((JsonValueRef(&item),))?;
        }
        Ok(JsonValue::from_js(ctx, user_arg)?.0)
    }
```