### PR TITLE
Implemented constructor call

### DIFF
--- a/core/src/value/convert/into.rs
+++ b/core/src/value/convert/into.rs
@@ -1,6 +1,6 @@
 use crate::{
-    Array, Ctx, Error, IntoAtom, IntoJs, IteratorJs, Object, Result, StdResult, StdString, String,
-    Value,
+    Array, Ctx, Error, Function, IntoAtom, IntoJs, IteratorJs, Object, Result, StdResult,
+    StdString, String, Value,
 };
 use std::{
     cell::{Cell, RefCell},
@@ -441,23 +441,9 @@ into_js_impls! {
 }
 
 fn millis_to_date<'js>(ctx: Ctx<'js>, millis: i64) -> Result<Value<'js>> {
-    let global = ctx.globals();
-    let date_constructor: Object = global.get("Date")?;
-    let timestamp = millis.into_js(ctx)?;
+    let date_ctor: Function = ctx.globals().get("Date")?;
 
-    // TODO:
-    //  Currently we lack equivalent hight-level alternative for CallConstructor.
-    //  https://github.com/DelSkayn/rquickjs/pull/67#discussion_r885592941
-    let value = unsafe {
-        crate::qjs::JS_CallConstructor(
-            ctx.ctx,
-            date_constructor.as_js_value(),
-            1,
-            &timestamp.as_js_value() as *const _ as *mut _,
-        )
-    };
-
-    Ok(Value { ctx, value })
+    date_ctor.construct((millis,))
 }
 
 impl<'js> IntoJs<'js> for SystemTime {

--- a/core/src/value/typed_array.rs
+++ b/core/src/value/typed_array.rs
@@ -158,17 +158,7 @@ impl<'js, T> TypedArray<'js, T> {
     {
         let ctx = arraybuffer.0.ctx;
         let ctor: Function = ctx.globals().get(T::CLASS_NAME)?;
-        let val = unsafe {
-            let val = qjs::JS_CallConstructor(
-                ctx.ctx,
-                ctor.as_js_value(),
-                1,
-                &arraybuffer.as_js_value() as *const _ as *mut _,
-            );
-            handle_exception(ctx, val)?;
-            Value::from_js_value(ctx, val)
-        };
-        Self::from_value(val)
+        ctor.construct((arraybuffer,))
     }
 
     pub(crate) fn get_raw(val: &Value<'js>) -> Option<(usize, *mut T)> {


### PR DESCRIPTION
- Added `construct` fn to the `Function` type
- Added `construct` fn to the `AsArguments` trait
- Replaced all raw constructor calls by `construct`