### PR TITLE
deps: Missing convert_case from recent updates.

### DIFF
--- a/macro/Cargo.toml
+++ b/macro/Cargo.toml
@@ -21,6 +21,7 @@ quote = "1"
 ident_case = "1"
 fnv = "1"
 indexmap = "2"
+convert_case = "0.6.0"
 
 [dependencies.darling]
 version = "0.20"


### PR DESCRIPTION
Looks like you missed this when landing recent changes.