### PR TITLE
Some small changes, quick fix for panic with non-object errors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -253,7 +253,7 @@ jobs:
           ENV_TARGET=$(printf "${{ matrix.target }}" | tr '[:lower:]' '[:upper:]' | tr '-' '_')
           sudo dpkg --add-architecture ${SYSTEM_ARCH}
           sudo apt-get update -y
-          sudo apt-get install -y libc6-dev:${SYSTEM_ARCH} gcc-${GCC_TARGET}
+          sudo apt-get install -y libc6-dev:${SYSTEM_ARCH} gcc-${GCC_TARGET} libgcc-s1:${SYSTEM_ARCH}
           echo "CARGO_TARGET_${ENV_TARGET}_LINKER=${GCC_TARGET}-gcc" >> $GITHUB_ENV
       - name: Setup musl-tools
         if: startsWith(matrix.target, 'x86_64-') && endsWith(matrix.target, '-musl')

--- a/core/src/class.rs
+++ b/core/src/class.rs
@@ -250,7 +250,7 @@ where
     pub fn register(ctx: Ctx<'js>) -> Result<()> {
         let rt = unsafe { qjs::JS_GetRuntime(ctx.as_ptr()) };
         let class_id = Self::id();
-        let class_name = CString::new(C::CLASS_NAME)?;
+        let class_name = CString::new(C::CLASS_NAME).expect("class name has an internal null byte");
         if 0 == unsafe { qjs::JS_IsRegisteredClass(rt, class_id) } {
             let class_def = qjs::JSClassDef {
                 class_name: class_name.as_ptr(),

--- a/core/src/result.rs
+++ b/core/src/result.rs
@@ -475,6 +475,6 @@ impl<'js> Ctx<'js> {
         }
 
         let exception = Value::from_js_value(self, exception_val);
-        Error::from_js(self, exception).unwrap()
+        Error::from_js(self, exception).unwrap_or(Error::Unknown)
     }
 }

--- a/core/src/value/atom.rs
+++ b/core/src/value/atom.rs
@@ -97,9 +97,11 @@ impl<'js> Atom<'js> {
                 // so just incase check it.
                 return Err(Error::Unknown);
             }
-            let res = CStr::from_ptr(c_str).to_str()?.to_string();
+            let bytes = CStr::from_ptr(c_str).to_bytes();
+            // Safety: quickjs should return valid utf8 so this should be safe.
+            let res = std::str::from_utf8_unchecked(bytes);
             mem::drop(drop);
-            Ok(res)
+            Ok(res.to_string())
         }
     }
 

--- a/core/src/value/convert/into.rs
+++ b/core/src/value/convert/into.rs
@@ -186,7 +186,8 @@ where
     T: IntoJs<'js>,
 {
     fn into_js(self, ctx: Ctx<'js>) -> Result<Value<'js>> {
-        self.into_inner().unwrap().into_js(ctx)
+        // TODO: determine we should panic her or just unpack the value.
+        self.into_inner().expect("mutex was poisoned").into_js(ctx)
     }
 }
 
@@ -195,7 +196,8 @@ where
     for<'r> &'r T: IntoJs<'js>,
 {
     fn into_js(self, ctx: Ctx<'js>) -> Result<Value<'js>> {
-        self.lock().unwrap().into_js(ctx)
+        // TODO: determine we should panic her or just unpack the value.
+        self.lock().expect("mutex was poisoned").into_js(ctx)
     }
 }
 
@@ -204,7 +206,8 @@ where
     T: IntoJs<'js>,
 {
     fn into_js(self, ctx: Ctx<'js>) -> Result<Value<'js>> {
-        self.into_inner().unwrap().into_js(ctx)
+        // TODO: determine we should panic her or just unpack the value.
+        self.into_inner().expect("lock was poisoned").into_js(ctx)
     }
 }
 
@@ -213,7 +216,8 @@ where
     for<'r> &'r T: IntoJs<'js>,
 {
     fn into_js(self, ctx: Ctx<'js>) -> Result<Value<'js>> {
-        self.read().unwrap().into_js(ctx)
+        // TODO: determine we should panic her or just unpack the value.
+        self.read().expect("lock was poisoned").into_js(ctx)
     }
 }
 

--- a/macro/src/bind/class.rs
+++ b/macro/src/bind/class.rs
@@ -34,10 +34,7 @@ impl BindClass {
     }
 
     pub fn ctor(&mut self) -> &mut BindFn {
-        if self.ctor.is_none() {
-            self.ctor = Some(BindFn::default());
-        }
-        self.ctor.as_mut().unwrap()
+        self.ctor.get_or_insert_with(BindFn::default)
     }
 
     pub fn expand(&self, name: &str, cfg: &Config) -> TokenStream {


### PR DESCRIPTION
Fixes CI problem which no misses a library on i386 platform. 

Also has a quick fix for the panic mentioned in #138.
Properly handling returned object will probably require some more work and design.