### PR TITLE
Switch path and name in embed macro

### DIFF
--- a/macro/src/lib.rs
+++ b/macro/src/lib.rs
@@ -497,7 +497,7 @@ pub fn bind(attr: TokenStream1, item: TokenStream1) -> TokenStream1 {
 
 static BUNDLE: Bundle = embed!{
     // Load file `../examples/module-loader/script_module.js" and name it `script_module`
-    "../examples/module-loader/script_module.js": "script_module",
+    "script_module": "../examples/module-loader/script_module.js",
     // Load file `../examples/module-loader/script_module.js" and name it
     // `../examples/module-loader/script_module.js`
     "../examples/module-loader/script_module.js"


### PR DESCRIPTION
Switching the name and path order in the `embed` macro as described by #144.

Fixes #144