### PR TITLE
Enable usage of `Value` in `Persistent` and guard against restoring in the unrelated `Runtime`

### DIFF
--- a/core/src/persistent.rs
+++ b/core/src/persistent.rs
@@ -211,4 +211,22 @@ mod test {
         });
         assert_eq!(res, 1);
     }
+
+    #[test]
+    fn persistent_value() {
+        let rt = Runtime::new().unwrap();
+        let ctx = Context::full(&rt).unwrap();
+
+        let persistent_v = ctx.with(|ctx| {
+            let v: Value = ctx.eval("1").unwrap();
+            Persistent::save(ctx, v)
+        });
+
+        ctx.with(|ctx| {
+            let v = persistent_v.clone().restore(ctx).unwrap();
+            ctx.globals().set("v", v).unwrap();
+            let eq: Value = ctx.eval("v == 1").unwrap();
+            assert!(eq.as_bool().unwrap());
+        });
+    }
 }

--- a/core/src/result.rs
+++ b/core/src/result.rs
@@ -17,6 +17,7 @@ pub type Result<T> = StdResult<T, Error>;
 
 /// Error type of the library.
 #[derive(Debug)]
+#[non_exhaustive]
 pub enum Error {
     /// Could not allocate memory
     /// This is generally only triggered when out of memory.
@@ -65,6 +66,8 @@ pub enum Error {
         name: StdString,
         message: Option<StdString>,
     },
+    /// Error when restoring a Persistent in a runtime other than the original runtime.
+    UnrelatedRuntime,
     /// An error from quickjs from which the specifics are unknown.
     /// Should eventually be removed as development progresses.
     Unknown,
@@ -355,6 +358,7 @@ impl Display for Error {
                 "IO Error: ".fmt(f)?;
                 error.fmt(f)?;
             }
+            UnrelatedRuntime => "Restoring Persistent in an unrelated runtime".fmt(f)?,
         }
         Ok(())
     }

--- a/core/src/value.rs
+++ b/core/src/value.rs
@@ -346,6 +346,12 @@ impl<'js> Value<'js> {
     }
 }
 
+impl<'js> AsRef<Value<'js>> for Value<'js> {
+    fn as_ref(&self) -> &Value<'js> {
+        self
+    }
+}
+
 macro_rules! type_impls {
     // type: name => tag
     ($($type:ident: $name:ident => $tag:ident,)*) => {


### PR DESCRIPTION
Supersedes #51 