### PR TITLE
Enable usage of Value in Persistent and guard against restoring in the wrong Runtime

### DIFF
--- a/core/src/persistent.rs
+++ b/core/src/persistent.rs
@@ -114,10 +114,9 @@ impl<T> Persistent<T> {
     /// Save the value of an arbitrary type
     pub fn save<'js>(ctx: Ctx<'js>, val: T) -> Persistent<T::Target>
     where
-        T: Into<Value<'js>> + Outlive<'static>,
+        T: AsRef<Value<'js>> + Outlive<'static>,
     {
-        let val = val.into();
-        let value = val.value;
+        let value = val.as_ref().value;
         mem::forget(val);
         let rt = unsafe { qjs::JS_GetRuntime(ctx.ctx) };
 

--- a/core/src/persistent.rs
+++ b/core/src/persistent.rs
@@ -1,4 +1,6 @@
-use crate::{qjs, Array, Ctx, FromJs, Function, IntoJs, Object, Result, String, Symbol, Value};
+use crate::{
+    qjs, Array, Ctx, Error, FromJs, Function, IntoJs, Object, Result, String, Symbol, Value,
+};
 use std::{
     cell::Cell,
     cmp::PartialEq,
@@ -55,7 +57,11 @@ outlive_impls! {
 /// assert_eq!(res, 1);
 /// ```
 ///
-/// NOTE: Be careful and ensure that no persistent links outlives the runtime.
+/// It it an error (`Error::UnrelatedRuntime`) to restore the `Persistent` in a
+/// context who isn't part of the original `Runtime`.
+///
+/// NOTE: Be careful and ensure that no persistent links outlives the runtime,
+/// otherwise Runtime will abort the process when dropped.
 ///
 pub struct Persistent<T> {
     pub(crate) rt: *mut qjs::JSRuntime,
@@ -124,6 +130,10 @@ impl<T> Persistent<T> {
         T: Outlive<'js>,
         T::Target: FromJs<'js>,
     {
+        let ctx_runtime_ptr = unsafe { qjs::JS_GetRuntime(ctx.ctx) };
+        if self.rt != ctx_runtime_ptr {
+            return Err(Error::UnrelatedRuntime);
+        }
         let value = unsafe { Value::from_js_value(ctx, self.value.get()) };
         mem::forget(self);
         T::Target::from_js(ctx, value)
@@ -188,6 +198,24 @@ impl<T> Eq for Persistent<T> {}
 #[cfg(test)]
 mod test {
     use crate::*;
+
+    #[test]
+    #[should_panic(expected = "UnrelatedRuntime")]
+    fn different_runtime() {
+        let rt1 = Runtime::new().unwrap();
+        let ctx = Context::full(&rt1).unwrap();
+
+        let persistent_v = ctx.with(|ctx| {
+            let v: Value = ctx.eval("1").unwrap();
+            Persistent::save(ctx, v)
+        });
+
+        let rt2 = Runtime::new().unwrap();
+        let ctx = Context::full(&rt2).unwrap();
+        ctx.with(|ctx| {
+            let _ = persistent_v.clone().restore(ctx).unwrap();
+        });
+    }
 
     #[test]
     fn persistent_function() {

--- a/core/src/result.rs
+++ b/core/src/result.rs
@@ -17,6 +17,7 @@ pub type Result<T> = StdResult<T, Error>;
 
 /// Error type of the library.
 #[derive(Debug)]
+#[non_exhaustive]
 pub enum Error {
     /// Could not allocate memory
     /// This is generally only triggered when out of memory.
@@ -65,6 +66,8 @@ pub enum Error {
         name: StdString,
         message: Option<StdString>,
     },
+    /// Error when restoring a Persistent in a runtime other than the original runtime.
+    UnrelatedRuntime,
     /// An error from quickjs from which the specifics are unknown.
     /// Should eventually be removed as development progresses.
     Unknown,
@@ -355,6 +358,7 @@ impl Display for Error {
                 "IO Error: ".fmt(f)?;
                 error.fmt(f)?;
             }
+            UnrelatedRuntime => "Restoring Persistent in an unrelated runtime".fmt(f)?,
         }
         Ok(())
     }

--- a/core/src/value.rs
+++ b/core/src/value.rs
@@ -346,6 +346,12 @@ impl<'js> Value<'js> {
     }
 }
 
+impl<'js> AsRef<Value<'js>> for Value<'js> {
+    fn as_ref(&self) -> &Value<'js> {
+        self
+    }
+}
+
 macro_rules! type_impls {
     // type: name => tag
     ($($type:ident: $name:ident => $tag:ident,)*) => {


### PR DESCRIPTION
Alternative solution for #51 to avoid potential breaking changes.