### PR TITLE
Some fixes having to do with classes.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
-docs
 target
 .ccls-cache
 Cargo.lock

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+docs
 target
 .ccls-cache
 Cargo.lock

--- a/core/src/class.rs
+++ b/core/src/class.rs
@@ -26,8 +26,8 @@ pub use refs::{HasRefs, RefsMarker};
 ///     const CLASS_NAME: &'static str = "MyClass";
 ///
 ///     fn class_id() -> &'static ClassId {
-///         static mut CLASS_ID: ClassId = ClassId::new();
-///         &mut CLASS_ID
+///         static CLASS_ID: ClassId = ClassId::new();
+///         &CLASS_ID
 ///     }
 ///
 ///     // With prototype
@@ -75,7 +75,7 @@ pub trait ClassDef {
     /// The reference to class identifier
     ///
     /// # Safety
-    /// This method should return reference to mutable static class id which should be initialized to zero.
+    /// This method should return reference to static class id which should be initialized to zero.
     fn class_id() -> &'static ClassId;
 
     /// The class has prototype

--- a/core/src/class.rs
+++ b/core/src/class.rs
@@ -25,7 +25,7 @@ pub use refs::{HasRefs, RefsMarker};
 /// impl ClassDef for MyClass {
 ///     const CLASS_NAME: &'static str = "MyClass";
 ///
-///     unsafe fn class_id() -> &'static mut ClassId {
+///     fn class_id() -> &'static ClassId {
 ///         static mut CLASS_ID: ClassId = ClassId::new();
 ///         &mut CLASS_ID
 ///     }
@@ -76,7 +76,7 @@ pub trait ClassDef {
     ///
     /// # Safety
     /// This method should return reference to mutable static class id which should be initialized to zero.
-    unsafe fn class_id() -> &'static mut ClassId;
+    fn class_id() -> &'static ClassId;
 
     /// The class has prototype
     const HAS_PROTO: bool = false;
@@ -183,7 +183,7 @@ where
     /// Get an integer class identifier
     #[inline(always)]
     pub(crate) fn id() -> qjs::JSClassID {
-        unsafe { C::class_id() }.get()
+        C::class_id().get()
     }
 
     /// Wrap constructor of class
@@ -249,8 +249,6 @@ where
     /// Register the class
     pub fn register(ctx: Ctx<'js>) -> Result<()> {
         let rt = unsafe { qjs::JS_GetRuntime(ctx.ctx) };
-        let class_id = unsafe { C::class_id() };
-        class_id.init();
         let class_id = Self::id();
         let class_name = CString::new(C::CLASS_NAME)?;
         if 0 == unsafe { qjs::JS_IsRegisteredClass(rt, class_id) } {
@@ -530,9 +528,9 @@ macro_rules! class_def {
         impl $crate::ClassDef for $name {
             const CLASS_NAME: &'static str = stringify!($name);
 
-            unsafe fn class_id() -> &'static mut $crate::ClassId {
-                static mut CLASS_ID: $crate::ClassId = $crate::ClassId::new();
-                &mut CLASS_ID
+            fn class_id() -> &'static $crate::ClassId {
+                static CLASS_ID: $crate::ClassId = $crate::ClassId::new();
+                &CLASS_ID
             }
 
             $($body)*

--- a/core/src/class.rs
+++ b/core/src/class.rs
@@ -266,12 +266,13 @@ where
             if 0 != unsafe { qjs::JS_NewClass(rt, class_id, &class_def) } {
                 return Err(Error::Unknown);
             }
-
-            if C::HAS_PROTO {
-                let proto = Object::new(ctx)?;
-                C::init_proto(ctx, &proto)?;
-                unsafe { qjs::JS_SetClassProto(ctx.ctx, class_id, proto.0.into_js_value()) }
-            }
+        }
+        // Even if the class is registered we still need to set the prototype as this can be a new
+        // context.
+        if C::HAS_PROTO {
+            let proto = Object::new(ctx)?;
+            C::init_proto(ctx, &proto)?;
+            unsafe { qjs::JS_SetClassProto(ctx.ctx, class_id, proto.0.into_js_value()) }
         }
         Ok(())
     }

--- a/core/src/value/function/ffi.rs
+++ b/core/src/value/function/ffi.rs
@@ -2,7 +2,7 @@ use super::Input;
 use crate::{handle_panic, qjs, ClassId, Ctx, Result, Value};
 use std::{ops::Deref, panic::AssertUnwindSafe, ptr};
 
-static mut FUNC_CLASS_ID: ClassId = ClassId::new();
+static FUNC_CLASS_ID: ClassId = ClassId::new();
 
 type BoxedFunc<'js> = Box<dyn Fn(&Input<'js>) -> Result<Value<'js>>>;
 
@@ -26,7 +26,7 @@ impl<'js> JsFunction<'js> {
     }
 
     pub fn class_id() -> qjs::JSClassID {
-        unsafe { &FUNC_CLASS_ID }.get() as _
+        FUNC_CLASS_ID.get() as _
     }
 
     pub unsafe fn into_js_value(self, ctx: Ctx<'_>) -> qjs::JSValue {
@@ -50,7 +50,6 @@ impl<'js> JsFunction<'js> {
     }
 
     pub unsafe fn register(rt: *mut qjs::JSRuntime) {
-        FUNC_CLASS_ID.init();
         let class_id = Self::class_id();
         if 0 == qjs::JS_IsRegisteredClass(rt, class_id) {
             let class_def = qjs::JSClassDef {

--- a/macro/src/bind/class.rs
+++ b/macro/src/bind/class.rs
@@ -133,9 +133,9 @@ impl BindClass {
             impl #lib_crate::ClassDef for #src {
                 const CLASS_NAME: &'static str = #name;
 
-                unsafe fn class_id() -> &'static mut #lib_crate::ClassId {
-                    static mut CLASS_ID: #lib_crate::ClassId = #lib_crate::ClassId::new();
-                    &mut CLASS_ID
+                fn class_id() -> &'static #lib_crate::ClassId {
+                    static CLASS_ID: #lib_crate::ClassId = #lib_crate::ClassId::new();
+                    &CLASS_ID
                 }
 
                 #extras
@@ -408,9 +408,9 @@ mod test {
             impl rquickjs::ClassDef for test::Test {
                 const CLASS_NAME: &'static str = "Test";
 
-                unsafe fn class_id() -> &'static mut rquickjs::ClassId {
-                    static mut CLASS_ID: rquickjs::ClassId = rquickjs::ClassId::new() ;
-                    &mut CLASS_ID
+                fn class_id() -> &'static rquickjs::ClassId {
+                    static CLASS_ID: rquickjs::ClassId = rquickjs::ClassId::new() ;
+                    &CLASS_ID
                 }
             }
 
@@ -441,9 +441,9 @@ mod test {
             impl rquickjs::ClassDef for test::Test {
                 const CLASS_NAME: &'static str = "Test";
 
-                unsafe fn class_id() -> &'static mut rquickjs::ClassId {
-                    static mut CLASS_ID: rquickjs::ClassId = rquickjs::ClassId::new() ;
-                    &mut CLASS_ID
+                fn class_id() -> &'static rquickjs::ClassId {
+                    static CLASS_ID: rquickjs::ClassId = rquickjs::ClassId::new() ;
+                    &CLASS_ID
                 }
 
                 const HAS_PROTO: bool = true;
@@ -504,9 +504,9 @@ mod test {
             impl rquickjs::ClassDef for test::Node {
                 const CLASS_NAME: &'static str = "Node";
 
-                unsafe fn class_id() -> &'static mut rquickjs::ClassId {
-                    static mut CLASS_ID: rquickjs::ClassId = rquickjs::ClassId::new() ;
-                    &mut CLASS_ID
+                fn class_id() -> &'static rquickjs::ClassId {
+                    static CLASS_ID: rquickjs::ClassId = rquickjs::ClassId::new() ;
+                    &CLASS_ID
                 }
 
                 const HAS_PROTO: bool = true;
@@ -577,9 +577,9 @@ mod test {
             impl rquickjs::ClassDef for test::Node {
                 const CLASS_NAME: &'static str = "Node";
 
-                unsafe fn class_id() -> &'static mut rquickjs::ClassId {
-                    static mut CLASS_ID: rquickjs::ClassId = rquickjs::ClassId::new() ;
-                    &mut CLASS_ID
+                fn class_id() -> &'static rquickjs::ClassId {
+                    static CLASS_ID: rquickjs::ClassId = rquickjs::ClassId::new() ;
+                    &CLASS_ID
                 }
 
                 const HAS_PROTO: bool = true;
@@ -629,9 +629,9 @@ mod test {
             impl rquickjs::ClassDef for test::Node {
                 const CLASS_NAME: &'static str = "Node";
 
-                unsafe fn class_id() -> &'static mut rquickjs::ClassId {
-                    static mut CLASS_ID: rquickjs::ClassId = rquickjs::ClassId::new() ;
-                    &mut CLASS_ID
+                fn class_id() -> &'static rquickjs::ClassId {
+                    static CLASS_ID: rquickjs::ClassId = rquickjs::ClassId::new() ;
+                    &CLASS_ID
                 }
             }
 
@@ -666,9 +666,9 @@ mod test {
             impl rquickjs::ClassDef for test::Node {
                 const CLASS_NAME: &'static str = "Node";
 
-                unsafe fn class_id() -> &'static mut rquickjs::ClassId {
-                    static mut CLASS_ID: rquickjs::ClassId = rquickjs::ClassId::new() ;
-                    &mut CLASS_ID
+                unsafe fn class_id() -> &'static rquickjs::ClassId {
+                    static CLASS_ID: rquickjs::ClassId = rquickjs::ClassId::new() ;
+                    &CLASS_ID
                 }
 
                 const HAS_STATIC: bool = true;
@@ -707,9 +707,9 @@ mod test {
             impl rquickjs::ClassDef for test::Node {
                 const CLASS_NAME: &'static str = "Node";
 
-                unsafe fn class_id() -> &'static mut rquickjs::ClassId {
-                    static mut CLASS_ID: rquickjs::ClassId = rquickjs::ClassId::new() ;
-                    &mut CLASS_ID
+                fn class_id() -> &'static rquickjs::ClassId {
+                    static CLASS_ID: rquickjs::ClassId = rquickjs::ClassId::new() ;
+                    &CLASS_ID
                 }
 
                 const HAS_REFS: bool = true;

--- a/macro/src/bind/class.rs
+++ b/macro/src/bind/class.rs
@@ -666,7 +666,7 @@ mod test {
             impl rquickjs::ClassDef for test::Node {
                 const CLASS_NAME: &'static str = "Node";
 
-                unsafe fn class_id() -> &'static rquickjs::ClassId {
+                fn class_id() -> &'static rquickjs::ClassId {
                     static CLASS_ID: rquickjs::ClassId = rquickjs::ClassId::new() ;
                     &CLASS_ID
                 }


### PR DESCRIPTION
This changes `ClassId` to instead of requiring a static mutable for implementing `ClassDef` it now only needs an immutable static. `ClassId` can will now initialize itself only once when its the id is read first. This prevents multiple calls to register from altering the class id. 

This also fixes #92. Once a class was registered in a runtime its prototype was no longer being set. This PR fixes that.