### PR TITLE
use global wasi-sdk if WASI_SDK env is set

### DIFF
--- a/sys/build.rs
+++ b/sys/build.rs
@@ -84,7 +84,9 @@ fn download_wasi_sdk() -> PathBuf {
 }
 
 fn get_wasi_sdk_path() -> PathBuf {
-    download_wasi_sdk()
+    std::env::var_os("WASI_SDK")
+        .map(|path| PathBuf::from(path))
+        .unwrap_or_else(download_wasi_sdk)
 }
 
 fn main() {


### PR DESCRIPTION
this patch allows to use an external wasi sdk by setting the environment variable `WASI_SDK` to the path to be used.

My usecase is that I have a wasi-sdk for linux-aarch64 installed in /opt/wasi-sdk and there is currently no binary package to install for that architecture