### PR TITLE
Fix a bug where `throw_(type,internal,..etc)` would feed into printf

### DIFF
--- a/core/src/value.rs
+++ b/core/src/value.rs
@@ -15,11 +15,11 @@ mod symbol;
 pub use array::Array;
 pub use atom::Atom;
 pub use bigint::BigInt;
-pub use convert::{Coerced, FromAtom, FromIteratorJs, FromJs, IntoAtom, IntoJs, IteratorJs};
+pub use convert::{FromAtom, FromIteratorJs, FromJs, IntoAtom, IntoJs, IteratorJs};
 pub use exception::Exception;
 pub use function::{Constructor, Function};
 pub use module::Module;
-pub use object::{Filter, Object};
+pub use object::Object;
 pub use string::String;
 pub use symbol::Symbol;
 


### PR DESCRIPTION
It turns out that `JS_ThrowTypeError` and other similar methods don't take a string but also a vararg and actually call printf directly. Causing any c format specifier in an error message to be replaced with a value read from the process memory.

This PR fixes this bug.