### PR TITLE
Remove `max-args-*` features.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -102,18 +102,6 @@ macro = ["rquickjs-macro"]
 # Enable interop between Rust futures and JS Promises
 futures = ["rquickjs-core/futures"]
 
-# Max number of function args
-max-args-7 = ["rquickjs-core/max-args-7"]
-max-args-8 = ["rquickjs-core/max-args-7"]
-max-args-9 = ["rquickjs-core/max-args-8"]
-max-args-10 = ["rquickjs-core/max-args-9"]
-max-args-11 = ["rquickjs-core/max-args-10"]
-max-args-12 = ["rquickjs-core/max-args-11"]
-max-args-13 = ["rquickjs-core/max-args-12"]
-max-args-14 = ["rquickjs-core/max-args-13"]
-max-args-15 = ["rquickjs-core/max-args-14"]
-max-args-16 = ["rquickjs-core/max-args-15"]
-
 # Enable QuickJS dumps for debug
 dump-bytecode = ["rquickjs-core/dump-bytecode"]
 dump-gc = ["rquickjs-core/dump-gc"]

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -89,18 +89,6 @@ futures = ["async-lock"]
 # Allows transferring objects between different contexts of the same runtime.
 multi-ctx = []
 
-# Max number of function args
-max-args-7 = []
-max-args-8 = ["max-args-7"]
-max-args-9 = ["max-args-8"]
-max-args-10 = ["max-args-9"]
-max-args-11 = ["max-args-10"]
-max-args-12 = ["max-args-11"]
-max-args-13 = ["max-args-12"]
-max-args-14 = ["max-args-13"]
-max-args-15 = ["max-args-14"]
-max-args-16 = ["max-args-15"]
-
 # Enable QuickJS dumps for debug
 dump-bytecode = ["rquickjs-sys/dump-bytecode"]
 dump-gc = ["rquickjs-sys/dump-gc"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -74,12 +74,6 @@
 //!
 //! - `phf` enables using Perfect Hash Function for builtin modules lookup
 //!
-//! ## Custom
-//!
-//! To gets build faster the numbers of arguments which can be passed to and given by the functions
-//! is limited to 6. If you need more arguments you can enabled feature `max-args-N` where N is
-//! number from 7 to 16.
-//!
 //! ## Extra types
 //!
 //! This crate has support for conversion of many Rust types like [`Option`],


### PR DESCRIPTION
These are no longer used.