### PR TITLE
Expose get_ptr

### DIFF
--- a/core/src/value.rs
+++ b/core/src/value.rs
@@ -258,7 +258,7 @@ impl<'js> Value<'js> {
     }
 
     #[inline]
-    pub(crate) unsafe fn get_ptr(&self) -> *mut qjs::c_void {
+    pub unsafe fn get_ptr(&self) -> *mut qjs::c_void {
         qjs::JS_VALUE_GET_PTR(self.value)
     }
 


### PR DESCRIPTION
Useful for when we we need to store references to the underlying qjs values