### PR TITLE
Implement chrono DateTime<Utc> to / from JS conversion.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,10 +61,13 @@ members = [
 default = ["exports", "classes", "properties"]
 
 # Almost all features excluding "parallel" and support for async runtimes
-full = ["exports", "loader", "allocator", "dyn-load", "either", "indexmap", "registery", "classes", "properties", "array-buffer", "macro", "phf"]
+full = ["chrono", "exports", "loader", "allocator", "dyn-load", "either", "indexmap", "registery", "classes", "properties", "array-buffer", "macro", "phf"]
 
 # Almost all features excluding "parallel"
 full-async = ["full", "async-std", "tokio", "smol"]
+
+# Chrono support.
+chrono = ["rquickjs-core/chrono"]
 
 # Enable support for Either type
 either = ["rquickjs-core/either", "either-rs"]

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -42,6 +42,10 @@ optional = true
 version = "1"
 optional = true
 
+[dependencies.chrono]
+version = "0.4"
+optional = true
+
 [dependencies.rquickjs-sys]
 version = "0.1.5"
 path = "../sys"
@@ -77,7 +81,7 @@ optional = true
 default = []
 
 # Almost all features excluding "parallel" and support for async runtimes
-full = ["exports", "loader", "allocator", "dyn-load", "either", "indexmap", "registery", "classes", "properties", "array-buffer"]
+full = ["chrono", "exports", "loader", "allocator", "dyn-load", "either", "indexmap", "registery", "classes", "properties", "array-buffer"]
 
 # Almost all features excluding "parallel"
 full-async = ["full", "async-std", "tokio", "smol"]
@@ -85,6 +89,9 @@ full-async = ["full", "async-std", "tokio", "smol"]
 # Use bindgen to generate bindings at compile-type
 # otherwise bundled bindings will be used
 bindgen = ["rquickjs-sys/bindgen"]
+
+# Chrono support.
+chrono = ["dep:chrono"]
 
 # Enable support of parallel execution
 parallel = []

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -90,9 +90,6 @@ full-async = ["full", "async-std", "tokio", "smol"]
 # otherwise bundled bindings will be used
 bindgen = ["rquickjs-sys/bindgen"]
 
-# Chrono support.
-chrono = ["dep:chrono"]
-
 # Enable support of parallel execution
 parallel = []
 

--- a/core/src/value/convert/from.rs
+++ b/core/src/value/convert/from.rs
@@ -21,12 +21,7 @@ impl<'js> FromJs<'js> for chrono::DateTime<chrono::Utc> {
     fn from_js(ctx: Ctx<'js>, value: Value<'js>) -> Result<chrono::DateTime<chrono::Utc>> {
         use chrono::TimeZone;
 
-        let value_obj = value.into_object().ok_or(Error::FromJs {
-            from: "Value",
-            to: "Object",
-            message: None,
-        })?;
-
+        let value_obj = Object::from_value(value)?;
         let global = ctx.globals();
         let date_constructor: Object = global.get("Date")?;
 

--- a/core/src/value/convert/from.rs
+++ b/core/src/value/convert/from.rs
@@ -396,14 +396,14 @@ mod test {
     #[test]
     fn js_to_chrono() {
         use crate::{Context, Runtime};
-        use chrono::{DateTime, Duration, Utc};
+        use chrono::{DateTime, Utc};
 
         let runtime = Runtime::new().unwrap();
         let ctx = Context::full(&runtime).unwrap();
 
         ctx.with(|ctx| {
-            let res: DateTime<Utc> = ctx.eval("new Date()").unwrap();
-            assert!(Utc::now() - res < Duration::seconds(1))
+            let res: DateTime<Utc> = ctx.eval("new Date(123456789)").unwrap();
+            assert_eq!(123456789, res.timestamp_millis());
         });
     }
 }

--- a/core/src/value/convert/from.rs
+++ b/core/src/value/convert/from.rs
@@ -22,27 +22,26 @@ impl<'js> FromJs<'js> for chrono::DateTime<chrono::Utc> {
         use chrono::TimeZone;
 
         let value_obj = value.into_object().ok_or(Error::FromJs {
-            from: "Date",
-            to: "DateTime<Utc>",
+            from: "Value",
+            to: "Object",
             message: None,
         })?;
 
         let global = ctx.globals();
         let date_constructor: Object = global.get("Date")?;
-        let is_date = value_obj.is_instance_of(&date_constructor);
 
-        if is_date {
-            let getter: crate::Function = value_obj.get("getTime")?;
-            let millis: i64 = getter.call((crate::This(value_obj),))?;
-
-            Ok(chrono::Utc.timestamp_millis(millis))
-        } else {
-            Err(Error::FromJs {
+        if !value_obj.is_instance_of(&date_constructor) {
+            return Err(Error::FromJs {
                 from: "Date",
                 to: "DateTime<Utc>",
                 message: None,
-            })
+            });
         }
+
+        let getter: crate::Function = value_obj.get("getTime")?;
+        let millis: i64 = getter.call((crate::This(value_obj),))?;
+
+        Ok(chrono::Utc.timestamp_millis(millis))
     }
 }
 

--- a/core/src/value/convert/into.rs
+++ b/core/src/value/convert/into.rs
@@ -19,15 +19,7 @@ impl<'js> IntoJs<'js> for chrono::DateTime<chrono::Utc> {
     fn into_js(self, ctx: Ctx<'js>) -> Result<Value<'js>> {
         let global = ctx.globals();
         let date_constructor: Object = global.get("Date")?;
-
-        let f = self.timestamp_millis() as f64;
-
-        let timestamp = crate::qjs::JSValue {
-            u: crate::qjs::JSValueUnion { float64: f },
-            tag: crate::qjs::JS_TAG_FLOAT64.into(),
-        };
-
-        let mut args = vec![timestamp];
+        let timestamp = self.timestamp_millis().into_js(ctx)?;
 
         // TODO:
         //  Currently we lack equivalent hight-level alternative for CallConstructor.
@@ -35,9 +27,9 @@ impl<'js> IntoJs<'js> for chrono::DateTime<chrono::Utc> {
         let value = unsafe {
             crate::qjs::JS_CallConstructor(
                 ctx.ctx,
-                date_constructor.0.value,
-                args.len() as i32,
-                args.as_mut_ptr(),
+                date_constructor.as_js_value(),
+                1,
+                &timestamp.as_js_value() as *const _ as *mut _,
             )
         };
 


### PR DESCRIPTION
This implementation is based on the chrono support as implemented by
https://github.com/theduke/quickjs-rs.

Closes #66.