### PR TITLE
Handle unknown object tags as unknown objects instead of panicking

### DIFF
--- a/core/src/value.rs
+++ b/core/src/value.rs
@@ -360,6 +360,7 @@ macro_rules! type_impls {
         #[repr(i32)]
         pub enum Type {
             $($type,)*
+            Unknown
         }
 
         impl Type {
@@ -386,6 +387,7 @@ macro_rules! type_impls {
             pub const fn as_str(self) -> &'static str {
                 match self {
                     $(Type::$type => stringify!($name),)*
+                    Type::Unknown => "Unknown type",
                 }
             }
         }
@@ -419,7 +421,7 @@ macro_rules! type_impls {
                 let tag = unsafe { qjs::JS_VALUE_GET_NORM_TAG(self.value) };
                 match tag {
                     $(qjs::$tag if type_impls!(@cond $type self) => Type::$type,)*
-                    _ => panic!("Unknown JS value tag: {}", tag),
+                    _ => Type::Unknown,
                 }
             }
 


### PR DESCRIPTION
The library currently handles object conversions by first trying to determine the type of object it receives. If it cannot determine the type it panics.

This could result in perfectly fine code suddenly panicking if a objects which we don't handle yet, like bigints, are returned from quickjs: #74.

We should probably implement some support for handling bigints but in the mean time it is probably better if we handle unknown object types as an error instead of a panic as this would also improve compatibility with possible new types implemented by quickjs in the future. 