### PR TITLE
implement patch manually without using external software

### DIFF
--- a/sys/Cargo.toml
+++ b/sys/Cargo.toml
@@ -12,6 +12,8 @@ repository = "https://github.com/DelSkayn/rquickjs.git"
 
 [build-dependencies]
 cc = "1"
+diffy = "0.3.0"
+newline-converter = "0.3.0"
 
 [build-dependencies.bindgen-rs]
 package = "bindgen"

--- a/sys/build.rs
+++ b/sys/build.rs
@@ -157,10 +157,12 @@ fn patch<D: AsRef<Path>, P: AsRef<Path>>(out_dir: D, patch: P) {
             let original = patch
                 .original()
                 .and_then(|x| x.split_once('/').map(|(_, b)| b))
+                .or(patch.original())
                 .expect("Cannot find original file name");
             let modified = patch
                 .modified()
                 .and_then(|x| x.split_once('/').map(|(_, b)| b))
+                .or(patch.modified())
                 .expect("Cannot find modified file name");
 
             // for now


### PR DESCRIPTION
This PR attempts to manually do patches without using GNU Patch. Despite the algorithm is quite primitive and had some questionable assumptions, at least it does compile in Windows natively now. The edge case is that I don't know how to determine the correct file to patch -- so I just assumed the `a/{filename}` and `b/{filename}` format.

Fixes #88. Since I made this in Windows and I have to compile it by myself. So I can't possibly made this PR possible if there are any errors. No need to test for Windows therefore.