### PR TITLE
Fix spawner ordering

### DIFF
--- a/core/src/runtime/spawner.rs
+++ b/core/src/runtime/spawner.rs
@@ -65,21 +65,14 @@ impl<'a, 'js> Future for SpawnFuture<'a, 'js> {
             return Poll::Ready(false);
         }
 
-        let mut completed_indices = Vec::new();
+        let mut did_complete = false;
+        self.0.futures.retain_mut(|f| {
+            let ready = f.as_mut().poll(cx).is_ready();
+            did_complete = did_complete || ready;
+            !ready
+        });
 
-        // Iterate over the futures and check their completion status.
-        for (i, f) in self.0.futures.iter_mut().enumerate() {
-            if let Poll::Ready(_) = f.as_mut().poll(cx) {
-                completed_indices.push(i);
-            }
-        }
-
-        // Remove the completed futures in reverse order to avoid index shifting.
-        for &idx in completed_indices.iter().rev() {
-            self.0.futures.remove(idx);
-        }
-
-        if !completed_indices.is_empty() {
+        if did_complete {
             Poll::Ready(true)
         } else {
             Poll::Pending


### PR DESCRIPTION
I noticed some timing issues when using `ctx.spawn`. Tracked down the issue to lie in `swap_remove` where the order of how futures are spawned will be modified.

I modified the logic to collect and remove all completed futures in a single pass and then remove them in reverse order to avoid index shifting as much as possible.

A linked list rather than a Vec is O(1) for removal during iteration and insertion at end but will involve pointer following rather than array iteration that might not be ideal.

It's also better for performance if we pull and remove all completed tasks.