### PR TITLE
Remove `Class::from_js_ref`

### DIFF
--- a/core/src/class.rs
+++ b/core/src/class.rs
@@ -1,13 +1,15 @@
 //! JS Class related functionality.
-
-mod refs;
+use std::{ffi::CString, marker::PhantomData, mem, ops::Deref, ptr};
 
 use crate::{
     persistent::Outlive, qjs, value::Object, ClassId, Ctx, Error, FromJs, Function, IntoJs, Result,
     Type, Value,
 };
-use std::{ffi::CString, marker::PhantomData, mem, ops::Deref, ptr};
 
+mod borrow;
+pub use borrow::Ref;
+
+mod refs;
 pub use refs::{HasRefs, RefsMarker};
 
 /// The ES6 class definition trait
@@ -57,15 +59,10 @@ pub use refs::{HasRefs, RefsMarker};
 ///     }
 /// }
 ///
-/// impl<'js> FromJs<'js> for &'js MyClass {
-///     fn from_js(ctx: Ctx<'js>, value: Value<'js>) -> Result<Self> {
-///         MyClass::from_js_ref(ctx, value)
-///     }
-/// }
-///
+/// // Can be implemented cause MyClass implementes Clone
 /// impl<'js> FromJs<'js> for MyClass {
 ///     fn from_js(ctx: Ctx<'js>, value: Value<'js>) -> Result<Self> {
-///         MyClass::from_js_obj(ctx, value)
+///         MyClass::from_js_obj(value)
 ///     }
 /// }
 /// ```
@@ -116,25 +113,13 @@ pub trait ClassDef {
         Class::<Self>::instance(ctx, self).map(|Class(Object(val), _)| val)
     }
 
-    /// Get reference from JS object
-    ///
-    /// This method helps implement [`FromJs`] trait for classes
-    fn from_js_ref<'js>(ctx: Ctx<'js>, value: Value<'js>) -> Result<&'js Self>
-    where
-        Self: Sized,
-    {
-        let value = Object::from_js(ctx, value)?;
-        Class::<Self>::try_ref(ctx, &value)
-    }
-
     /// Get an instance of class from JS object
-    fn from_js_obj<'js>(ctx: Ctx<'js>, value: Value<'js>) -> Result<Self>
+    fn from_js_obj<'js>(value: Value<'js>) -> Result<Self>
     where
         Self: Clone + Sized,
     {
-        let value = Object::from_js(ctx, value)?;
-        let instance = Class::<Self>::try_ref(ctx, &value)?;
-        Ok(instance.clone())
+        let value = Ref::<Self>::from_js(value.ctx(), value)?;
+        Ok((*value).clone())
     }
 }
 
@@ -143,6 +128,12 @@ pub trait ClassDef {
 // FIXME: Maybe it should be private.
 #[cfg_attr(feature = "doc-cfg", doc(cfg(feature = "classes")))]
 pub struct Class<'js, C>(pub(crate) Object<'js>, PhantomData<C>);
+
+impl<'js, C> Clone for Class<'js, C> {
+    fn clone(&self) -> Self {
+        Class(self.0.clone(), PhantomData)
+    }
+}
 
 impl<'js, 't, C> Outlive<'t> for Class<'js, C> {
     type Target = Class<'t, C>;
@@ -168,16 +159,6 @@ impl<'js, C> AsRef<Value<'js>> for Class<'js, C> {
     }
 }
 
-impl<'js, C> AsRef<C> for Class<'js, C>
-where
-    C: ClassDef,
-{
-    fn as_ref(&self) -> &C {
-        let obj = &self.0;
-        Class::<C>::try_ref(obj.0.ctx, obj).unwrap()
-    }
-}
-
 impl<'js, C> Class<'js, C>
 where
     C: ClassDef,
@@ -195,9 +176,9 @@ where
     }
 
     /// Initialize static data
-    pub fn static_init(ctx: Ctx<'js>, func: &Function<'js>) -> Result<()> {
+    pub fn static_init(func: &Function<'js>) -> Result<()> {
         if C::HAS_STATIC {
-            C::init_static(ctx, func.as_object())?;
+            C::init_static(func.ctx(), func.as_object())?;
         }
         Ok(())
     }
@@ -215,10 +196,10 @@ where
     }
 
     /// Instantiate the object of class with given prototype
-    pub fn instance_proto(ctx: Ctx<'js>, value: C, proto: Object<'js>) -> Result<Class<'js, C>> {
+    pub fn instance_proto(value: C, proto: Object<'js>) -> Result<Class<'js, C>> {
         let val = unsafe {
-            ctx.handle_exception(qjs::JS_NewObjectProtoClass(
-                ctx.as_ptr(),
+            proto.ctx().handle_exception(qjs::JS_NewObjectProtoClass(
+                proto.ctx().as_ptr(),
                 proto.0.as_js_value(),
                 Self::id(),
             ))
@@ -226,27 +207,17 @@ where
         let ptr = Box::into_raw(Box::new(value));
         unsafe { qjs::JS_SetOpaque(val, ptr as _) };
         Ok(Self(
-            unsafe { Object::from_js_value(ctx, val) },
+            unsafe { Object::from_js_value(proto.ctx(), val) },
             PhantomData,
         ))
     }
 
-    /// Get reference from object
-    pub fn try_ref<'r>(ctx: Ctx<'js>, value: &Object<'js>) -> Result<&'r C> {
-        Ok(unsafe { &*Self::try_ptr(ctx.as_ptr(), value.0.as_js_value())? })
-    }
-
-    /// Get instance pointer from object
-    unsafe fn try_ptr(ctx: *mut qjs::JSContext, value: qjs::JSValue) -> Result<*mut C> {
-        let ptr = qjs::JS_GetOpaque2(ctx, value, Self::id()) as *mut C;
+    pub(crate) unsafe fn class_ptr(&self) -> *mut C {
+        let ptr = qjs::JS_GetOpaque2(self.ctx.as_ptr(), self.value, Self::id()).cast::<C>();
         if ptr.is_null() {
-            return Err(Error::FromJs {
-                from: "object",
-                to: C::CLASS_NAME,
-                message: None,
-            });
+            panic!("invalid class object, class objects with ClassDef C should always point to objects of class C");
         }
-        Ok(ptr)
+        ptr
     }
 
     /// Register the class
@@ -317,11 +288,8 @@ where
         }
     }
 
-    /// Get reference to class definition
-    #[inline]
-    pub fn as_class_def(&self) -> &C {
-        // This should always succeed
-        Self::try_ref(self.ctx, &self.0).unwrap()
+    pub fn borrow(&self) -> Ref<'js, C> {
+        Ref::new(self.clone())
     }
 
     /// Get reference to object
@@ -432,15 +400,15 @@ impl<'js, C> IntoJs<'js> for WithProto<'js, C>
 where
     C: ClassDef + IntoJs<'js>,
 {
-    fn into_js(self, ctx: Ctx<'js>) -> Result<Value<'js>> {
-        Class::<C>::instance_proto(ctx, self.0, self.1).map(|Class(Object(val), _)| val)
+    fn into_js(self, _ctx: Ctx<'js>) -> Result<Value<'js>> {
+        Class::<C>::instance_proto(self.0, self.1).map(|Class(Object(val), _)| val)
     }
 }
 
 /// The macro to simplify class definition.
 ///
 /// ```
-/// # use rquickjs::{class_def, function::{Method, Func}};
+/// # use rquickjs::{class_def, function::{Method, Func, SelfMethod}};
 /// #
 /// struct TestClass;
 ///
@@ -453,7 +421,7 @@ where
 ///     TestClass
 ///     // optional prototype initializer
 ///     (proto) {
-///         proto.set("method", Func::from(Method(TestClass::method)))?;
+///         proto.set("method", Func::from(SelfMethod::<TestClass,_>::from(TestClass::method)))?;
 ///     }
 ///     // optional static initializer
 ///     @(ctor) {
@@ -546,18 +514,12 @@ macro_rules! class_def {
                 <$name as $crate::class::ClassDef>::into_js_obj(self, ctx)
             }
         }
-
-        impl<'js> $crate::FromJs<'js> for &'js $name {
-            fn from_js(ctx: $crate::Ctx<'js>, value: $crate::Value<'js>) -> $crate::Result<Self> {
-                <$name as $crate::class::ClassDef>::from_js_ref(ctx, value)
-            }
-        }
     };
 }
 
 #[cfg(test)]
 mod test {
-    use crate::*;
+    use crate::{function::SelfMethod, *};
     use approx::assert_abs_diff_eq as assert_approx_eq;
     use function::{Func, Method};
 
@@ -578,20 +540,20 @@ mod test {
             global.set("foo", Foo("I'm foo".into())).unwrap();
             global.set("bar", Bar(14)).unwrap();
 
-            let foo: &Foo = global.get("foo").unwrap();
+            let foo: class::Ref<Foo> = global.get("foo").unwrap();
             assert_eq!(foo.0, "I'm foo");
 
-            let bar: &Bar = global.get("bar").unwrap();
+            let bar: class::Ref<Bar> = global.get("bar").unwrap();
             assert_eq!(bar.0, 14);
 
-            if let Err(Error::FromJs { from, to, .. }) = global.get::<_, &Bar>("foo") {
+            if let Err(Error::FromJs { from, to, .. }) = global.get::<_, class::Ref<Bar>>("foo") {
                 assert_eq!(from, "object");
                 assert_eq!(to, "Bar");
             } else {
                 panic!("An error was expected");
             }
 
-            if let Err(Error::FromJs { from, to, .. }) = global.get::<_, &Foo>("bar") {
+            if let Err(Error::FromJs { from, to, .. }) = global.get::<_, class::Ref<Foo>>("bar") {
                 assert_eq!(from, "object");
                 assert_eq!(to, "Foo");
             } else {
@@ -633,8 +595,8 @@ mod test {
 
         class_def! {
             Point (proto) {
-                proto.set("get_x", Func::from(Method(Point::get_x)))?;
-                proto.set("get_y", Func::from(Method(|Point { y, .. }: &Point| *y)))?;
+                proto.set("get_x", Func::from(SelfMethod::<Point,_>::from(Point::get_x)))?;
+                proto.set("get_y", Func::from(SelfMethod::<Point,_>::from(|Point { y, .. }: &Point| *y)))?;
             } @(ctor) {
                 ctor.set("zero", Func::from(Point::zero))?;
             }
@@ -773,11 +735,11 @@ mod test {
 
         impl<'js> Class<'js, A> {
             pub fn add(self, val: Persistent<Class<'static, A>>) {
-                self.as_class_def().refs.borrow_mut().insert(val);
+                self.borrow().refs.borrow_mut().insert(val);
             }
 
             pub fn rm(self, val: Persistent<Class<'static, A>>) {
-                self.as_class_def().refs.borrow_mut().remove(&val);
+                self.borrow().refs.borrow_mut().remove(&val);
             }
         }
 

--- a/core/src/class/borrow.rs
+++ b/core/src/class/borrow.rs
@@ -10,12 +10,6 @@ impl<'js, C: ClassDef + fmt::Debug> fmt::Debug for Ref<'js, C> {
     }
 }
 
-impl<'js, C> Clone for Ref<'js, C> {
-    fn clone(&self) -> Self {
-        Ref(self.0.clone())
-    }
-}
-
 impl<'js, C: ClassDef> Deref for Ref<'js, C> {
     type Target = C;
 

--- a/core/src/class/borrow.rs
+++ b/core/src/class/borrow.rs
@@ -1,0 +1,54 @@
+use std::{fmt, ops::Deref};
+
+use crate::{class::ClassDef, Class, Ctx, FromJs, IntoJs, Result, Value};
+
+pub struct Ref<'js, C>(Class<'js, C>);
+
+impl<'js, C: ClassDef + fmt::Debug> fmt::Debug for Ref<'js, C> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_tuple("Ref").field(self.deref()).finish()
+    }
+}
+
+impl<'js, C> Clone for Ref<'js, C> {
+    fn clone(&self) -> Self {
+        Ref(self.0.clone())
+    }
+}
+
+impl<'js, C: ClassDef> Deref for Ref<'js, C> {
+    type Target = C;
+
+    fn deref(&self) -> &Self::Target {
+        self.get_ref()
+    }
+}
+
+impl<'js, C: ClassDef> Ref<'js, C> {
+    pub fn new(class: Class<'js, C>) -> Self {
+        Ref(class)
+    }
+
+    pub fn into_inner(self) -> Class<'js, C> {
+        self.0
+    }
+
+    fn get_ref(&self) -> &C {
+        unsafe {
+            let ptr = self.0.class_ptr();
+            &*ptr
+        }
+    }
+}
+
+impl<'js, C: ClassDef> FromJs<'js> for Ref<'js, C> {
+    fn from_js(ctx: Ctx<'js>, value: Value<'js>) -> Result<Self> {
+        Ok(Ref(Class::<C>::from_js(ctx, value)?))
+    }
+}
+
+impl<'js, C: ClassDef> IntoJs<'js> for Ref<'js, C> {
+    fn into_js(self, ctx: Ctx<'js>) -> Result<Value<'js>> {
+        self.0.into_js(ctx)
+    }
+}

--- a/core/src/value.rs
+++ b/core/src/value.rs
@@ -160,6 +160,12 @@ impl<'js> Value<'js> {
         Self { ctx, value }
     }
 
+    /// Returns the Ctx object associated with this value.
+    #[inline]
+    pub fn ctx(&self) -> Ctx<'js> {
+        self.ctx
+    }
+
     // unsafe because no type checking
     #[inline]
     pub(crate) unsafe fn get_bool(&self) -> bool {

--- a/core/src/value/function.rs
+++ b/core/src/value/function.rs
@@ -8,7 +8,7 @@ mod as_func;
 mod ffi;
 mod types;
 
-pub use args::{FromInput, Input};
+pub use args::{FromInput, Input, InputAccessor};
 pub use as_args::{AsArguments, CallInput, IntoInput};
 pub use as_func::AsFunction;
 use ffi::JsFunction;

--- a/core/src/value/function.rs
+++ b/core/src/value/function.rs
@@ -8,7 +8,7 @@ mod as_func;
 mod ffi;
 mod types;
 
-use args::{FromInput, Input};
+pub use args::{FromInput, Input};
 pub use as_args::{AsArguments, CallInput, IntoInput};
 pub use as_func::AsFunction;
 use ffi::JsFunction;

--- a/core/src/value/function.rs
+++ b/core/src/value/function.rs
@@ -12,7 +12,7 @@ use args::{FromInput, Input};
 pub use as_args::{AsArguments, CallInput, IntoInput};
 pub use as_func::AsFunction;
 use ffi::JsFunction;
-pub use types::{Func, Method, MutFn, OnceFn, Opt, Rest, This};
+pub use types::{Func, Method, MutFn, OnceFn, Opt, Rest, SelfMethod, This};
 
 #[cfg(feature = "futures")]
 #[cfg_attr(feature = "doc-cfg", doc(cfg(feature = "futures")))]

--- a/core/src/value/function/args.rs
+++ b/core/src/value/function/args.rs
@@ -75,6 +75,12 @@ impl<'i, 'js> InputAccessor<'i, 'js> {
         self.input.args.len() - self.arg
     }
 
+    /// Get whether there are no more arguments
+    #[inline]
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
     /// Get next argument
     #[inline]
     pub fn arg<T>(&mut self) -> Result<T>
@@ -164,7 +170,7 @@ where
     }
 
     fn from_input<'i>(accessor: &mut InputAccessor<'i, 'js>) -> Result<Self> {
-        if accessor.len() > 0 {
+        if !accessor.is_empty() {
             accessor.arg().map(Self)
         } else {
             Ok(Self(None))

--- a/core/src/value/function/args.rs
+++ b/core/src/value/function/args.rs
@@ -4,6 +4,7 @@ use crate::{
 };
 use std::{ops::Range, slice};
 
+/// The input to rust callback functions containing its arguments.
 pub struct Input<'js> {
     ctx: Ctx<'js>,
     this: qjs::JSValue,
@@ -12,7 +13,7 @@ pub struct Input<'js> {
 
 impl<'js> Input<'js> {
     #[inline]
-    pub unsafe fn new_raw(
+    pub(crate) unsafe fn new_raw(
         ctx: *mut qjs::JSContext,
         this: qjs::JSValue,
         argc: qjs::c_int,
@@ -23,6 +24,7 @@ impl<'js> Input<'js> {
         Self { ctx, this, args }
     }
 
+    /// Returns the input accessor for actually acquiring arguments
     #[inline]
     pub fn access(&self) -> InputAccessor<'_, 'js> {
         InputAccessor {
@@ -31,12 +33,20 @@ impl<'js> Input<'js> {
         }
     }
 
+    /// Returns the number of arguments
     #[inline]
     pub fn len(&self) -> usize {
         self.args.len()
     }
+
+    /// Returns whether there are no arguments
+    #[inline]
+    pub fn is_empty(&self) -> bool {
+        self.args.is_empty()
+    }
 }
 
+/// struct for accessing function arguments
 pub struct InputAccessor<'i, 'js> {
     input: &'i Input<'js>,
     arg: usize,

--- a/core/src/value/function/as_func.rs
+++ b/core/src/value/function/as_func.rs
@@ -1,6 +1,7 @@
 use super::{FromInput, Input};
 use crate::{
-    function::{Method, MutFn, OnceFn, This},
+    class,
+    function::{Method, MutFn, OnceFn, SelfMethod, This},
     Ctx, Error, FromJs, Function, IntoJs, Result, Value,
 };
 use std::ops::Range;
@@ -226,22 +227,21 @@ macro_rules! as_function_impls {
                 fn call(&self, input: &Input<'js>) -> Result<Value<'js>> {
                     input.check_num_args::<Self, _, _>()?;
                     let mut accessor = input.access();
+                    let this = This::<T>::from_input(&mut accessor)?.0;
                     self(
-                        This::<T>::from_input(&mut accessor)?.0,
+                        this,
                         $($arg::from_input(&mut accessor)?,)*
                     ).into_js(accessor.ctx())
                 }
             }
 
-            // for async methods via Method wrapper
-            #[cfg(feature = "futures")]
+            // for methods via Method wrapper
             $(#[$meta])*
-            impl<'js, F, Fut,R, T $(, $arg)*> AsFunction<'js, (T, $($arg),*), Promised<R>> for Async<Method<F>>
+            impl<'js, F, R, T $(, $arg)*> AsFunction<'js, (T, $($arg),*), R> for SelfMethod<T,F>
             where
-                F: Fn(T, $($arg),*) -> Fut + 'js,
-                Fut: Future<Output = Result<R>> + 'js,
-                R: IntoJs<'js> + 'js,
-                T: FromJs<'js>,
+                F: Fn(&T, $($arg),*) -> R + 'js,
+                R: IntoJs<'js>,
+                T: ClassDef,
                 $($arg: FromInput<'js>,)*
             {
                 #[allow(non_snake_case)]
@@ -254,12 +254,111 @@ macro_rules! as_function_impls {
                 fn call(&self, input: &Input<'js>) -> Result<Value<'js>> {
                     input.check_num_args::<Self, _, _>()?;
                     let mut accessor = input.access();
-                    Promised(self(
-                        This::<T>::from_input(&mut accessor)?.0,
+                    let this = This::<class::Ref<T>>::from_input(&mut accessor)?.0;
+                    self(
+                        &*this,
                         $($arg::from_input(&mut accessor)?,)*
-                    )).into_js(accessor.ctx())
+                    ).into_js(accessor.ctx())
                 }
             }
+
+            // for async methods via Method wrapper
+            #[cfg(feature = "futures")]
+            #[allow(non_snake_case)]
+            $(#[$meta])*
+            impl<'js,F,Fut,R, T $(, $arg)*> AsFunction<'js, (T, $($arg),*), Promised<R>> for Async<Method<F>>
+            where
+                F: Fn(T,$($arg),*) -> Fut + 'js,
+                Fut: Future<Output = Result<R>> + 'js,
+                R: IntoJs<'js> + 'js,
+                T: FromJs<'js> + 'js,
+                $($arg: FromInput<'js> + 'js,)*
+            {
+                fn num_args() -> Range<usize> {
+                    $(let $arg = $arg::num_args();)*
+                    0usize $(+ $arg.start)* .. 0usize $(.saturating_add($arg.end))*
+                }
+
+                #[allow(unused_mut)]
+                fn call(&self, input: &Input<'js>) -> Result<Value<'js>> {
+                    input.check_num_args::<Self, _, _>()?;
+                    let mut accessor = input.access();
+                    let this = This::<T>::from_input(&mut accessor)?;
+                    $(let $arg = $arg::from_input(&mut accessor)?;)*
+                    let future = self(
+                        this.0,
+                        $($arg,)*
+                    );
+                    Promised(future).into_js(accessor.ctx())
+                }
+            }
+
+            // for async methods via Method wrapper
+            #[cfg(feature = "futures")]
+            #[allow(non_snake_case)]
+            $(#[$meta])*
+            impl<'js,Fut,R, T $(, $arg)*> AsFunction<'js, (&T, $($arg),*), Promised<R>> for Async<SelfMethod<T,fn(&T$(,$arg)*) -> Fut>>
+            where
+                Fut: Future<Output = Result<R>> + 'js,
+                R: IntoJs<'js> + 'js,
+                T: ClassDef + 'js,
+                $($arg: FromInput<'js> + 'js,)*
+            {
+                fn num_args() -> Range<usize> {
+                    $(let $arg = $arg::num_args();)*
+                    0usize $(+ $arg.start)* .. 0usize $(.saturating_add($arg.end))*
+                }
+
+                #[allow(unused_mut)]
+                fn call(&self, input: &Input<'js>) -> Result<Value<'js>> {
+                    input.check_num_args::<Self, _, _>()?;
+                    let mut accessor = input.access();
+                    let this = This::<class::Ref<T>>::from_input(&mut accessor)?;
+                    $(let $arg = $arg::from_input(&mut accessor)?;)*
+                    let f = self.0.0;
+                    let future = async move {
+                        f(
+                            &*this,
+                            $($arg,)*
+                        ).await
+                    };
+                    Promised(future).into_js(accessor.ctx())
+                }
+            }
+
+            // for async methods via Method wrapper
+            #[cfg(feature = "futures")]
+            #[allow(non_snake_case)]
+            $(#[$meta])*
+            impl<'js,Fut,R, T $(, $arg)*> AsFunction<'js, (&T, $($arg),*), Promised<R>> for Async<SelfMethod<T,fn(T$(,$arg)*) -> Fut>>
+            where
+                Fut: Future<Output = Result<R>> + 'js,
+                R: IntoJs<'js> + 'js,
+                T: ClassDef + Clone + 'js,
+                $($arg: FromInput<'js> + 'js,)*
+            {
+                fn num_args() -> Range<usize> {
+                    $(let $arg = $arg::num_args();)*
+                    0usize $(+ $arg.start)* .. 0usize $(.saturating_add($arg.end))*
+                }
+
+                #[allow(unused_mut)]
+                fn call(&self, input: &Input<'js>) -> Result<Value<'js>> {
+                    input.check_num_args::<Self, _, _>()?;
+                    let mut accessor = input.access();
+                    let this = This::<class::Ref<T>>::from_input(&mut accessor)?;
+                    $(let $arg = $arg::from_input(&mut accessor)?;)*
+                    let f = self.0.0;
+                    let future = async move {
+                        f(
+                            (**this).clone(),
+                            $($arg,)*
+                        ).await
+                    };
+                    Promised(future).into_js(accessor.ctx())
+                }
+            }
+
         )*
     };
 }
@@ -347,7 +446,7 @@ where
             crate::Object::new(ctx)?
         };
         func.set_prototype(&proto);
-        Class::<C>::static_init(ctx, func)?;
+        Class::<C>::static_init(func)?;
         Ok(())
     }
 }

--- a/core/src/value/function/as_func.rs
+++ b/core/src/value/function/as_func.rs
@@ -236,6 +236,7 @@ macro_rules! as_function_impls {
             }
 
             // for methods via Method wrapper
+            #[cfg(feature="classes")]
             $(#[$meta])*
             impl<'js, F, R, T $(, $arg)*> AsFunction<'js, (T, $($arg),*), R> for SelfMethod<T,F>
             where
@@ -294,7 +295,7 @@ macro_rules! as_function_impls {
             }
 
             // for async methods via Method wrapper
-            #[cfg(feature = "futures")]
+            #[cfg(all(feature = "futures", feature="classes"))]
             #[allow(non_snake_case)]
             $(#[$meta])*
             impl<'js,Fut,R, T $(, $arg)*> AsFunction<'js, (&T, $($arg),*), Promised<R>> for Async<SelfMethod<T,fn(&T$(,$arg)*) -> Fut>>
@@ -327,7 +328,7 @@ macro_rules! as_function_impls {
             }
 
             // for async methods via Method wrapper
-            #[cfg(feature = "futures")]
+            #[cfg(all(feature = "futures", feature="classes"))]
             #[allow(non_snake_case)]
             $(#[$meta])*
             impl<'js,Fut,R, T $(, $arg)*> AsFunction<'js, (&T, $($arg),*), Promised<R>> for Async<SelfMethod<T,fn(T$(,$arg)*) -> Fut>>

--- a/core/src/value/function/types.rs
+++ b/core/src/value/function/types.rs
@@ -26,6 +26,16 @@ use std::{
 #[repr(transparent)]
 pub struct Method<F>(pub F);
 
+/// A method which takes a class type as a self argument.
+#[repr(transparent)]
+pub struct SelfMethod<S, F>(pub F, PhantomData<S>);
+
+impl<S, F> From<F> for SelfMethod<S, F> {
+    fn from(func: F) -> Self {
+        Self(func, PhantomData)
+    }
+}
+
 /// The wrapper for function to convert is into JS
 ///
 /// The Rust functions should be wrapped to convert it to JS using [`IntoJs`] trait.
@@ -288,6 +298,7 @@ type_impls! {
     MutFn<F>(RefCell<F>): AsRef Deref;
     OnceFn<F>(RefCell<Option<F>>): AsRef Deref;
     Method<F>(F): AsRef Deref;
+    SelfMethod<T,F>(F, PhantomData): AsRef Deref;
     This<T>(T): into_inner From AsRef AsMut Deref DerefMut;
     Opt<T>(Option<T>): into_inner Into From AsRef AsMut Deref DerefMut;
     Rest<T>(Vec<T>): into_inner Into From AsRef AsMut Deref DerefMut;

--- a/macro/src/bind/class.rs
+++ b/macro/src/bind/class.rs
@@ -322,10 +322,7 @@ impl Binder {
                         args: vec![val],
                         method: true,
                         define: Some(def),
-                        self_arg: Some(SelfArg {
-                            self_,
-                            class: class.clone(),
-                        }),
+                        self_arg: Some(SelfArg { self_, class }),
                         ..Default::default()
                     }
                 });

--- a/macro/src/bind/class.rs
+++ b/macro/src/bind/class.rs
@@ -1,6 +1,6 @@
 use super::{
     attrs::{AttrData, AttrField, AttrImpl},
-    function::BindFn1,
+    function::{BindFn1, SelfArg},
     BindFn, BindItems, BindProp, Binder,
 };
 use crate::{config::Config, context::Source, Ident, TokenStream};
@@ -104,11 +104,6 @@ impl BindClass {
                 }
             }
 
-            impl<'js> #lib_crate::FromJs<'js> for &'js #src {
-                fn from_js(ctx: #lib_crate::Ctx<'js>, value: #lib_crate::Value<'js>) -> #lib_crate::Result<Self> {
-                    <#src as #lib_crate::class::ClassDef>::from_js_ref(ctx, value)
-                }
-            }
         };
 
         if self.cloneable {
@@ -300,8 +295,12 @@ impl Binder {
                 let src = src.with_ident(fn_);
                 BindFn1 {
                     src,
-                    args: vec![self_],
+                    args: Vec::new(),
                     method: true,
+                    self_arg: Some(SelfArg {
+                        self_,
+                        class: class.clone(),
+                    }),
                     define: Some(def),
                     ..Default::default()
                 }
@@ -320,9 +319,13 @@ impl Binder {
                     let src = src.with_ident(fn_);
                     BindFn1 {
                         src,
-                        args: vec![self_, val],
+                        args: vec![val],
                         method: true,
                         define: Some(def),
+                        self_arg: Some(SelfArg {
+                            self_,
+                            class: class.clone(),
+                        }),
                         ..Default::default()
                     }
                 });
@@ -424,12 +427,6 @@ mod test {
                 }
             }
 
-            impl<'js> rquickjs::FromJs<'js> for &'js test::Test {
-                fn from_js(ctx: rquickjs::Ctx<'js>, value: rquickjs::Value<'js>) -> rquickjs::Result<Self> {
-                    <test::Test as rquickjs::class::ClassDef>::from_js_ref(ctx, value)
-                }
-            }
-
             rquickjs::Class::<test::Test>::register(_ctx)?;
         };
 
@@ -457,23 +454,23 @@ mod test {
                         fn get_a(self_: &test::Test) -> String {
                             self_.a
                         }
-                        rquickjs::function::Method(get_a)
+                        rquickjs::function::SelfMethod::<test::Test,_>::from(get_a)
                     }, {
                         fn set_a(self_: &mut test::Test, val: String) {
                             self_.a = val;
                         }
-                        rquickjs::function::Method(set_a)
+                        rquickjs::function::SelfMethod::<test::Test,_>::from(set_a)
                     }))?;
                     exports.prop("b", rquickjs::object::Accessor::new({
                         fn get_b(self_: &test::Test) -> f64 {
                             self_.b
                         }
-                        rquickjs::function::Method(get_b)
+                        rquickjs::function::SelfMethod::<test::Test,_>::from(get_b)
                     }, {
                         fn set_b(self_: &mut test::Test, val: f64) {
                             self_.b = val;
                         }
-                        rquickjs::function::Method(set_b)
+                        rquickjs::function::SelfMethod::<test::Test,_>::from(set_b)
                     }))?;
                     Ok (())
                 }
@@ -482,12 +479,6 @@ mod test {
             impl<'js> rquickjs::IntoJs<'js> for test::Test {
                 fn into_js(self, ctx: rquickjs::Ctx<'js>) -> rquickjs::Result<rquickjs::Value<'js>> {
                     <test::Test as rquickjs::class::ClassDef>::into_js_obj(self, ctx)
-                }
-            }
-
-            impl<'js> rquickjs::FromJs<'js> for &'js test::Test {
-                fn from_js(ctx: rquickjs::Ctx<'js>, value: rquickjs::Value<'js>) -> rquickjs::Result<Self> {
-                    <test::Test as rquickjs::class::ClassDef>::from_js_ref(ctx, value)
                 }
             }
 
@@ -516,9 +507,9 @@ mod test {
                 const HAS_PROTO: bool = true;
 
                 fn init_proto<'js>(_ctx: rquickjs::Ctx<'js>, exports: &rquickjs::Object<'js>) -> rquickjs::Result<()> {
-                    exports.set("len", rquickjs::function::Func::new("len", rquickjs::function::Method(test::Node::len)))?;
-                    exports.set("add", rquickjs::function::Func::new("add", rquickjs::function::Method(test::Node::add)))?;
-                    exports.set("run", rquickjs::function::Func::new("run", rquickjs::function::Async(rquickjs::function::Method(test::Node::run))))?;
+                    exports.set("len", rquickjs::function::Func::new("len", rquickjs::function::SelfMethod::<test::Node,_>::from(test::Node::len)))?;
+                    exports.set("add", rquickjs::function::Func::new("add", rquickjs::function::SelfMethod::<test::Node,_>::from(test::Node::add)))?;
+                    exports.set("run", rquickjs::function::Func::new("run", rquickjs::function::Async(rquickjs::function::SelfMethod::<test::Node,_>::from(test::Node::run))))?;
                     Ok(())
                 }
             }
@@ -526,12 +517,6 @@ mod test {
             impl<'js> rquickjs::IntoJs<'js> for test::Node {
                 fn into_js(self, ctx: rquickjs::Ctx<'js>) -> rquickjs::Result<rquickjs::Value<'js>> {
                     <test::Node as rquickjs::class::ClassDef>::into_js_obj(self, ctx)
-                }
-            }
-
-            impl<'js> rquickjs::FromJs<'js> for &'js test::Node {
-                fn from_js(ctx: rquickjs::Ctx<'js>, value: rquickjs::Value<'js>) -> rquickjs::Result<Self> {
-                    <test::Node as rquickjs::class::ClassDef>::from_js_ref(ctx, value)
                 }
             }
 
@@ -591,8 +576,8 @@ mod test {
                 fn init_proto<'js>(_ctx: rquickjs::Ctx<'js>, exports: &rquickjs::Object<'js>) -> rquickjs::Result<()> {
                     exports.prop("children", rquickjs::object::Property::from(test::Node::HAS_CHILDREN))?;
                     exports.prop("parent", rquickjs::object::Accessor::new(
-                        rquickjs::function::Method(test::Node::parent),
-                        rquickjs::function::Method(test::Node::set_parent)
+                        rquickjs::function::SelfMethod::<test::Node,_>::from(test::Node::parent),
+                        rquickjs::function::SelfMethod::<test::Node,_>::from(test::Node::set_parent)
                     ).enumerable())?;
                     Ok(())
                 }
@@ -609,12 +594,6 @@ mod test {
             impl<'js> rquickjs::IntoJs<'js> for test::Node {
                 fn into_js(self, ctx: rquickjs::Ctx<'js>) -> rquickjs::Result<rquickjs::Value<'js>> {
                     <test::Node as rquickjs::class::ClassDef>::into_js_obj(self, ctx)
-                }
-            }
-
-            impl<'js> rquickjs::FromJs<'js> for &'js test::Node {
-                fn from_js(ctx: rquickjs::Ctx<'js>, value: rquickjs::Value<'js>) -> rquickjs::Result<Self> {
-                    <test::Node as rquickjs::class::ClassDef>::from_js_ref(ctx, value)
                 }
             }
 
@@ -642,12 +621,6 @@ mod test {
             impl<'js> rquickjs::IntoJs<'js> for test::Node {
                 fn into_js(self, ctx: rquickjs::Ctx<'js>) -> rquickjs::Result<rquickjs::Value<'js>> {
                     <test::Node as rquickjs::class::ClassDef>::into_js_obj(self, ctx)
-                }
-            }
-
-            impl<'js> rquickjs::FromJs<'js> for &'js test::Node {
-                fn from_js(ctx: rquickjs::Ctx<'js>, value: rquickjs::Value<'js>) -> rquickjs::Result<Self> {
-                    <test::Node as rquickjs::class::ClassDef>::from_js_ref(ctx, value)
                 }
             }
 
@@ -690,12 +663,6 @@ mod test {
                 }
             }
 
-            impl<'js> rquickjs::FromJs<'js> for &'js test::Node {
-                fn from_js(ctx: rquickjs::Ctx<'js>, value: rquickjs::Value<'js>) -> rquickjs::Result<Self> {
-                    <test::Node as rquickjs::class::ClassDef>::from_js_ref(ctx, value)
-                }
-            }
-
             rquickjs::Class::<test::Node>::register(_ctx)?;
 
             exports.set("Node", rquickjs::function::Func::new("Node", rquickjs::Class::<test::Node>::constructor(test::Node::new)))?;
@@ -726,12 +693,6 @@ mod test {
             impl<'js> rquickjs::IntoJs<'js> for test::Node {
                 fn into_js(self, ctx: rquickjs::Ctx<'js>) -> rquickjs::Result<rquickjs::Value<'js>> {
                     <test::Node as rquickjs::class::ClassDef>::into_js_obj(self, ctx)
-                }
-            }
-
-            impl<'js> rquickjs::FromJs<'js> for &'js test::Node {
-                fn from_js(ctx: rquickjs::Ctx<'js>, value: rquickjs::Value<'js>) -> rquickjs::Result<Self> {
-                    <test::Node as rquickjs::class::ClassDef>::from_js_ref(ctx, value)
                 }
             }
 

--- a/macro/src/bind/class.rs
+++ b/macro/src/bind/class.rs
@@ -122,7 +122,7 @@ impl BindClass {
 
                 impl<'js> #lib_crate::FromJs<'js> for #src {
                     fn from_js(ctx: #lib_crate::Ctx<'js>, value: #lib_crate::Value<'js>) -> #lib_crate::Result<Self> {
-                        #lib_crate::class::ClassDef::from_js_obj(ctx, value)
+                        #lib_crate::class::ClassDef::from_js_obj(value)
                     }
                 }
             });
@@ -534,7 +534,7 @@ mod test {
 
             impl<'js> rquickjs::FromJs<'js> for test::Node {
                 fn from_js(ctx: rquickjs::Ctx<'js>, value: rquickjs::Value<'js>) -> rquickjs::Result<Self> {
-                    rquickjs::class::ClassDef::from_js_obj(ctx, value)
+                    rquickjs::class::ClassDef::from_js_obj(value)
                 }
             }
 

--- a/macro/src/lib.rs
+++ b/macro/src/lib.rs
@@ -337,6 +337,7 @@ use rquickjs::{bind, Context, Runtime};
 #[bind(object)]
 #[quickjs(bare)]
 mod geom {
+    use rquickjs::class::Ref;
     use std::cell::Cell;
 
     pub struct Point {
@@ -399,7 +400,13 @@ mod geom {
         }
 
         // static method
-        pub fn dot(a: &Point, b: &Point) -> f64 {
+        #[quickjs(rename = "dot")]
+        pub fn dot_js(a: Ref<Point>, b: Ref<Point>) -> f64 {
+            Self::dot(&*a,&*b)
+        }
+
+        #[quickjs(skip)]
+        pub fn dot(a: &Self, b: &Self) -> f64{
             a.x.get() * b.x.get() + a.y.get() * b.y.get()
         }
 


### PR DESCRIPTION
This PR is an attempt to fix #167. 

It removes `Class::from_js_ref` as it's implementation was unsound.
This has some significant consequences.

`&C` where `C: ClassDef` no longer implements `FromJs`.
This trait implementation is what allowed methods to borrow class objects in their arguments.
With this PR it is no longer possible to pass a function like `fn foo(a: &C) -> Foo{ ... }` directly into rust.
Instead if one wants to borrow a class def object the function should instead be `fn foo(a: class::Ref<C>) -> Foo{ ... }`.
`Ref` is a new type which functions as a borrowed class def objects. It keeps the object which holds the class def alive and implements deref into `C`. 
This makes referencing `C` safe and will allow us to implement a RefCell like borrowing algorithm in the future.

In order to facilitate methods with `&self` to still function I implemented the `SelfMethod` type.
This type implements `AsFunction` for with a signature similar to `fn foo(&self, arg1: (), arg2) -> Foo`. 
This type is required due to implementing `Method` over both `Fn(T)` and `Fn(&T)` separately is not allowed.
`SelfMethod` only allows taking self as a borrow.

I think the current way we handle passing functions to javascript is becoming a bit unwieldy. 
The lifetime requirements are rather complicated and when a function is not completely right rust returns errors which are almost completely unhelpful.
We should probably move away from all the function wrappers and maybe rely somewhat more on macros to implement functions, only allowing the function wrappers for closures.

This current PR is to remove the unsound behavior with the current approach and we should probably look at rewriting the class and function modules in a later version.