### PR TITLE
Switch rust defined function to use `JS_NewCFunctionData`

### DIFF
--- a/core/src/value/function.rs
+++ b/core/src/value/function.rs
@@ -34,7 +34,6 @@ impl<'js> Function<'js> {
             Self::from_js_value(ctx, func)
         };
         F::post(ctx, &func)?;
-        func.set_length(F::num_args().start)?;
         Ok(func)
     }
 

--- a/core/src/value/function.rs
+++ b/core/src/value/function.rs
@@ -27,7 +27,8 @@ impl<'js> Function<'js> {
     where
         F: AsFunction<'js, A, R> + ParallelSend + 'static,
     {
-        let func = JsFunction::new(move |input: &Input<'js>| func.call(input));
+        let length = F::num_args().start;
+        let func = JsFunction::new(length, move |input: &Input<'js>| func.call(input));
         let func = unsafe {
             let func = func.into_js_value(ctx);
             Self::from_js_value(ctx, func)

--- a/core/src/value/function/ffi.rs
+++ b/core/src/value/function/ffi.rs
@@ -35,6 +35,10 @@ impl<'js> JsFunction<'js> {
     }
 
     pub unsafe fn into_js_value(self, ctx: Ctx<'_>) -> qjs::JSValue {
+        let length = self
+            .length
+            .try_into()
+            .expect("function argument length exceeded i32::MAX");
         let ptr = Box::into_raw(Box::new(self.func));
         let finalizer = qjs::JS_NewObjectClass(ctx.ctx, Self::class_id() as _);
         qjs::JS_SetOpaque(finalizer, ptr as _);
@@ -43,9 +47,7 @@ impl<'js> JsFunction<'js> {
         let function = qjs::JS_NewCFunctionData(
             ctx.ctx,
             Some(Self::call),
-            self.length
-                .try_into()
-                .expect("function argument length exceeded i32::MAX"),
+            length,
             0,
             1,
             (&mut data) as *mut _,

--- a/core/src/value/function/types.rs
+++ b/core/src/value/function/types.rs
@@ -40,7 +40,7 @@ pub struct Method<F>(pub F);
 /// ctx.globals().set("sum", Func::from(|a: i32, b: i32| a + b))?;
 /// assert_eq!(ctx.eval::<i32, _>("sum(3, 2)")?, 5);
 /// assert_eq!(ctx.eval::<usize, _>("sum.length")?, 2);
-/// assert!(ctx.eval::<Option<String>, _>("sum.name")?.is_none());
+/// assert_eq!(ctx.eval::<String, _>("sum.name")?,"");
 ///
 /// // Named function
 /// ctx.globals().set("prod", Func::new("multiply", |a: i32, b: i32| a * b))?;


### PR DESCRIPTION
This PR switches rust function from being created as a class with a call field to instead use `JS_NewCFunctionData`. By creating functions this way the function will properly inherit the function prototype and have function prototype methods like `apply` and `bind` defined.

This might cause slightly more overhead than the previous way of creating function objects as this methods requires two object to be created: the function itself and a finalizer object which drops the function data.

This PR fixes issue #59.