### PR TITLE
Add name to constructor when registering constructor

### DIFF
--- a/core/src/class.rs
+++ b/core/src/class.rs
@@ -165,7 +165,6 @@ impl<'js, C: JsClass<'js>> Class<'js, C> {
     /// Defines the predefined constructor of this class, if there is one, onto the given object.
     pub fn define(object: &Object<'js>) -> Result<()> {
         if let Some(constructor) = Self::create_constructor(object.ctx())? {
-            constructor.set(PredefinedAtom::Name, C::NAME)?;
             object.set(C::NAME, constructor)?;
         }
         Ok(())
@@ -396,7 +395,7 @@ mod test {
         function::This,
         test_with,
         value::Constructor,
-        Class, Context, FromJs, Function, IntoJs, Object, Runtime,
+        Class, Context, FromJs, Function, IntoJs, Object, Runtime, Value,
     };
 
     /// Test circular references.
@@ -561,6 +560,9 @@ mod test {
             approx::assert_abs_diff_eq!(v.x, 5.0);
             approx::assert_abs_diff_eq!(v.y, 4.0);
             approx::assert_abs_diff_eq!(v.z, 11.0);
+
+            let name: String = ctx.eval("new Vec3(1,2,3).constructor.name").unwrap();
+            assert_eq!(name, Vec3::NAME);
         })
     }
 

--- a/core/src/class.rs
+++ b/core/src/class.rs
@@ -1,8 +1,8 @@
 //! JavaScript classes defined from Rust.
 
 use crate::{
-    atom::PredefinedAtom, function::StaticJsFn, qjs, value::Constructor, Ctx, Error, FromJs,
-    IntoJs, Object, Outlive, Result, Value,
+    function::StaticJsFn, qjs, value::Constructor, Ctx, Error, FromJs, IntoJs, Object, Outlive,
+    Result, Value,
 };
 use std::{
     ffi::CString,

--- a/core/src/class.rs
+++ b/core/src/class.rs
@@ -1,8 +1,8 @@
 //! JavaScript classes defined from Rust.
 
 use crate::{
-    function::StaticJsFn, qjs, value::Constructor, Ctx, Error, FromJs, IntoJs, Object, Outlive,
-    Result, Value,
+    atom::PredefinedAtom, function::StaticJsFn, qjs, value::Constructor, Ctx, Error, FromJs,
+    IntoJs, Object, Outlive, Result, Value,
 };
 use std::{
     ffi::CString,
@@ -165,6 +165,7 @@ impl<'js, C: JsClass<'js>> Class<'js, C> {
     /// Defines the predefined constructor of this class, if there is one, onto the given object.
     pub fn define(object: &Object<'js>) -> Result<()> {
         if let Some(constructor) = Self::create_constructor(object.ctx())? {
+            constructor.set(PredefinedAtom::Name, C::NAME)?;
             object.set(C::NAME, constructor)?;
         }
         Ok(())

--- a/core/src/value/function.rs
+++ b/core/src/value/function.rs
@@ -220,6 +220,7 @@ impl<'js> Constructor<'js> {
             Ok(res)
         });
         let func = Function(Class::instance(ctx.clone(), RustFunction(func))?.into_inner())
+            .with_name(C::NAME)?
             .with_constructor(true);
         unsafe {
             qjs::JS_SetConstructor(


### PR DESCRIPTION
Name property is not set when creating constructors. This PR adds the name from the class to the constructor so the following will work for classes defined in Rust.

```javascript
new MyClass().constructor.name == "MyClass"
```