### PR TITLE
Clarify error if Command fails

### DIFF
--- a/sys/build.rs
+++ b/sys/build.rs
@@ -133,7 +133,7 @@ fn patch<D: AsRef<Path>, P: AsRef<Path>>(out_dir: D, patch: P) {
         .stdin(Stdio::piped())
         .current_dir(out_dir)
         .spawn()
-        .unwrap();
+        .expect("Unable to execute patch, you may need to install it: {}");
     println!("Appliyng patch {}", patch.as_ref().display());
     {
         let patch = fs::read(patch).expect("Unable to read patch");


### PR DESCRIPTION
I personally ran into this while building another crate. I was running in a container w/out `patch`, and it gave me a unfriendly unwrap. I rather have this be more friendly.