### PR TITLE
Bump version due to changes to allocator API.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rquickjs"
-version = "0.4.3"
+version = "0.5.0"
 authors = ["Mees Delzenne <mees.delzenne@gmail.com>", "K. <kayo@illumium.org>"]
 edition = "2021"
 rust-version = "1.65"
@@ -12,11 +12,11 @@ categories = ["api-bindings"]
 repository = "https://github.com/DelSkayn/rquickjs.git"
 
 [dependencies.rquickjs-core]
-version = "0.4.3"
+version = "0.5.0"
 path = "core"
 
 [dependencies.rquickjs-macro]
-version = "0.4.3"
+version = "0.5.0"
 path = "macro"
 optional = true
 

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rquickjs-core"
-version = "0.4.3"
+version = "0.5.0"
 authors = ["Mees Delzenne <mees.delzenne@gmail.com>", "K. <kayo@illumium.org>"]
 edition = "2021"
 license = "MIT"
@@ -31,7 +31,7 @@ version = "0.4"
 optional = true
 
 [dependencies.rquickjs-sys]
-version = "0.4.3"
+version = "0.5.0"
 path = "../sys"
 
 [dependencies.dlopen]

--- a/core/src/allocator.rs
+++ b/core/src/allocator.rs
@@ -23,7 +23,7 @@ pub trait Allocator {
     unsafe fn realloc(&mut self, ptr: RawMemPtr, new_size: usize) -> RawMemPtr;
 
     /// Get usable size of allocated memory region
-    fn usable_size(ptr: RawMemPtr) -> usize
+    unsafe fn usable_size(ptr: RawMemPtr) -> usize
     where
         Self: Sized;
 }

--- a/core/src/allocator.rs
+++ b/core/src/allocator.rs
@@ -11,18 +11,41 @@ pub use rust::RustAllocator;
 pub type RawMemPtr = *mut u8;
 
 /// The allocator interface
+///
+/// # Safety
+/// Failure to implement this trait correctly will result in undefined behavior.
+/// - `alloc` must return a either a null pointer or a pointer to an available region of memory
+/// atleast `size` bytes and aligned to the size of `usize`.
+/// - `realloc` must either return a null pointer or return a pointer to an available region of
+/// memory atleast `new_size` bytes and aligned to the size of `usize`.
+/// - `usable_size` must return the amount of available memory for any allocation allocated with
+/// this allocator.
 #[cfg_attr(feature = "doc-cfg", doc(cfg(feature = "allocator")))]
-pub trait Allocator {
+pub unsafe trait Allocator {
     /// Allocate new memory
-    unsafe fn alloc(&mut self, size: usize) -> RawMemPtr;
+    ///
+    ///
+    fn alloc(&mut self, size: usize) -> RawMemPtr;
 
     /// De-allocate previously allocated memory
+    ///
+    /// # Safety
+    /// Caller must ensure that the pointer that is being deallocated was allocated by the same
+    /// Allocator instance.
     unsafe fn dealloc(&mut self, ptr: RawMemPtr);
 
     /// Re-allocate previously allocated memory
+    ///
+    /// # Safety
+    /// Caller must ensure that the pointer points to an allocation that was allocated by the same
+    /// Allocator instance.
     unsafe fn realloc(&mut self, ptr: RawMemPtr, new_size: usize) -> RawMemPtr;
 
     /// Get usable size of allocated memory region
+    ///
+    /// # Safety
+    /// Caller must ensure that the pointer handed to this function points to an allocation
+    /// allocated by the same allocator instance.
     unsafe fn usable_size(ptr: RawMemPtr) -> usize
     where
         Self: Sized;

--- a/core/src/allocator/rust.rs
+++ b/core/src/allocator/rust.rs
@@ -116,10 +116,12 @@ mod test {
     struct TestAllocator;
 
     unsafe impl Allocator for TestAllocator {
-        unsafe fn alloc(&mut self, size: usize) -> crate::allocator::RawMemPtr {
-            let res = RustAllocator.alloc(size);
-            ALLOC_SIZE.fetch_add(RustAllocator::usable_size(res), Ordering::AcqRel);
-            res
+        fn alloc(&mut self, size: usize) -> crate::allocator::RawMemPtr {
+            unsafe {
+                let res = RustAllocator.alloc(size);
+                ALLOC_SIZE.fetch_add(RustAllocator::usable_size(res), Ordering::AcqRel);
+                res
+            }
         }
 
         unsafe fn dealloc(&mut self, ptr: crate::allocator::RawMemPtr) {

--- a/core/src/runtime/async.rs
+++ b/core/src/runtime/async.rs
@@ -286,11 +286,12 @@ impl AsyncRuntime {
         lock.drop_pending();
 
         loop {
-            match lock.runtime.execute_pending_job().map_err(|e| {
+            let pending = lock.runtime.execute_pending_job().map_err(|e| {
                 let ptr = NonNull::new(e)
                     .expect("executing pending job returned a null context on error");
                 AsyncJobException(unsafe { AsyncContext::from_raw(ptr, self.clone()) })
-            }) {
+            });
+            match pending {
                 Err(e) => {
                     // SAFETY: Runtime is already locked so creating a context is safe.
                     let ctx = unsafe { Ctx::from_ptr(e.0 .0.ctx.as_ptr()) };

--- a/core/src/runtime/raw.rs
+++ b/core/src/runtime/raw.rs
@@ -232,10 +232,11 @@ impl RawRuntime {
             _rt: *mut qjs::JSRuntime,
             opaque: *mut ::std::os::raw::c_void,
         ) -> ::std::os::raw::c_int {
-            let should_interrupt = match panic::catch_unwind(move || {
+            let catch_unwind = panic::catch_unwind(move || {
                 let opaque = &mut *(opaque as *mut Opaque);
                 opaque.interrupt_handler.as_mut().expect("handler is set")()
-            }) {
+            });
+            let should_interrupt = match catch_unwind {
                 Ok(should_interrupt) => should_interrupt,
                 Err(panic) => {
                     let opaque = &mut *(opaque as *mut Opaque);

--- a/macro/Cargo.toml
+++ b/macro/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rquickjs-macro"
-version = "0.4.3"
+version = "0.5.0"
 authors = ["K. <kayo@illumium.org>", "Mees Delzenne <mees.delzenne@gmail.com>"]
 edition = "2021"
 license = "MIT"
@@ -37,7 +37,7 @@ optional = true
 
 [dependencies.rquickjs-core]
 path = "../core"
-version = "0.4.3"
+version = "0.5.0"
 features = ["loader"]
 
 [dev-dependencies.difference]
@@ -45,7 +45,7 @@ version = "2"
 
 [dev-dependencies.rquickjs]
 path = ".."
-version = "0.4.3"
+version = "0.5.0"
 features = ["macro", "classes", "properties", "futures","phf"]
 
 [dev-dependencies.async-std]

--- a/sys/Cargo.toml
+++ b/sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rquickjs-sys"
-version = "0.4.3"
+version = "0.5.0"
 authors = ["Mees Delzenne <mees.delzenne@gmail.com>"]
 edition = "2021"
 license = "MIT"


### PR DESCRIPTION
PR finishes changes to allocator making all it's methods unsafe.

This is a breaking change so it requires a version bump.