### PR TITLE
Restructured imports.

### DIFF
--- a/core/src/allocator/rust.rs
+++ b/core/src/allocator/rust.rs
@@ -1,9 +1,10 @@
-use crate::{Allocator, RawMemPtr};
 use std::{
     alloc::{alloc, dealloc, realloc, Layout},
     mem::size_of,
     ptr::null_mut,
 };
+
+use super::{Allocator, RawMemPtr};
 
 #[cfg(target_pointer_width = "32")]
 const ALLOC_ALIGN: usize = 4;

--- a/core/src/class.rs
+++ b/core/src/class.rs
@@ -20,7 +20,7 @@ pub use refs::{HasRefs, RefsMarker};
 /// NOTE: Usually no need implements this trait manually. Instead you can use [`class_def`](crate::class_def) macro or [`bind`](attr.bind.html) attribute to export classes to JS in easy way.
 ///
 /// ```
-/// # use rquickjs::{ClassId, ClassDef, FromJs, IntoJs, Ctx, Object, Result, Value, RefsMarker};
+/// # use rquickjs::{ClassId, class::{ClassDef, RefsMarker}, FromJs, IntoJs, Ctx, Object, Result, Value};
 /// #[derive(Clone)]
 /// struct MyClass;
 ///
@@ -440,7 +440,7 @@ where
 /// The macro to simplify class definition.
 ///
 /// ```
-/// # use rquickjs::{class_def, Method, Func};
+/// # use rquickjs::{class_def, function::{Method, Func}};
 /// #
 /// struct TestClass;
 ///

--- a/core/src/context.rs
+++ b/core/src/context.rs
@@ -1,3 +1,5 @@
+//! JS Contexts related types.
+
 use crate::{qjs, Error, Result, Runtime};
 use std::{mem, ptr::NonNull};
 

--- a/core/src/context/ctx.rs
+++ b/core/src/context/ctx.rs
@@ -239,7 +239,7 @@ mod test {
     #[cfg(feature = "exports")]
     #[test]
     fn exports() {
-        use crate::{intrinsic, Context, Function, Runtime};
+        use crate::{context::intrinsic, Context, Function, Runtime};
 
         let runtime = Runtime::new().unwrap();
         let ctx = Context::custom::<(intrinsic::Promise, intrinsic::Eval)>(&runtime).unwrap();
@@ -302,7 +302,7 @@ mod test {
 
     #[test]
     fn eval_with_options_no_strict_sloppy_code() {
-        use crate::{Context, EvalOptions, Runtime};
+        use crate::{context::EvalOptions, Context, Runtime};
 
         let runtime = Runtime::new().unwrap();
         let ctx = Context::full(&runtime).unwrap();
@@ -331,7 +331,7 @@ mod test {
     #[test]
     #[should_panic(expected = "'foo' is not defined")]
     fn eval_with_options_strict_sloppy_code() {
-        use crate::{CatchResultExt, Context, EvalOptions, Runtime};
+        use crate::{context::EvalOptions, CatchResultExt, Context, Runtime};
 
         let runtime = Runtime::new().unwrap();
         let ctx = Context::full(&runtime).unwrap();

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -43,23 +43,20 @@ mod result;
 pub use result::{CatchResultExt, CaughtError, CaughtResult, Error, Result, ThrowResultExt};
 mod safe_ref;
 pub(crate) use safe_ref::*;
-mod runtime;
-#[cfg(feature = "async-std")]
-pub use runtime::AsyncStd;
-#[cfg(all(feature = "smol", feature = "parallel"))]
-pub use runtime::Smol;
-#[cfg(feature = "tokio")]
-pub use runtime::Tokio;
-#[cfg(feature = "futures")]
-pub use runtime::{Executor, ExecutorSpawner, Idle};
-pub use runtime::{MemoryUsage, Runtime};
-mod context;
-pub use context::{intrinsic, Context, ContextBuilder, Ctx, EvalOptions, Intrinsic, MultiWith};
-mod value;
-pub use value::*;
+pub mod runtime;
+pub use runtime::Runtime;
+pub mod context;
+pub use context::{Context, Ctx};
 mod persistent;
-pub use persistent::{Outlive, Persistent};
+mod value;
+pub use persistent::Persistent;
+pub use value::{
+    convert, function, module, object, Array, Atom, BigInt, Exception, FromAtom, FromJs, Function,
+    IntoAtom, IntoJs, Module, Object, String, Symbol, Type, Undefined, Value,
+};
 
+#[cfg(feature = "array-buffer")]
+pub use value::{ArrayBuffer, TypedArray};
 mod class_id;
 #[cfg(not(feature = "classes"))]
 pub(crate) use class_id::ClassId;
@@ -67,31 +64,35 @@ pub(crate) use class_id::ClassId;
 pub use class_id::ClassId;
 
 #[cfg(feature = "classes")]
-mod class;
+pub mod class;
 #[cfg(feature = "classes")]
-pub use class::{Class, ClassDef, Constructor, HasRefs, RefsMarker, WithProto};
-
-#[cfg(feature = "properties")]
-mod property;
-#[cfg(feature = "properties")]
-pub use property::{Accessor, AsProperty, Property};
+pub use class::Class;
 
 pub(crate) use std::{result::Result as StdResult, string::String as StdString};
 
 #[cfg(feature = "futures")]
 mod promise;
 
-#[cfg(feature = "futures")]
-pub use promise::{Promise, Promised};
-
 #[cfg(feature = "allocator")]
-mod allocator;
-
-#[cfg(feature = "allocator")]
-pub use allocator::{Allocator, RawMemPtr, RustAllocator};
+pub mod allocator;
 
 #[cfg(feature = "loader")]
 pub mod loader;
+
+pub mod prelude {
+    //! A group of often used types.
+    pub use crate::{
+        context::MultiWith,
+        convert::{Coerced, FromAtom, FromJs, IntoAtom, IntoJs, IteratorJs},
+        function::{AsArguments, Func, MutFn, OnceFn, Rest, This},
+        result::{CatchResultExt, ThrowResultExt},
+    };
+    #[cfg(feature = "futures")]
+    pub use crate::{
+        function::Async,
+        promise::{Promise, Promised},
+    };
+}
 
 /*#[cfg(feature = "loader")]
 pub use loader::{

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -71,7 +71,7 @@ pub use class::Class;
 pub(crate) use std::{result::Result as StdResult, string::String as StdString};
 
 #[cfg(feature = "futures")]
-mod promise;
+pub mod promise;
 
 #[cfg(feature = "allocator")]
 pub mod allocator;

--- a/core/src/loader.rs
+++ b/core/src/loader.rs
@@ -2,7 +2,7 @@
 
 use std::{ffi::CStr, ptr};
 
-use crate::{qjs, Ctx, Module, ModuleData, Result};
+use crate::{module::ModuleData, qjs, Ctx, Module, Result};
 
 mod builtin_resolver;
 pub use builtin_resolver::BuiltinResolver;
@@ -267,7 +267,7 @@ loader_impls!(A B C D E F G H);
 
 #[cfg(test)]
 mod test {
-    use crate::{Context, Ctx, Error, ModuleData, Result, Runtime};
+    use crate::{module::ModuleData, Context, Ctx, Error, Result, Runtime};
 
     use super::{Loader, Resolver};
 

--- a/core/src/loader/builtin_loader.rs
+++ b/core/src/loader/builtin_loader.rs
@@ -1,4 +1,4 @@
-use crate::{loader::Loader, Ctx, Error, ModuleData, Result};
+use crate::{loader::Loader, module::ModuleData, Ctx, Error, Result};
 use std::collections::HashMap;
 
 /// The builtin script module loader

--- a/core/src/loader/bundle.rs
+++ b/core/src/loader/bundle.rs
@@ -1,7 +1,7 @@
 //! Utilites for embedding JS modules.
 
 use super::{util::resolve_simple, Loader, Resolver};
-use crate::{Ctx, Error, ModuleData, Result};
+use crate::{module::ModuleData, Ctx, Error, Result};
 use std::ops::Deref;
 
 /// The module data which contains bytecode

--- a/core/src/loader/compile.rs
+++ b/core/src/loader/compile.rs
@@ -1,6 +1,7 @@
 use crate::{
     loader::{util::resolve_simple, Loader, RawLoader, Resolver},
-    Ctx, Lock, Module, ModuleDataKind, Mut, Ref, Result,
+    module::ModuleDataKind,
+    Ctx, Lock, Module, Mut, Ref, Result,
 };
 use std::{
     collections::{hash_map::Iter as HashMapIter, HashMap},

--- a/core/src/loader/module_loader.rs
+++ b/core/src/loader/module_loader.rs
@@ -1,4 +1,7 @@
-use crate::{Ctx, Error, ModuleData, ModuleDef, Result};
+use crate::{
+    module::{ModuleData, ModuleDef},
+    Ctx, Error, Result,
+};
 use std::{collections::HashMap, fmt::Debug};
 
 use super::Loader;

--- a/core/src/loader/native_loader.rs
+++ b/core/src/loader/native_loader.rs
@@ -1,4 +1,6 @@
-use crate::{loader::util::check_extensions, Ctx, Error, ModuleData, ModuleLoadFn, Result};
+use crate::{
+    loader::util::check_extensions, module::ModuleData, module::ModuleLoadFn, Ctx, Error, Result,
+};
 
 use super::Loader;
 

--- a/core/src/loader/script_loader.rs
+++ b/core/src/loader/script_loader.rs
@@ -1,6 +1,7 @@
 use crate::{
     loader::{util::check_extensions, Loader},
-    Ctx, Error, ModuleData, Result,
+    module::ModuleData,
+    Ctx, Error, Result,
 };
 
 /// The script module loader

--- a/core/src/promise.rs
+++ b/core/src/promise.rs
@@ -173,11 +173,7 @@ fn resolve<'js>(_ctx: Ctx<'js>, func: Function<'js>, value: Value<'js>) {
 
 #[cfg(all(test, any(feature = "async-std", feature = "tokio")))]
 mod test {
-    use crate::{
-        prelude::*,
-        runtime::{self, Tokio},
-        Context, Function, Runtime, Value,
-    };
+    use crate::{prelude::*, runtime, Context, Function, Runtime, Value};
     use futures_rs::prelude::*;
 
     macro_rules! test_cases {
@@ -201,7 +197,7 @@ mod test {
                                 let rt = Runtime::new().unwrap();
                                 let $ctx = Context::full(&rt).unwrap();
 
-                                rt.spawn_executor(Tokio);
+                                rt.spawn_executor(runtime::Tokio);
 
                                 $($content)*
 

--- a/core/src/promise.rs
+++ b/core/src/promise.rs
@@ -1,6 +1,7 @@
 use crate::{
-    Context, Ctx, FromJs, Func, Function, IntoJs, Mut, Object, ParallelSend, Persistent, Ref,
-    Result, This, Value,
+    function::{Func, This},
+    Context, Ctx, FromJs, Function, IntoJs, Mut, Object, ParallelSend, Persistent, Ref, Result,
+    Value,
 };
 use pin_project_lite::pin_project;
 use std::{
@@ -172,7 +173,7 @@ fn resolve<'js>(_ctx: Ctx<'js>, func: Function<'js>, value: Value<'js>) {
 
 #[cfg(all(test, any(feature = "async-std", feature = "tokio")))]
 mod test {
-    use crate::*;
+    use crate::{prelude::*, runtime, Context, Function, Runtime, Value};
     use futures_rs::prelude::*;
 
     macro_rules! test_cases {
@@ -208,7 +209,7 @@ mod test {
                             let rt = Runtime::new().unwrap();
                             let $ctx = Context::full(&rt).unwrap();
 
-                            rt.spawn_executor(Tokio);
+                            rt.spawn_executor(runtime::Tokio);
 
                             $($content)*
 
@@ -234,7 +235,7 @@ mod test {
                         let rt = Runtime::new().unwrap();
                         let $ctx = Context::full(&rt).unwrap();
 
-                        rt.spawn_executor(AsyncStd);
+                        rt.spawn_executor(runtime::AsyncStd);
 
                         $($content)*
 

--- a/core/src/promise.rs
+++ b/core/src/promise.rs
@@ -173,7 +173,11 @@ fn resolve<'js>(_ctx: Ctx<'js>, func: Function<'js>, value: Value<'js>) {
 
 #[cfg(all(test, any(feature = "async-std", feature = "tokio")))]
 mod test {
-    use crate::{prelude::*, runtime, Context, Function, Runtime, Value};
+    use crate::{
+        prelude::*,
+        runtime::{self, Tokio},
+        Context, Function, Runtime, Value,
+    };
     use futures_rs::prelude::*;
 
     macro_rules! test_cases {

--- a/core/src/runtime.rs
+++ b/core/src/runtime.rs
@@ -1,3 +1,5 @@
+//! Quickjs runtime related types.
+
 #[cfg(feature = "loader")]
 use crate::loader::{LoaderHolder, RawLoader, Resolver};
 use crate::{qjs, result::JobException, Context, Ctx, Error, Function, Mut, Ref, Result, Weak};
@@ -15,11 +17,12 @@ pub use self::async_executor::*;
 pub use qjs::JSMemoryUsage as MemoryUsage;
 
 #[cfg(feature = "allocator")]
-use crate::{allocator::AllocatorHolder, Allocator};
+use crate::allocator::{Allocator, AllocatorHolder};
 
 //#[cfg(feature = "loader")]
 //use crate::{loader::LoaderHolder, Loader, Resolver};
 
+/// A weak handle to the runtime.
 #[derive(Clone)]
 #[repr(transparent)]
 pub struct WeakRuntime(Weak<Mut<Inner>>);
@@ -31,7 +34,7 @@ impl WeakRuntime {
 }
 
 /// Opaque book keeping data for rust.
-pub struct Opaque {
+pub(crate) struct Opaque {
     /// Used to carry a panic if a callback triggered one.
     pub panic: Option<Box<dyn Any + Send + 'static>>,
 
@@ -147,7 +150,7 @@ impl Runtime {
             )
         }
         #[cfg(feature = "rust-alloc")]
-        Self::new_with_alloc(crate::RustAllocator)
+        Self::new_with_alloc(crate::allocator::RustAllocator)
     }
 
     #[cfg(feature = "allocator")]

--- a/core/src/value.rs
+++ b/core/src/value.rs
@@ -1,11 +1,11 @@
 mod array;
 mod atom;
 mod bigint;
-mod convert;
+pub mod convert;
 mod exception;
-mod function;
-mod module;
-mod object;
+pub mod function;
+pub mod module;
+pub mod object;
 mod string;
 mod symbol;
 
@@ -24,10 +24,7 @@ pub use exception::Exception;
 pub use function::{
     AsArguments, AsFunction, Func, Function, Method, MutFn, OnceFn, Opt, Rest, This,
 };
-pub use module::{
-    Declarations, Exports, Module, ModuleData, ModuleDataKind, ModuleDef, ModuleLoadFn,
-    ModulesBuilder,
-};
+pub use module::Module;
 pub use object::{Filter, Object, ObjectDef};
 pub use string::String;
 pub use symbol::Symbol;
@@ -352,7 +349,7 @@ impl<'js> AsRef<Value<'js>> for Value<'js> {
 macro_rules! type_impls {
     // type: name => tag
     ($($type:ident: $name:ident => $tag:ident,)*) => {
-        /// The type of value
+        /// The type of Javascript value
         #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
         #[repr(i32)]
         pub enum Type {

--- a/core/src/value/array.rs
+++ b/core/src/value/array.rs
@@ -190,6 +190,8 @@ where
 
 #[cfg(test)]
 mod test {
+    use convert::IteratorJs;
+
     use crate::*;
     #[test]
     fn from_javascript() {

--- a/core/src/value/convert.rs
+++ b/core/src/value/convert.rs
@@ -10,7 +10,7 @@ mod into;
 /// The wrapper for values to force coercion
 ///
 /// ```
-/// # use rquickjs::{Runtime, Context, Result, Coerced};
+/// # use rquickjs::{Runtime, Context, Result, convert::Coerced};
 /// # let rt = Runtime::new().unwrap();
 /// # let ctx = Context::full(&rt).unwrap();
 /// # ctx.with(|ctx| -> Result<()> {

--- a/core/src/value/convert.rs
+++ b/core/src/value/convert.rs
@@ -1,3 +1,5 @@
+//! Utilites for converting to and from javascript values.
+
 use crate::{Atom, Ctx, Result, Value};
 
 mod atom;

--- a/core/src/value/convert/coerce.rs
+++ b/core/src/value/convert/coerce.rs
@@ -1,4 +1,4 @@
-use crate::{qjs, Coerced, Ctx, FromJs, Result, StdString, String, Value};
+use crate::{convert::Coerced, qjs, Ctx, FromJs, Result, StdString, String, Value};
 use std::{
     mem::MaybeUninit,
     ops::{Deref, DerefMut},

--- a/core/src/value/convert/from.rs
+++ b/core/src/value/convert/from.rs
@@ -331,7 +331,7 @@ fn date_to_millis<'js>(ctx: Ctx<'js>, value: Value<'js>) -> Result<i64> {
 
     let get_time_fn: crate::Function = value.get("getTime")?;
 
-    get_time_fn.call((crate::This(value),))
+    get_time_fn.call((crate::function::This(value),))
 }
 
 impl<'js> FromJs<'js> for SystemTime {

--- a/core/src/value/convert/into.rs
+++ b/core/src/value/convert/into.rs
@@ -1,5 +1,5 @@
 use crate::{
-    Array, Ctx, Error, Function, IntoAtom, IntoJs, IteratorJs, Object, Result, StdResult,
+    convert::IteratorJs, Array, Ctx, Error, Function, IntoAtom, IntoJs, Object, Result, StdResult,
     StdString, String, Value,
 };
 use std::{

--- a/core/src/value/exception.rs
+++ b/core/src/value/exception.rs
@@ -1,8 +1,8 @@
 use std::{fmt, ops::Deref};
 
-use crate::{qjs, Coerced, Ctx, Error, FromJs, IntoJs, Object, Result, Value};
+use crate::{convert::Coerced, qjs, Ctx, Error, FromJs, IntoJs, Object, Result, Value};
 
-/// A javascript error
+/// A javascript instance of Error
 ///
 /// Will turn into a error when converted to javascript but won't autmatically be thrown.
 #[repr(transparent)]

--- a/core/src/value/function.rs
+++ b/core/src/value/function.rs
@@ -1,3 +1,5 @@
+//! JS functions and rust callbacks.
+
 use crate::{qjs, Ctx, Error, FromJs, IntoAtom, IntoJs, Object, ParallelSend, Result, Value};
 
 mod args;
@@ -269,7 +271,7 @@ impl<'js> Function<'js> {
 
 #[cfg(test)]
 mod test {
-    use crate::*;
+    use crate::{prelude::*, *};
     use approx::assert_abs_diff_eq as assert_approx_eq;
 
     #[test]

--- a/core/src/value/function/args.rs
+++ b/core/src/value/function/args.rs
@@ -1,4 +1,7 @@
-use crate::{qjs, Ctx, Error, FromJs, Opt, Rest, Result, This, Value};
+use crate::{
+    function::{Opt, Rest, This},
+    qjs, Ctx, Error, FromJs, Result, Value,
+};
 use std::{ops::Range, slice};
 
 pub struct Input<'js> {

--- a/core/src/value/function/as_args.rs
+++ b/core/src/value/function/as_args.rs
@@ -1,4 +1,7 @@
-use crate::{qjs, Ctx, FromJs, Function, IntoJs, Opt, Rest, Result, This};
+use crate::{
+    function::{Opt, Rest, This},
+    qjs, Ctx, FromJs, Function, IntoJs, Result,
+};
 
 /// The input for function call
 pub struct CallInput<'js> {

--- a/core/src/value/function/as_func.rs
+++ b/core/src/value/function/as_func.rs
@@ -1,14 +1,16 @@
 use super::{FromInput, Input};
 use crate::{
-    Ctx, Error, FromJs, Function, IntoJs, Method, MutFn, OnceFn, ParallelSend, Result, This, Value,
+    function::{Method, MutFn, OnceFn, This},
+    markers::ParallelSend,
+    Ctx, Error, FromJs, Function, IntoJs, Result, Value,
 };
 use std::ops::Range;
 
 #[cfg(feature = "classes")]
-use crate::{Class, ClassDef, Constructor};
+use crate::class::{Class, ClassDef, Constructor};
 
 #[cfg(feature = "futures")]
-use crate::{Async, Promised};
+use crate::{function::Async, promise::Promised};
 #[cfg(feature = "futures")]
 use std::future::Future;
 

--- a/core/src/value/function/types.rs
+++ b/core/src/value/function/types.rs
@@ -1,4 +1,4 @@
-use crate::{AsFunction, Ctx, Function, IntoJs, ParallelSend, Result, Value};
+use crate::{function::AsFunction, Ctx, Function, IntoJs, ParallelSend, Result, Value};
 use std::{
     cell::RefCell,
     marker::PhantomData,

--- a/core/src/value/function/types.rs
+++ b/core/src/value/function/types.rs
@@ -10,7 +10,7 @@ use std::{
 /// The method-like functions is functions which get `this` as the first argument. This wrapper allows receive `this` directly as first argument and do not requires using [`This`] for that purpose.
 ///
 /// ```
-/// # use rquickjs::{Runtime, Context, Result, Method, Function, This};
+/// # use rquickjs::{Runtime, Context, Result, Function, function::{Method, This}};
 /// # let rt = Runtime::new().unwrap();
 /// # let ctx = Context::full(&rt).unwrap();
 /// # ctx.with(|ctx| -> Result<()> {
@@ -31,7 +31,7 @@ pub struct Method<F>(pub F);
 /// The Rust functions should be wrapped to convert it to JS using [`IntoJs`] trait.
 ///
 /// ```
-/// # use rquickjs::{Runtime, Context, Result, Func};
+/// # use rquickjs::{Runtime, Context, Result, function::Func};
 /// # let rt = Runtime::new().unwrap();
 /// # let ctx = Context::full(&rt).unwrap();
 /// # ctx.with(|ctx| -> Result<()> {
@@ -65,7 +65,7 @@ pub struct Func<F>(pub F);
 /// This type wraps returned future into [`Promised`](crate::Promised)
 ///
 /// ```
-/// # use rquickjs::{Runtime, Context, Result, Function, Async};
+/// # use rquickjs::{Runtime, Context, Result, Function, function::Async};
 /// # let rt = Runtime::new().unwrap();
 /// # let ctx = Context::full(&rt).unwrap();
 /// # ctx.with(|ctx| -> Result<()> {
@@ -108,7 +108,7 @@ impl<F> From<F> for OnceFn<F> {
 /// The wrapper to get `this` from input
 ///
 /// ```
-/// # use rquickjs::{Runtime, Context, Result, This, Function};
+/// # use rquickjs::{Runtime, Context, Result, function::This, Function};
 /// # let rt = Runtime::new().unwrap();
 /// # let ctx = Context::full(&rt).unwrap();
 /// # ctx.with(|ctx| -> Result<()> {
@@ -132,7 +132,7 @@ pub struct This<T>(pub T);
 /// The [`Option`] type cannot be used for that purpose because it implements [`FromJs`](crate::FromJs) trait and requires the argument which may be `undefined`.
 ///
 /// ```
-/// # use rquickjs::{Runtime, Context, Result, Opt, Function};
+/// # use rquickjs::{Runtime, Context, Result, function::Opt, Function};
 /// # let rt = Runtime::new().unwrap();
 /// # let ctx = Context::full(&rt).unwrap();
 /// # ctx.with(|ctx| -> Result<()> {
@@ -156,7 +156,7 @@ pub struct Opt<T>(pub Option<T>);
 /// The [`Vec`] type cannot be used for that purpose because it implements [`FromJs`](crate::FromJs) and already used to convert JS arrays.
 ///
 /// ```
-/// # use rquickjs::{Runtime, Context, Result, Rest, Function};
+/// # use rquickjs::{Runtime, Context, Result, function::Rest, Function};
 /// # let rt = Runtime::new().unwrap();
 /// # let ctx = Context::full(&rt).unwrap();
 /// # ctx.with(|ctx| -> Result<()> {

--- a/core/src/value/module.rs
+++ b/core/src/value/module.rs
@@ -18,7 +18,7 @@ use crate::{qjs, Atom, Context, Ctx, Error, FromAtom, FromJs, IntoJs, Result, Va
 /// Helper macro to provide module init function.
 /// Use for exporting module definitions to be loaded as part of a dynamic library.
 /// ```
-/// use rquickjs::{ModuleDef, module_init};
+/// use rquickjs::{module::ModuleDef, module_init};
 ///
 /// struct MyModule;
 /// impl ModuleDef for MyModule {}

--- a/core/src/value/module.rs
+++ b/core/src/value/module.rs
@@ -1,3 +1,5 @@
+//! Types for loading and handling JS modules.
+
 use std::{
     borrow::Cow,
     collections::HashSet,

--- a/core/src/value/object.rs
+++ b/core/src/value/object.rs
@@ -1,12 +1,19 @@
+//! Module for types dealing with JS objects.
+
 use crate::{
-    qjs, Array, Atom, Ctx, Error, FromAtom, FromIteratorJs, FromJs, Function, IntoAtom, IntoJs,
-    Result, Value,
+    convert::FromIteratorJs, qjs, Array, Atom, Ctx, Error, FromAtom, FromJs, Function, IntoAtom,
+    IntoJs, Result, Value,
 };
 use std::{
     iter::{DoubleEndedIterator, ExactSizeIterator, FusedIterator, IntoIterator, Iterator},
     marker::PhantomData,
     mem,
 };
+
+#[cfg(feature = "properties")]
+mod property;
+#[cfg(feature = "properties")]
+pub use property::{Accessor, AsProperty, Property};
 
 /// The helper trait to define objects
 pub trait ObjectDef {
@@ -674,7 +681,7 @@ where
 
 #[cfg(test)]
 mod test {
-    use crate::*;
+    use crate::{prelude::*, *};
 
     #[test]
     fn from_javascript() {

--- a/core/src/value/object/property.rs
+++ b/core/src/value/object/property.rs
@@ -7,7 +7,7 @@ impl<'js> Object<'js> {
     /// Define a property of an object
     ///
     /// ```
-    /// # use rquickjs::{Runtime, Context, Object, Property, Accessor};
+    /// # use rquickjs::{Runtime, Context, Object, object::{Property, Accessor}};
     /// # let rt = Runtime::new().unwrap();
     /// # let ctx = Context::full(&rt).unwrap();
     /// # ctx.with(|ctx| {

--- a/core/src/value/object/property.rs
+++ b/core/src/value/object/property.rs
@@ -1,6 +1,6 @@
 use crate::{
-    qjs, AsFunction, Ctx, Function, IntoAtom, IntoJs, Object, ParallelSend, Result, Undefined,
-    Value,
+    function::AsFunction, qjs, Ctx, Function, IntoAtom, IntoJs, Object, ParallelSend, Result,
+    Undefined, Value,
 };
 
 impl<'js> Object<'js> {
@@ -259,7 +259,7 @@ where
 
 #[cfg(test)]
 mod test {
-    use crate::*;
+    use crate::{object::*, *};
 
     #[test]
     fn property_with_undefined() {
@@ -358,7 +358,7 @@ mod test {
             let obj = Object::new(ctx).unwrap();
             obj.prop("key", Property::from("str")).unwrap();
             let keys: Vec<StdString> = obj
-                .own_keys(Filter::new().string())
+                .own_keys(object::Filter::new().string())
                 .collect::<Result<_>>()
                 .unwrap();
             assert_eq!(keys.len(), 1);

--- a/core/src/value/string.rs
+++ b/core/src/value/string.rs
@@ -39,7 +39,7 @@ impl<'js> String<'js> {
 
 #[cfg(test)]
 mod test {
-    use crate::*;
+    use crate::{prelude::*, *};
     #[test]
     fn from_javascript() {
         test_with(|ctx| {

--- a/examples/module-loader/src/bundle/hand_written.rs
+++ b/examples/module-loader/src/bundle/hand_written.rs
@@ -1,19 +1,19 @@
-use rquickjs::{Created, Ctx, Func, Loaded, Module, ModuleDef, Native, Result};
+use rquickjs::{function::Func, module::ModuleDef, Ctx, Module, Result};
 
 pub struct NativeModule;
 
 impl ModuleDef for NativeModule {
-    fn load<'js>(_ctx: Ctx<'js>, module: &Module<'js, Created>) -> Result<()> {
-        module.add("n")?;
-        module.add("s")?;
-        module.add("f")?;
+    fn declare<'js>(_ctx: Ctx<'js>, exports: &mut Declarations) -> Result<()> {
+        module.declare("n")?;
+        module.declare("s")?;
+        module.declare("f")?;
         Ok(())
     }
 
-    fn eval<'js>(_ctx: Ctx<'js>, module: &Module<'js, Loaded<Native>>) -> Result<()> {
-        module.set("n", 123)?;
-        module.set("s", "abc")?;
-        module.set("f", Func::new("f", |a: f64, b: f64| (a + b) * 0.5))?;
+    fn eval<'js>(_ctx: Ctx<'js>, exports: &Exports<'js>) -> Result<()> {
+        exports.export("n", 123)?;
+        exports.export("s", "abc")?;
+        exports.export("f", Func::new("f", |a: f64, b: f64| (a + b) * 0.5))?;
         Ok(())
     }
 }

--- a/examples/module-loader/src/main.rs
+++ b/examples/module-loader/src/main.rs
@@ -1,8 +1,9 @@
 use rquickjs::{
+    function::Func,
     loader::{
         BuiltinLoader, BuiltinResolver, FileResolver, ModuleLoader, NativeLoader, ScriptLoader,
     },
-    Context, Func, Runtime,
+    Context, Runtime,
 };
 
 mod bundle;

--- a/macro/src/bind.rs
+++ b/macro/src/bind.rs
@@ -392,13 +392,13 @@ impl Binder {
                 };
 
                 bindings.push(quote! {
-                    impl #lib_crate::ModuleDef for #ident {
-                        fn declare(#declares: &mut #lib_crate::Declarations) -> #lib_crate::Result<()> {
+                    impl #lib_crate::module::ModuleDef for #ident {
+                        fn declare(#declares: &mut #lib_crate::module::Declarations) -> #lib_crate::Result<()> {
                             #mod_decl
                             Ok(())
                         }
 
-                        fn evaluate<'js>(_ctx: #lib_crate::Ctx<'js>, #exports: &mut #lib_crate::Exports<'js>) -> #lib_crate::Result<()> {
+                        fn evaluate<'js>(_ctx: #lib_crate::Ctx<'js>, #exports: &mut #lib_crate::module::Exports<'js>) -> #lib_crate::Result<()> {
                             #mod_impl
                             Ok(())
                         }
@@ -412,7 +412,7 @@ impl Binder {
                 let obj_init = def.object_init(&name, &self.config);
 
                 bindings.push(quote! {
-                    impl #lib_crate::ObjectDef for #ident {
+                    impl #lib_crate::object::ObjectDef for #ident {
                         fn init<'js>(_ctx: #lib_crate::Ctx<'js>, #exports: &#lib_crate::Object<'js>) -> #lib_crate::Result<()> {
                             #obj_init
                             Ok(())

--- a/macro/src/bind/class.rs
+++ b/macro/src/bind/class.rs
@@ -91,8 +91,8 @@ impl BindClass {
             extras.extend(quote! {
                 const HAS_REFS: bool = true;
 
-                fn mark_refs(&self, marker: &#lib_crate::RefsMarker) {
-                    #lib_crate::HasRefs::mark_refs(self, marker);
+                fn mark_refs(&self, marker: &#lib_crate::class::RefsMarker) {
+                    #lib_crate::class::HasRefs::mark_refs(self, marker);
                 }
             })
         }
@@ -100,13 +100,13 @@ impl BindClass {
         let mut converts = quote! {
             impl<'js> #lib_crate::IntoJs<'js> for #src {
                 fn into_js(self, ctx: #lib_crate::Ctx<'js>) -> #lib_crate::Result<#lib_crate::Value<'js>> {
-                    <#src as #lib_crate::ClassDef>::into_js_obj(self, ctx)
+                    <#src as #lib_crate::class::ClassDef>::into_js_obj(self, ctx)
                 }
             }
 
             impl<'js> #lib_crate::FromJs<'js> for &'js #src {
                 fn from_js(ctx: #lib_crate::Ctx<'js>, value: #lib_crate::Value<'js>) -> #lib_crate::Result<Self> {
-                    <#src as #lib_crate::ClassDef>::from_js_ref(ctx, value)
+                    <#src as #lib_crate::class::ClassDef>::from_js_ref(ctx, value)
                 }
             }
         };
@@ -115,26 +115,26 @@ impl BindClass {
             converts.extend(quote! {
                 impl<'js> #lib_crate::IntoJs<'js> for &#src {
                     fn into_js(self, ctx: #lib_crate::Ctx<'js>) -> #lib_crate::Result<#lib_crate::Value<'js>> {
-                        #lib_crate::ClassDef::into_js_obj(self.clone(), ctx)
+                        #lib_crate::class::ClassDef::into_js_obj(self.clone(), ctx)
                     }
                 }
 
                 impl<'js> #lib_crate::IntoJs<'js> for &mut #src {
                     fn into_js(self, ctx: #lib_crate::Ctx<'js>) -> #lib_crate::Result<#lib_crate::Value<'js>> {
-                        #lib_crate::ClassDef::into_js_obj(self.clone(), ctx)
+                        #lib_crate::class::ClassDef::into_js_obj(self.clone(), ctx)
                     }
                 }
 
                 impl<'js> #lib_crate::FromJs<'js> for #src {
                     fn from_js(ctx: #lib_crate::Ctx<'js>, value: #lib_crate::Value<'js>) -> #lib_crate::Result<Self> {
-                        #lib_crate::ClassDef::from_js_obj(ctx, value)
+                        #lib_crate::class::ClassDef::from_js_obj(ctx, value)
                     }
                 }
             });
         }
 
         quote! {
-            impl #lib_crate::ClassDef for #src {
+            impl #lib_crate::class::ClassDef for #src {
                 const CLASS_NAME: &'static str = #name;
 
                 fn class_id() -> &'static #lib_crate::ClassId {
@@ -409,7 +409,7 @@ mod test {
                 impl Test {}
             }
         } {
-            impl rquickjs::ClassDef for test::Test {
+            impl rquickjs::class::ClassDef for test::Test {
                 const CLASS_NAME: &'static str = "Test";
 
                 fn class_id() -> &'static rquickjs::ClassId {
@@ -420,13 +420,13 @@ mod test {
 
             impl<'js> rquickjs::IntoJs<'js> for test::Test {
                 fn into_js(self, ctx: rquickjs::Ctx<'js>) -> rquickjs::Result<rquickjs::Value<'js>> {
-                    <test::Test as rquickjs::ClassDef>::into_js_obj(self, ctx)
+                    <test::Test as rquickjs::class::ClassDef>::into_js_obj(self, ctx)
                 }
             }
 
             impl<'js> rquickjs::FromJs<'js> for &'js test::Test {
                 fn from_js(ctx: rquickjs::Ctx<'js>, value: rquickjs::Value<'js>) -> rquickjs::Result<Self> {
-                    <test::Test as rquickjs::ClassDef>::from_js_ref(ctx, value)
+                    <test::Test as rquickjs::class::ClassDef>::from_js_ref(ctx, value)
                 }
             }
 
@@ -442,7 +442,7 @@ mod test {
                 }
             }
         } {
-            impl rquickjs::ClassDef for test::Test {
+            impl rquickjs::class::ClassDef for test::Test {
                 const CLASS_NAME: &'static str = "Test";
 
                 fn class_id() -> &'static rquickjs::ClassId {
@@ -453,27 +453,27 @@ mod test {
                 const HAS_PROTO: bool = true;
 
                 fn init_proto<'js >(_ctx: rquickjs::Ctx<'js>, exports: &rquickjs::Object<'js>) -> rquickjs::Result<()> {
-                    exports.prop("a", rquickjs::Accessor::new({
+                    exports.prop("a", rquickjs::object::Accessor::new({
                         fn get_a(self_: &test::Test) -> String {
                             self_.a
                         }
-                        rquickjs::Method(get_a)
+                        rquickjs::function::Method(get_a)
                     }, {
                         fn set_a(self_: &mut test::Test, val: String) {
                             self_.a = val;
                         }
-                        rquickjs::Method(set_a)
+                        rquickjs::function::Method(set_a)
                     }))?;
-                    exports.prop("b", rquickjs::Accessor::new({
+                    exports.prop("b", rquickjs::object::Accessor::new({
                         fn get_b(self_: &test::Test) -> f64 {
                             self_.b
                         }
-                        rquickjs::Method(get_b)
+                        rquickjs::function::Method(get_b)
                     }, {
                         fn set_b(self_: &mut test::Test, val: f64) {
                             self_.b = val;
                         }
-                        rquickjs::Method(set_b)
+                        rquickjs::function::Method(set_b)
                     }))?;
                     Ok (())
                 }
@@ -481,13 +481,13 @@ mod test {
 
             impl<'js> rquickjs::IntoJs<'js> for test::Test {
                 fn into_js(self, ctx: rquickjs::Ctx<'js>) -> rquickjs::Result<rquickjs::Value<'js>> {
-                    <test::Test as rquickjs::ClassDef>::into_js_obj(self, ctx)
+                    <test::Test as rquickjs::class::ClassDef>::into_js_obj(self, ctx)
                 }
             }
 
             impl<'js> rquickjs::FromJs<'js> for &'js test::Test {
                 fn from_js(ctx: rquickjs::Ctx<'js>, value: rquickjs::Value<'js>) -> rquickjs::Result<Self> {
-                    <test::Test as rquickjs::ClassDef>::from_js_ref(ctx, value)
+                    <test::Test as rquickjs::class::ClassDef>::from_js_ref(ctx, value)
                 }
             }
 
@@ -505,7 +505,7 @@ mod test {
                 }
             }
         } {
-            impl rquickjs::ClassDef for test::Node {
+            impl rquickjs::class::ClassDef for test::Node {
                 const CLASS_NAME: &'static str = "Node";
 
                 fn class_id() -> &'static rquickjs::ClassId {
@@ -516,40 +516,40 @@ mod test {
                 const HAS_PROTO: bool = true;
 
                 fn init_proto<'js>(_ctx: rquickjs::Ctx<'js>, exports: &rquickjs::Object<'js>) -> rquickjs::Result<()> {
-                    exports.set("len", rquickjs::Func::new("len", rquickjs::Method(test::Node::len)))?;
-                    exports.set("add", rquickjs::Func::new("add", rquickjs::Method(test::Node::add)))?;
-                    exports.set("run", rquickjs::Func::new("run", rquickjs::Async(rquickjs::Method(test::Node::run))))?;
+                    exports.set("len", rquickjs::function::Func::new("len", rquickjs::function::Method(test::Node::len)))?;
+                    exports.set("add", rquickjs::function::Func::new("add", rquickjs::function::Method(test::Node::add)))?;
+                    exports.set("run", rquickjs::function::Func::new("run", rquickjs::function::Async(rquickjs::function::Method(test::Node::run))))?;
                     Ok(())
                 }
             }
 
             impl<'js> rquickjs::IntoJs<'js> for test::Node {
                 fn into_js(self, ctx: rquickjs::Ctx<'js>) -> rquickjs::Result<rquickjs::Value<'js>> {
-                    <test::Node as rquickjs::ClassDef>::into_js_obj(self, ctx)
+                    <test::Node as rquickjs::class::ClassDef>::into_js_obj(self, ctx)
                 }
             }
 
             impl<'js> rquickjs::FromJs<'js> for &'js test::Node {
                 fn from_js(ctx: rquickjs::Ctx<'js>, value: rquickjs::Value<'js>) -> rquickjs::Result<Self> {
-                    <test::Node as rquickjs::ClassDef>::from_js_ref(ctx, value)
+                    <test::Node as rquickjs::class::ClassDef>::from_js_ref(ctx, value)
                 }
             }
 
             impl<'js> rquickjs::IntoJs<'js> for &test::Node {
                 fn into_js(self, ctx: rquickjs::Ctx<'js>) -> rquickjs::Result<rquickjs::Value<'js>> {
-                    rquickjs::ClassDef::into_js_obj(self.clone(), ctx)
+                    rquickjs::class::ClassDef::into_js_obj(self.clone(), ctx)
                 }
             }
 
             impl<'js> rquickjs::IntoJs<'js> for &mut test::Node {
                 fn into_js(self, ctx: rquickjs::Ctx<'js>) -> rquickjs::Result<rquickjs::Value<'js>> {
-                    rquickjs::ClassDef::into_js_obj(self.clone(), ctx)
+                    rquickjs::class::ClassDef::into_js_obj(self.clone(), ctx)
                 }
             }
 
             impl<'js> rquickjs::FromJs<'js> for test::Node {
                 fn from_js(ctx: rquickjs::Ctx<'js>, value: rquickjs::Value<'js>) -> rquickjs::Result<Self> {
-                    rquickjs::ClassDef::from_js_obj(ctx, value)
+                    rquickjs::class::ClassDef::from_js_obj(ctx, value)
                 }
             }
 
@@ -578,7 +578,7 @@ mod test {
                 }
             }
         } {
-            impl rquickjs::ClassDef for test::Node {
+            impl rquickjs::class::ClassDef for test::Node {
                 const CLASS_NAME: &'static str = "Node";
 
                 fn class_id() -> &'static rquickjs::ClassId {
@@ -589,10 +589,10 @@ mod test {
                 const HAS_PROTO: bool = true;
 
                 fn init_proto<'js>(_ctx: rquickjs::Ctx<'js>, exports: &rquickjs::Object<'js>) -> rquickjs::Result<()> {
-                    exports.prop("children", rquickjs::Property::from(test::Node::HAS_CHILDREN))?;
-                    exports.prop("parent", rquickjs::Accessor::new(
-                        rquickjs::Method(test::Node::parent),
-                        rquickjs::Method(test::Node::set_parent)
+                    exports.prop("children", rquickjs::object::Property::from(test::Node::HAS_CHILDREN))?;
+                    exports.prop("parent", rquickjs::object::Accessor::new(
+                        rquickjs::function::Method(test::Node::parent),
+                        rquickjs::function::Method(test::Node::set_parent)
                     ).enumerable())?;
                     Ok(())
                 }
@@ -600,21 +600,21 @@ mod test {
                 const HAS_STATIC: bool = true;
 
                 fn init_static<'js>(_ctx: rquickjs::Ctx<'js>, exports: &rquickjs::Object<'js>) -> rquickjs::Result<()> {
-                    exports.prop("children", rquickjs::Property::from(test::Node::MAX_CHILDREN).configurable())?;
-                    exports.prop("root", rquickjs::Accessor::new_get(test::Node::get_root))?;
+                    exports.prop("children", rquickjs::object::Property::from(test::Node::MAX_CHILDREN).configurable())?;
+                    exports.prop("root", rquickjs::object::Accessor::new_get(test::Node::get_root))?;
                     Ok(())
                 }
             }
 
             impl<'js> rquickjs::IntoJs<'js> for test::Node {
                 fn into_js(self, ctx: rquickjs::Ctx<'js>) -> rquickjs::Result<rquickjs::Value<'js>> {
-                    <test::Node as rquickjs::ClassDef>::into_js_obj(self, ctx)
+                    <test::Node as rquickjs::class::ClassDef>::into_js_obj(self, ctx)
                 }
             }
 
             impl<'js> rquickjs::FromJs<'js> for &'js test::Node {
                 fn from_js(ctx: rquickjs::Ctx<'js>, value: rquickjs::Value<'js>) -> rquickjs::Result<Self> {
-                    <test::Node as rquickjs::ClassDef>::from_js_ref(ctx, value)
+                    <test::Node as rquickjs::class::ClassDef>::from_js_ref(ctx, value)
                 }
             }
 
@@ -630,7 +630,7 @@ mod test {
                 }
             }
         } {
-            impl rquickjs::ClassDef for test::Node {
+            impl rquickjs::class::ClassDef for test::Node {
                 const CLASS_NAME: &'static str = "Node";
 
                 fn class_id() -> &'static rquickjs::ClassId {
@@ -641,19 +641,19 @@ mod test {
 
             impl<'js> rquickjs::IntoJs<'js> for test::Node {
                 fn into_js(self, ctx: rquickjs::Ctx<'js>) -> rquickjs::Result<rquickjs::Value<'js>> {
-                    <test::Node as rquickjs::ClassDef>::into_js_obj(self, ctx)
+                    <test::Node as rquickjs::class::ClassDef>::into_js_obj(self, ctx)
                 }
             }
 
             impl<'js> rquickjs::FromJs<'js> for &'js test::Node {
                 fn from_js(ctx: rquickjs::Ctx<'js>, value: rquickjs::Value<'js>) -> rquickjs::Result<Self> {
-                    <test::Node as rquickjs::ClassDef>::from_js_ref(ctx, value)
+                    <test::Node as rquickjs::class::ClassDef>::from_js_ref(ctx, value)
                 }
             }
 
             rquickjs::Class::<test::Node>::register(_ctx)?;
 
-            exports.set("Node", rquickjs::Func::new("Node", rquickjs::Class::<test::Node>::constructor(test::Node::new)))?;
+            exports.set("Node", rquickjs::function::Func::new("Node", rquickjs::Class::<test::Node>::constructor(test::Node::new)))?;
         };
 
         class_with_static { test } {
@@ -667,7 +667,7 @@ mod test {
                 }
             }
         } {
-            impl rquickjs::ClassDef for test::Node {
+            impl rquickjs::class::ClassDef for test::Node {
                 const CLASS_NAME: &'static str = "Node";
 
                 fn class_id() -> &'static rquickjs::ClassId {
@@ -679,26 +679,26 @@ mod test {
 
                 fn init_static<'js>(_ctx: rquickjs::Ctx<'js>, exports: &rquickjs::Object<'js>) -> rquickjs::Result<()> {
                     exports.set("TAG", test::Node::TAG)?;
-                    exports.set("mix", rquickjs::Func::new("mix", test::Node::mix))?;
+                    exports.set("mix", rquickjs::function::Func::new("mix", test::Node::mix))?;
                     Ok(())
                 }
             }
 
             impl<'js> rquickjs::IntoJs<'js> for test::Node {
                 fn into_js(self, ctx: rquickjs::Ctx<'js>) -> rquickjs::Result<rquickjs::Value<'js>> {
-                    <test::Node as rquickjs::ClassDef>::into_js_obj(self, ctx)
+                    <test::Node as rquickjs::class::ClassDef>::into_js_obj(self, ctx)
                 }
             }
 
             impl<'js> rquickjs::FromJs<'js> for &'js test::Node {
                 fn from_js(ctx: rquickjs::Ctx<'js>, value: rquickjs::Value<'js>) -> rquickjs::Result<Self> {
-                    <test::Node as rquickjs::ClassDef>::from_js_ref(ctx, value)
+                    <test::Node as rquickjs::class::ClassDef>::from_js_ref(ctx, value)
                 }
             }
 
             rquickjs::Class::<test::Node>::register(_ctx)?;
 
-            exports.set("Node", rquickjs::Func::new("Node", rquickjs::Class::<test::Node>::constructor(test::Node::new)))?;
+            exports.set("Node", rquickjs::function::Func::new("Node", rquickjs::Class::<test::Node>::constructor(test::Node::new)))?;
         };
 
         class_with_internal_refs { test } {
@@ -708,7 +708,7 @@ mod test {
                 pub struct Node;
             }
         } {
-            impl rquickjs::ClassDef for test::Node {
+            impl rquickjs::class::ClassDef for test::Node {
                 const CLASS_NAME: &'static str = "Node";
 
                 fn class_id() -> &'static rquickjs::ClassId {
@@ -718,20 +718,20 @@ mod test {
 
                 const HAS_REFS: bool = true;
 
-                fn mark_refs(&self, marker: &rquickjs::RefsMarker) {
-                    rquickjs::HasRefs::mark_refs(self, marker);
+                fn mark_refs(&self, marker: &rquickjs::class::RefsMarker) {
+                    rquickjs::class::HasRefs::mark_refs(self, marker);
                 }
             }
 
             impl<'js> rquickjs::IntoJs<'js> for test::Node {
                 fn into_js(self, ctx: rquickjs::Ctx<'js>) -> rquickjs::Result<rquickjs::Value<'js>> {
-                    <test::Node as rquickjs::ClassDef>::into_js_obj(self, ctx)
+                    <test::Node as rquickjs::class::ClassDef>::into_js_obj(self, ctx)
                 }
             }
 
             impl<'js> rquickjs::FromJs<'js> for &'js test::Node {
                 fn from_js(ctx: rquickjs::Ctx<'js>, value: rquickjs::Value<'js>) -> rquickjs::Result<Self> {
-                    <test::Node as rquickjs::ClassDef>::from_js_ref(ctx, value)
+                    <test::Node as rquickjs::class::ClassDef>::from_js_ref(ctx, value)
                 }
             }
 

--- a/macro/src/bind/constant.rs
+++ b/macro/src/bind/constant.rs
@@ -120,7 +120,7 @@ mod test {
 
             struct Math;
 
-            impl rquickjs::ObjectDef for Math {
+            impl rquickjs::object::ObjectDef for Math {
                 fn init<'js>(_ctx: rquickjs::Ctx<'js>, exports: &rquickjs::Object<'js>) -> rquickjs::Result<()>{
                     exports.set("PI" , PI)?;
                     Ok(())
@@ -136,13 +136,13 @@ mod test {
 
             struct Constants;
 
-            impl rquickjs::ModuleDef for Constants {
-                fn declare(declares: &mut rquickjs::Declarations) -> rquickjs::Result<()>{
+            impl rquickjs::module::ModuleDef for Constants {
+                fn declare(declares: &mut rquickjs::module::Declarations) -> rquickjs::Result<()>{
                     declares.declare("pi")?;
                     Ok(())
                 }
 
-                fn evaluate<'js>(_ctx: rquickjs::Ctx<'js>, exports: &mut rquickjs::Exports<'js>) -> rquickjs::Result<()>{
+                fn evaluate<'js>(_ctx: rquickjs::Ctx<'js>, exports: &mut rquickjs::module::Exports<'js>) -> rquickjs::Result<()>{
                     exports.export("pi", PI)?;
                     Ok(())
                 }

--- a/macro/src/bind/function.rs
+++ b/macro/src/bind/function.rs
@@ -58,9 +58,9 @@ impl BindFn {
             bindings
         };
         if is_module {
-            quote! { #exports_var.export(#name, #lib_crate::Func::new(#func_name, #bindings))?; }
+            quote! { #exports_var.export(#name, #lib_crate::function::Func::new(#func_name, #bindings))?; }
         } else {
-            quote! { #exports_var.set(#name, #lib_crate::Func::new(#func_name, #bindings))?; }
+            quote! { #exports_var.set(#name, #lib_crate::function::Func::new(#func_name, #bindings))?; }
         }
     }
 }
@@ -93,12 +93,12 @@ impl BindFn1 {
 
         let path = &self.src;
         let bind = if self.method {
-            quote! { #lib_crate::Method(#path) }
+            quote! { #lib_crate::function::Method(#path) }
         } else {
             quote! { #path }
         };
         let bind = if self.async_ {
-            quote! { #lib_crate::Async(#bind) }
+            quote! { #lib_crate::function::Async(#bind) }
         } else {
             bind
         };
@@ -237,7 +237,7 @@ mod test {
         no_args_no_return { test } {
             fn doit() {}
         } {
-            exports.set("doit", rquickjs::Func::new("doit", doit))?;
+            exports.set("doit", rquickjs::function::Func::new("doit", doit))?;
         };
 
         overloaded_function { test } {
@@ -251,7 +251,7 @@ mod test {
                 pub fn sum(a: i32, b: i32) -> i32 { a + b }
             }
         } {
-            exports.set("calc", rquickjs::Func::new("calc", (calc::one, calc::inc, calc::sum)))?;
+            exports.set("calc", rquickjs::function::Func::new("calc", (calc::one, calc::inc, calc::sum)))?;
         };
 
         sync_function_object_export { object } {
@@ -265,9 +265,9 @@ mod test {
 
             struct Add2;
 
-            impl rquickjs::ObjectDef for Add2 {
+            impl rquickjs::object::ObjectDef for Add2 {
                 fn init<'js>(_ctx: rquickjs::Ctx<'js>, exports: &rquickjs::Object<'js>) -> rquickjs::Result<()> {
-                    exports.set("add2", rquickjs::Func::new("add2", add2))?;
+                    exports.set("add2", rquickjs::function::Func::new("add2", add2))?;
                     Ok(())
                 }
             }
@@ -280,9 +280,9 @@ mod test {
 
             struct Fetch;
 
-            impl rquickjs::ObjectDef for Fetch {
+            impl rquickjs::object::ObjectDef for Fetch {
                 fn init<'js>(_ctx: rquickjs::Ctx<'js>, exports: &rquickjs::Object<'js>) -> rquickjs::Result<()> {
-                    exports.set("fetch", rquickjs::Func::new("fetch", rquickjs::Async(fetch)))?;
+                    exports.set("fetch", rquickjs::function::Func::new("fetch", rquickjs::function::Async(fetch)))?;
                     Ok(())
                 }
             }

--- a/macro/src/bind/module.rs
+++ b/macro/src/bind/module.rs
@@ -112,17 +112,17 @@ mod test {
 
             struct Lib;
 
-            impl rquickjs::ModuleDef for Lib {
-                fn declare(declares: &mut rquickjs::Declarations) -> rquickjs::Result<()>{
+            impl rquickjs::module::ModuleDef for Lib {
+                fn declare(declares: &mut rquickjs::module::Declarations) -> rquickjs::Result<()>{
                     declares.declare("lib")?;
                     Ok(())
                 }
 
-                fn evaluate<'js>(_ctx: rquickjs::Ctx<'js>, exports: &mut rquickjs::Exports<'js>) -> rquickjs::Result<()>{
+                fn evaluate<'js>(_ctx: rquickjs::Ctx<'js>, exports: &mut rquickjs::module::Exports<'js>) -> rquickjs::Result<()>{
                     exports.export("lib", {
                         let exports = rquickjs::Object::new(_ctx)?;
                         exports.set("N", lib::N)?;
-                        exports.set("doit", rquickjs::Func::new("doit", lib::doit))?;
+                        exports.set("doit", rquickjs::function::Func::new("doit", lib::doit))?;
                         exports
                     })?;
                     Ok(())
@@ -143,12 +143,12 @@ mod test {
 
             pub(crate) struct Lib;
 
-            impl rquickjs::ObjectDef for Lib {
+            impl rquickjs::object::ObjectDef for Lib {
                 fn init<'js>(_ctx: rquickjs::Ctx<'js>, exports: &rquickjs::Object<'js>) -> rquickjs::Result<()>{
                     exports.set("lib", {
                         let exports = rquickjs::Object::new(_ctx)?;
                         exports.set("N", lib::N)?;
-                        exports.set("doit", rquickjs::Func::new("doit", lib::doit))?;
+                        exports.set("doit", rquickjs::function::Func::new("doit", lib::doit))?;
                         exports
                     })?;
                     Ok(())
@@ -170,10 +170,10 @@ mod test {
 
             pub struct Lib;
 
-            impl rquickjs::ObjectDef for Lib {
+            impl rquickjs::object::ObjectDef for Lib {
                 fn init<'js>(_ctx: rquickjs::Ctx<'js>, exports: &rquickjs::Object<'js>) -> rquickjs::Result<()>{
                     exports.set("N", lib::N)?;
-                    exports.set("doit", rquickjs::Func::new("doit", lib::doit))?;
+                    exports.set("doit", rquickjs::function::Func::new("doit", lib::doit))?;
                     Ok(())
                 }
             }
@@ -193,16 +193,16 @@ mod test {
 
             struct Lib;
 
-            impl rquickjs::ModuleDef for Lib {
-                fn declare(declares: &mut rquickjs::Declarations) -> rquickjs::Result<()>{
+            impl rquickjs::module::ModuleDef for Lib {
+                fn declare(declares: &mut rquickjs::module::Declarations) -> rquickjs::Result<()>{
                     declares.declare("N")?;
                     declares.declare("doit")?;
                     Ok(())
                 }
 
-                fn evaluate<'js>(_ctx: rquickjs::Ctx<'js>, exports: &mut rquickjs::Exports<'js>) -> rquickjs::Result<()>{
+                fn evaluate<'js>(_ctx: rquickjs::Ctx<'js>, exports: &mut rquickjs::module::Exports<'js>) -> rquickjs::Result<()>{
                     exports.export("N", lib::N)?;
-                    exports.export("doit", rquickjs::Func::new("doit", lib::doit))?;
+                    exports.export("doit", rquickjs::function::Func::new("doit", lib::doit))?;
                     Ok(())
                 }
             }
@@ -222,16 +222,16 @@ mod test {
 
             struct Lib;
 
-            impl rquickjs::ModuleDef for Lib {
-                fn declare(declares: &mut rquickjs::Declarations) -> rquickjs::Result<()>{
+            impl rquickjs::module::ModuleDef for Lib {
+                fn declare(declares: &mut rquickjs::module::Declarations) -> rquickjs::Result<()>{
                     declares.declare("N")?;
                     declares.declare("doit")?;
                     Ok(())
                 }
 
-                fn evaluate<'js>(_ctx: rquickjs::Ctx<'js>, exports: &mut rquickjs::Exports<'js>) -> rquickjs::Result<()>{
+                fn evaluate<'js>(_ctx: rquickjs::Ctx<'js>, exports: &mut rquickjs::module::Exports<'js>) -> rquickjs::Result<()>{
                     exports.export("N", lib::N)?;
-                    exports.export("doit", rquickjs::Func::new("doit", lib::doit))?;
+                    exports.export("doit", rquickjs::function::Func::new("doit", lib::doit))?;
                     Ok(())
                 }
             }

--- a/macro/src/bind/property.rs
+++ b/macro/src/bind/property.rs
@@ -95,19 +95,19 @@ impl BindProp {
             (Some(get), Some(set), _) => {
                 let get = get.expand_pure(cfg);
                 let set = set.expand_pure(cfg);
-                quote! { #lib_crate::Accessor::new(#get, #set) }
+                quote! { #lib_crate::object::Accessor::new(#get, #set) }
             }
             (Some(get), _, _) => {
                 let get = get.expand_pure(cfg);
-                quote! { #lib_crate::Accessor::new_get(#get) }
+                quote! { #lib_crate::object::Accessor::new_get(#get) }
             }
             (_, Some(set), _) => {
                 let set = set.expand_pure(cfg);
-                quote! { #lib_crate::Accessor::new_set(#set) }
+                quote! { #lib_crate::object::Accessor::new_set(#set) }
             }
             (_, _, Some(val)) => {
                 let val = val.expand_pure(cfg);
-                quote! { #lib_crate::Property::from(#val) }
+                quote! { #lib_crate::object::Property::from(#val) }
             }
             _ => {
                 error!("Misconfigured property '{}'", name);

--- a/macro/src/derive/has_refs.rs
+++ b/macro/src/derive/has_refs.rs
@@ -18,7 +18,8 @@ impl HasRefs {
         let ident = &input.ident;
         let impl_params = input.impl_params(false);
         let type_name = input.type_name();
-        let where_clause = input.where_clause(Some(parse_quote!(T: #lib_crate::HasRefs)), None);
+        let where_clause =
+            input.where_clause(Some(parse_quote!(T: #lib_crate::class::HasRefs)), None);
 
         use Data::*;
         let body = match &input.data {
@@ -42,8 +43,8 @@ impl HasRefs {
         };
 
         quote! {
-            impl #impl_params #lib_crate::HasRefs for #type_name #where_clause {
-                fn mark_refs(&self, _marker: &#lib_crate::RefsMarker) {
+            impl #impl_params #lib_crate::class::HasRefs for #type_name #where_clause {
+                fn mark_refs(&self, _marker: &#lib_crate::class::RefsMarker) {
                     #body
                 }
             }
@@ -88,13 +89,13 @@ impl HasRefs {
                     };
                     quote! {
                         #ident::#variant { #(#field_idents,)* #rest } => {
-                            #(#lib_crate::HasRefs::mark_refs(#field_idents, _marker);)*
+                            #(#lib_crate::class::HasRefs::mark_refs(#field_idents, _marker);)*
                         }
                     }
                 } else {
                     // struct
                     quote! {
-                        #(#lib_crate::HasRefs::mark_refs(&self.#field_idents, _marker);)*
+                        #(#lib_crate::class::HasRefs::mark_refs(&self.#field_idents, _marker);)*
                     }
                 }
             }
@@ -118,7 +119,7 @@ impl HasRefs {
 
                     quote! {
                         #ident::#variant(#(#field_patterns),*) => {
-                            #(#lib_crate::HasRefs::mark_refs(#field_aliases, _marker);)*
+                            #(#lib_crate::class::HasRefs::mark_refs(#field_aliases, _marker);)*
                         }
                     }
                 } else {
@@ -131,7 +132,7 @@ impl HasRefs {
                         .map(|(index, _)| Index::from(index));
 
                     quote! {
-                        #(#lib_crate::HasRefs::mark_refs(&self.#field_indexes, _marker);)*
+                        #(#lib_crate::class::HasRefs::mark_refs(&self.#field_indexes, _marker);)*
                     }
                 }
             }
@@ -152,10 +153,10 @@ mod test {
                 text: String,
             }
         } {
-            impl rquickjs::HasRefs for Data {
-                fn mark_refs(&self, _marker: &rquickjs::RefsMarker) {
-                    rquickjs::HasRefs::mark_refs(&self.lists, _marker);
-                    rquickjs::HasRefs::mark_refs(&self.func, _marker);
+            impl rquickjs::class::HasRefs for Data {
+                fn mark_refs(&self, _marker: &rquickjs::class::RefsMarker) {
+                    rquickjs::class::HasRefs::mark_refs(&self.lists, _marker);
+                    rquickjs::class::HasRefs::mark_refs(&self.func, _marker);
                 }
             }
         };
@@ -175,14 +176,14 @@ mod test {
                 Text(String),
             }
         } {
-            impl rquickjs::HasRefs for Data {
-                fn mark_refs(&self, _marker: &rquickjs::RefsMarker) {
+            impl rquickjs::class::HasRefs for Data {
+                fn mark_refs(&self, _marker: &rquickjs::class::RefsMarker) {
                     match self {
                         Data::Lists(_0) => {
-                            rquickjs::HasRefs::mark_refs(_0, _marker);
+                            rquickjs::class::HasRefs::mark_refs(_0, _marker);
                         }
                         Data::Func { func, .. } => {
-                            rquickjs::HasRefs::mark_refs(func, _marker);
+                            rquickjs::class::HasRefs::mark_refs(func, _marker);
                         }
                         Data::Flag(_) => { }
                         Data::Text(_) => { }

--- a/macro/src/lib.rs
+++ b/macro/src/lib.rs
@@ -78,8 +78,8 @@ Attribute                         | Description
 --------------------------------- | ---------------------------
 __`ident = "MyModule"`__          | The name of target unit struct to export
 __`public`__, __`public = "self/super/crate"`__ | Makes the target unit struct visible
-__`module`__                      | Adds the [`ModuleDef`](rquickjs_core::ModuleDef) impl to use bindings as ES6 module
-__`object`__                      | Adds the [`ObjectDef`](rquickjs_core::ObjectDef) impl for attaching bindings to an object
+__`module`__                      | Adds the [`ModuleDef`](rquickjs_core::module::ModuleDef) impl to use bindings as ES6 module
+__`object`__                      | Adds the [`ObjectDef`](rquickjs_core::object::ObjectDef) impl for attaching bindings to an object
 __`init`__, __`init = "js_module_init"`__     | Adds the `js_module_init` function (in particular for creating dynamically loadable modules or static libraries to use from `C`)
 __`crate = "rquickjs"`__          | Allows rename `rquickjs` crate
 
@@ -135,7 +135,7 @@ __`skip`__                | Skips exporting this data type
 __`hide`__                | Do not output this data type (bindings only)
 
 The following traits will be implemented for data type:
-- [`ClassDef`](rquickjs_core::ClassDef)
+- [`ClassDef`](rquickjs_core::class::ClassDef)
 - [`IntoJs`](rquickjs_core::IntoJs)
 - [`FromJs`](rquickjs_core::FromJs) if `cloneable` attribute is present
 
@@ -300,7 +300,7 @@ ctx.with(|ctx| {
 ```
 # #[async_std::main]
 # async fn main() {
-use rquickjs::{Runtime, Context, Promise, bind, AsyncStd};
+use rquickjs::{Runtime, Context, promise::Promise, bind, runtime::AsyncStd};
 
 #[bind(object)]
 pub async fn sleep(msecs: u64) {
@@ -523,7 +523,7 @@ pub fn embed(item: TokenStream1) -> TokenStream1 {
 }
 
 /**
-A macro to derive [`HasRefs`](rquickjs_core::HasRefs)
+A macro to derive [`HasRefs`](rquickjs_core::module::HasRefs)
 
 # Supported attributes
 


### PR DESCRIPTION
Rquickjs currently exports almost all types in the crate root, this makes it harder to read the documentation and find what types are relevant.

This PR restructures import by putting some types behind modules and creating a `prelude` module which exports all commonly used types.