### PR TITLE
Introduce new more efficient scheduler

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ package = "either"
 version = "1"
 optional = true
 
+
 [workspace]
 members = [
     "sys",
@@ -128,3 +129,4 @@ trybuild = "1.0.82"
 
 [package.metadata.docs.rs]
 features = ["full-async", "parallel", "doc-cfg"]
+

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -42,6 +42,11 @@ optional = true
 version = "1.3"
 optional = true
 
+[dependencies.atomic-waker]
+version = "1.1.2"
+optional = true
+
+
 [features]
 default = []
 
@@ -84,7 +89,7 @@ properties = []
 array-buffer = []
 
 # Enable interop between Rust futures and JS Promises
-futures = ["async-lock"]
+futures = ["dep:async-lock","dep:atomic-waker"]
 
 # Allows transferring objects between different contexts of the same runtime.
 multi-ctx = []
@@ -128,3 +133,4 @@ trybuild = "1.0.23"
 
 [package.metadata.docs.rs]
 features = ["full-async", "doc-cfg"]
+

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -42,10 +42,6 @@ optional = true
 version = "1.3"
 optional = true
 
-[dependencies.atomic-waker]
-version = "1.1.2"
-optional = true
-
 
 [features]
 default = []
@@ -89,7 +85,7 @@ properties = []
 array-buffer = []
 
 # Enable interop between Rust futures and JS Promises
-futures = ["dep:async-lock","dep:atomic-waker"]
+futures = ["dep:async-lock"]
 
 # Allows transferring objects between different contexts of the same runtime.
 multi-ctx = []

--- a/core/src/class.rs
+++ b/core/src/class.rs
@@ -348,7 +348,7 @@ impl<'js> Object<'js> {
         if self.instance_of::<C>() {
             Ok(Class(self.clone(), PhantomData))
         } else {
-            Err(&self)
+            Err(self)
         }
     }
 

--- a/core/src/runtime.rs
+++ b/core/src/runtime.rs
@@ -19,6 +19,8 @@ pub(crate) use r#async::InnerRuntime;
 #[cfg(feature = "futures")]
 pub use r#async::{AsyncRuntime, AsyncWeakRuntime};
 #[cfg(feature = "futures")]
+mod schedular;
+#[cfg(feature = "futures")]
 mod spawner;
 
 /// A struct with information about the runtimes memory usage.

--- a/core/src/runtime/raw.rs
+++ b/core/src/runtime/raw.rs
@@ -22,7 +22,7 @@ pub(crate) struct Opaque<'js> {
     pub interrupt_handler: Option<InterruptHandler>,
 
     #[cfg(feature = "futures")]
-    pub spawner: Option<Spawner<'js>>,
+    pub spawner: Option<Spawner>,
 
     _marker: PhantomData<&'js ()>,
 }
@@ -50,7 +50,7 @@ impl<'js> Opaque<'js> {
     }
 
     #[cfg(feature = "futures")]
-    pub fn spawner(&mut self) -> &mut Spawner<'js> {
+    pub fn spawner(&mut self) -> &mut Spawner {
         self.spawner
             .as_mut()
             .expect("tried to use async function in non async runtime")

--- a/core/src/runtime/schedular.rs
+++ b/core/src/runtime/schedular.rs
@@ -1,0 +1,293 @@
+use std::{
+    cell::{Cell, UnsafeCell},
+    future::Future,
+    mem::{offset_of, ManuallyDrop},
+    pin::Pin,
+    ptr::NonNull,
+    sync::{
+        atomic::{AtomicBool, Ordering},
+        Arc, Weak,
+    },
+    task::{Context, Poll},
+};
+
+mod queue;
+use queue::Queue;
+
+mod vtable;
+use vtable::VTable;
+
+mod waker;
+
+use self::queue::NodeHeader;
+
+use std::ops::{Deref, DerefMut};
+
+pub struct Defer<T, F: FnOnce(&mut T)> {
+    value: ManuallyDrop<T>,
+    f: Option<F>,
+}
+
+impl<T, F: FnOnce(&mut T)> Defer<T, F> {
+    pub fn new(value: T, func: F) -> Self {
+        Defer {
+            value: ManuallyDrop::new(value),
+            f: Some(func),
+        }
+    }
+
+    pub fn take(mut self) -> T {
+        self.f = None;
+        unsafe { ManuallyDrop::take(&mut self.value) }
+    }
+}
+
+impl<T, F: FnOnce(&mut T)> Deref for Defer<T, F> {
+    type Target = T;
+
+    fn deref(&self) -> &Self::Target {
+        &self.value
+    }
+}
+
+impl<T, F: FnOnce(&mut T)> DerefMut for Defer<T, F> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.value
+    }
+}
+
+impl<T, F> Drop for Defer<T, F>
+where
+    F: FnOnce(&mut T),
+{
+    fn drop(&mut self) {
+        if let Some(x) = self.f.take() {
+            (x)(&mut *self.value);
+            unsafe { ManuallyDrop::drop(&mut self.value) }
+        }
+    }
+}
+
+#[repr(C)]
+struct Task<F> {
+    head: NodeHeader,
+    body: TaskBody,
+    future: UnsafeCell<F>,
+}
+
+// Seperate struct to not have everything be repr(C)
+struct TaskBody {
+    queue: Weak<Queue>,
+    vtable: &'static VTable,
+    // The double linked list of tasks.
+    next: Cell<Option<NonNull<Task<u8>>>>,
+    prev: Cell<Option<NonNull<Task<u8>>>>,
+    // wether the task is currently in the queue to be re-polled.
+    queued: AtomicBool,
+    done: Cell<bool>,
+}
+
+pub struct Schedular {
+    len: Cell<usize>,
+    should_poll: Arc<Queue>,
+    all_next: Cell<Option<NonNull<Task<u8>>>>,
+    all_prev: Cell<Option<NonNull<Task<u8>>>>,
+}
+
+impl Schedular {
+    pub fn new() -> Self {
+        let queue = Arc::new(Queue::new());
+        unsafe {
+            Pin::new_unchecked(&*queue).init();
+        }
+        Schedular {
+            len: Cell::new(0),
+            should_poll: queue,
+            all_prev: Cell::new(None),
+            all_next: Cell::new(None),
+        }
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.all_next.get().is_none()
+    }
+
+    /// # Safety
+    /// This function erases any lifetime associated with the future.
+    /// Caller must ensure that either the future completes or is dropped before the lifetime
+    pub unsafe fn push<F>(&self, f: F)
+    where
+        F: Future<Output = ()>,
+    {
+        let queue = Arc::downgrade(&self.should_poll);
+
+        debug_assert_eq!(offset_of!(Task<F>, future), offset_of!(Task<u8>, future));
+
+        let task = Arc::new(Task {
+            head: NodeHeader::new(),
+            body: TaskBody {
+                queue,
+                vtable: VTable::get::<F>(),
+                next: Cell::new(None),
+                prev: Cell::new(None),
+                queued: AtomicBool::new(true),
+                done: Cell::new(false),
+            },
+            future: UnsafeCell::new(ManuallyDrop::new(f)),
+        });
+
+        // One count for the all list and one for the should_poll list.
+        let task = NonNull::new_unchecked(Arc::into_raw(task) as *mut Task<F>).cast::<Task<u8>>();
+        Arc::increment_strong_count(task.as_ptr());
+
+        self.push_task_to_all(task);
+
+        Pin::new_unchecked(&*self.should_poll).push(task.cast());
+        self.len.set(self.len.get() + 1);
+    }
+
+    unsafe fn push_task_to_all(&self, task: NonNull<Task<u8>>) {
+        task.as_ref().body.next.set(self.all_next.get());
+
+        if let Some(x) = self.all_next.get() {
+            x.as_ref().body.prev.set(Some(task));
+        }
+        self.all_next.set(Some(task));
+        if self.all_prev.get().is_none() {
+            self.all_prev.set(Some(task));
+        }
+    }
+
+    unsafe fn pop_task_all(&self, task: NonNull<Task<u8>>) {
+        task.as_ref().body.queued.store(true, Ordering::Release);
+        task.as_ref().body.done.set(true);
+
+        // detach the task from the all list
+        if let Some(next) = task.as_ref().body.next.get() {
+            next.as_ref().body.prev.set(task.as_ref().body.prev.get())
+        } else {
+            self.all_prev.set(task.as_ref().body.prev.get());
+        }
+        if let Some(prev) = task.as_ref().body.prev.get() {
+            prev.as_ref().body.next.set(task.as_ref().body.next.get())
+        } else {
+            self.all_next.set(task.as_ref().body.next.get());
+        }
+
+        // drop the ownership of the all list,
+        // Task is now dropped or only owned by wakers or
+        Self::drop_task(task);
+        self.len.set(self.len.get() - 1);
+    }
+
+    unsafe fn drop_task(ptr: NonNull<Task<u8>>) {
+        (ptr.as_ref().body.vtable.task_drop)(ptr)
+    }
+
+    unsafe fn drive_task(ptr: NonNull<Task<u8>>, ctx: &mut Context) -> Poll<()> {
+        (ptr.as_ref().body.vtable.task_drive)(ptr, ctx)
+    }
+
+    pub unsafe fn poll(&self, cx: &mut Context) -> Poll<bool> {
+        // During polling ownership is upheld by making sure arc counts are properly tranfered.
+        // Both ques, should_poll and all, have ownership of the arc count.
+        // Whenever a task is pushed onto the should_poll queue ownership is transfered.
+        // During task pusing into the schedular ownership of the count was transfered into the all
+        // list.
+
+        if self.is_empty() {
+            // No tasks, nothing to be done.
+            return Poll::Ready(false);
+        }
+
+        self.should_poll.waker().register(cx.waker());
+
+        let mut iteration = 0;
+        let mut yielded = 0;
+        let mut pending = false;
+
+        loop {
+            // Popped a task, ownership taken from the que
+            let cur = match Pin::new_unchecked(&*self.should_poll).pop() {
+                queue::Pop::Empty => {
+                    if pending {
+                        return Poll::Pending;
+                    } else {
+                        return Poll::Ready(iteration > 0);
+                    }
+                }
+                queue::Pop::Value(x) => x,
+                queue::Pop::Inconsistant => {
+                    cx.waker().wake_by_ref();
+                    return Poll::Pending;
+                }
+            };
+
+            let cur = cur.cast::<Task<u8>>();
+
+            if cur.as_ref().body.done.get() {
+                // Task was already done, we con drop the ownership we got from the que.
+                Self::drop_task(cur);
+                continue;
+            }
+
+            let prev = cur.as_ref().body.queued.swap(false, Ordering::AcqRel);
+            assert!(prev);
+
+            // ownership transfered into the waker, which won't drop until the iteration completes.
+            let waker = waker::get(cur);
+            // if drive_task panics we still want to remove the task from the list.
+            // So handle it with a drop
+            let remove = Defer::new(self, |this| (*this).pop_task_all(cur));
+            let mut ctx = Context::from_waker(&waker);
+
+            iteration += 1;
+
+            match Self::drive_task(cur, &mut ctx) {
+                Poll::Ready(_) => {
+                    // Nothing todo the defer will remove the task from the list.
+                }
+                Poll::Pending => {
+                    // don't remove task from the list.
+                    remove.take();
+                    pending = true;
+                    yielded += cur.as_ref().body.queued.load(Ordering::Relaxed) as usize;
+                    if yielded > 2 || iteration > self.len.get() {
+                        cx.waker().wake_by_ref();
+                        return Poll::Pending;
+                    }
+                }
+            }
+        }
+    }
+
+    pub fn clear(&self) {
+        // Clear all pending futures from the all list
+        let mut cur = self.all_next.get();
+        while let Some(c) = cur {
+            unsafe {
+                cur = c.as_ref().body.next.get();
+                self.pop_task_all(c)
+            }
+        }
+
+        loop {
+            let cur = match unsafe { Pin::new_unchecked(&*self.should_poll).pop() } {
+                queue::Pop::Empty => break,
+                queue::Pop::Value(x) => x,
+                queue::Pop::Inconsistant => {
+                    std::thread::yield_now();
+                    continue;
+                }
+            };
+
+            unsafe { Self::drop_task(cur.cast()) };
+        }
+    }
+}
+
+impl Drop for Schedular {
+    fn drop(&mut self) {
+        self.clear()
+    }
+}

--- a/core/src/runtime/schedular.rs
+++ b/core/src/runtime/schedular.rs
@@ -19,6 +19,8 @@ use vtable::VTable;
 
 mod waker;
 
+mod atomic_waker;
+
 use self::queue::NodeHeader;
 
 use std::ops::{Deref, DerefMut};

--- a/core/src/runtime/schedular/atomic_waker.rs
+++ b/core/src/runtime/schedular/atomic_waker.rs
@@ -1,0 +1,341 @@
+//! The atomic waker from the futures crate pulled into its own file.
+//! This is done to avoid having to pull in the entire futures crate just for a single struct.
+//!
+//! All copyright of this file belongs to the futures authors.
+
+use core::cell::UnsafeCell;
+use core::fmt;
+use core::task::Waker;
+
+use atomic::AtomicUsize;
+use atomic::Ordering::{AcqRel, Acquire, Release};
+
+#[cfg(feature = "portable-atomic")]
+use portable_atomic as atomic;
+
+#[cfg(not(feature = "portable-atomic"))]
+use core::sync::atomic;
+
+/// A synchronization primitive for task wakeup.
+///
+/// Sometimes the task interested in a given event will change over time.
+/// An `AtomicWaker` can coordinate concurrent notifications with the consumer
+/// potentially "updating" the underlying task to wake up. This is useful in
+/// scenarios where a computation completes in another thread and wants to
+/// notify the consumer, but the consumer is in the process of being migrated to
+/// a new logical task.
+///
+/// Consumers should call `register` before checking the result of a computation
+/// and producers should call `wake` after producing the computation (this
+/// differs from the usual `thread::park` pattern). It is also permitted for
+/// `wake` to be called **before** `register`. This results in a no-op.
+///
+/// A single `AtomicWaker` may be reused for any number of calls to `register` or
+/// `wake`.
+///
+/// # Memory ordering
+///
+/// Calling `register` "acquires" all memory "released" by calls to `wake`
+/// before the call to `register`.  Later calls to `wake` will wake the
+/// registered waker (on contention this wake might be triggered in `register`).
+///
+/// For concurrent calls to `register` (should be avoided) the ordering is only
+/// guaranteed for the winning call.
+pub struct AtomicWaker {
+    state: AtomicUsize,
+    waker: UnsafeCell<Option<Waker>>,
+}
+
+// `AtomicWaker` is a multi-consumer, single-producer transfer cell. The cell
+// stores a `Waker` value produced by calls to `register` and many threads can
+// race to take the waker (to wake it) by calling `wake`.
+//
+// If a new `Waker` instance is produced by calling `register` before an
+// existing one is consumed, then the existing one is overwritten.
+//
+// While `AtomicWaker` is single-producer, the implementation ensures memory
+// safety. In the event of concurrent calls to `register`, there will be a
+// single winner whose waker will get stored in the cell. The losers will not
+// have their tasks woken. As such, callers should ensure to add synchronization
+// to calls to `register`.
+//
+// The implementation uses a single `AtomicUsize` value to coordinate access to
+// the `Waker` cell. There are two bits that are operated on independently.
+// These are represented by `REGISTERING` and `WAKING`.
+//
+// The `REGISTERING` bit is set when a producer enters the critical section. The
+// `WAKING` bit is set when a consumer enters the critical section. Neither bit
+// being set is represented by `WAITING`.
+//
+// A thread obtains an exclusive lock on the waker cell by transitioning the
+// state from `WAITING` to `REGISTERING` or `WAKING`, depending on the operation
+// the thread wishes to perform. When this transition is made, it is guaranteed
+// that no other thread will access the waker cell.
+//
+// # Registering
+//
+// On a call to `register`, an attempt to transition the state from WAITING to
+// REGISTERING is made. On success, the caller obtains a lock on the waker cell.
+//
+// If the lock is obtained, then the thread sets the waker cell to the waker
+// provided as an argument. Then it attempts to transition the state back from
+// `REGISTERING` -> `WAITING`.
+//
+// If this transition is successful, then the registering process is complete
+// and the next call to `wake` will observe the waker.
+//
+// If the transition fails, then there was a concurrent call to `wake` that was
+// unable to access the waker cell (due to the registering thread holding the
+// lock). To handle this, the registering thread removes the waker it just set
+// from the cell and calls `wake` on it. This call to wake represents the
+// attempt to wake by the other thread (that set the `WAKING` bit). The state is
+// then transitioned from `REGISTERING | WAKING` back to `WAITING`.  This
+// transition must succeed because, at this point, the state cannot be
+// transitioned by another thread.
+//
+// # Waking
+//
+// On a call to `wake`, an attempt to transition the state from `WAITING` to
+// `WAKING` is made. On success, the caller obtains a lock on the waker cell.
+//
+// If the lock is obtained, then the thread takes ownership of the current value
+// in the waker cell, and calls `wake` on it. The state is then transitioned
+// back to `WAITING`. This transition must succeed as, at this point, the state
+// cannot be transitioned by another thread.
+//
+// If the thread is unable to obtain the lock, the `WAKING` bit is still.  This
+// is because it has either been set by the current thread but the previous
+// value included the `REGISTERING` bit **or** a concurrent thread is in the
+// `WAKING` critical section. Either way, no action must be taken.
+//
+// If the current thread is the only concurrent call to `wake` and another
+// thread is in the `register` critical section, when the other thread **exits**
+// the `register` critical section, it will observe the `WAKING` bit and handle
+// the wake itself.
+//
+// If another thread is in the `wake` critical section, then it will handle
+// waking the task.
+//
+// # A potential race (is safely handled).
+//
+// Imagine the following situation:
+//
+// * Thread A obtains the `wake` lock and wakes a task.
+//
+// * Before thread A releases the `wake` lock, the woken task is scheduled.
+//
+// * Thread B attempts to wake the task. In theory this should result in the
+//   task being woken, but it cannot because thread A still holds the wake lock.
+//
+// This case is handled by requiring users of `AtomicWaker` to call `register`
+// **before** attempting to observe the application state change that resulted
+// in the task being awoken. The wakers also change the application state before
+// calling wake.
+//
+// Because of this, the waker will do one of two things.
+//
+// 1) Observe the application state change that Thread B is woken for. In this
+//    case, it is OK for Thread B's wake to be lost.
+//
+// 2) Call register before attempting to observe the application state. Since
+//    Thread A still holds the `wake` lock, the call to `register` will result
+//    in the task waking itself and get scheduled again.
+
+/// Idle state
+const WAITING: usize = 0;
+
+/// A new waker value is being registered with the `AtomicWaker` cell.
+const REGISTERING: usize = 0b01;
+
+/// The waker currently registered with the `AtomicWaker` cell is being woken.
+const WAKING: usize = 0b10;
+
+impl AtomicWaker {
+    /// Create an `AtomicWaker`.
+    pub const fn new() -> Self {
+        // Make sure that task is Sync
+        trait AssertSync: Sync {}
+        impl AssertSync for Waker {}
+
+        Self {
+            state: AtomicUsize::new(WAITING),
+            waker: UnsafeCell::new(None),
+        }
+    }
+
+    /// Registers the waker to be notified on calls to `wake`.
+    ///
+    /// The new task will take place of any previous tasks that were registered
+    /// by previous calls to `register`. Any calls to `wake` that happen after
+    /// a call to `register` (as defined by the memory ordering rules), will
+    /// notify the `register` caller's task and deregister the waker from future
+    /// notifications. Because of this, callers should ensure `register` gets
+    /// invoked with a new `Waker` **each** time they require a wakeup.
+    ///
+    /// It is safe to call `register` with multiple other threads concurrently
+    /// calling `wake`. This will result in the `register` caller's current
+    /// task being notified once.
+    ///
+    /// This function is safe to call concurrently, but this is generally a bad
+    /// idea. Concurrent calls to `register` will attempt to register different
+    /// tasks to be notified. One of the callers will win and have its task set,
+    /// but there is no guarantee as to which caller will succeed.
+    pub fn register(&self, waker: &Waker) {
+        match self
+            .state
+            .compare_exchange(WAITING, REGISTERING, Acquire, Acquire)
+            .unwrap_or_else(|x| x)
+        {
+            WAITING => {
+                unsafe {
+                    // Locked acquired, update the waker cell
+
+                    // Avoid cloning the waker if the old waker will awaken the same task.
+                    match &*self.waker.get() {
+                        Some(old_waker) if old_waker.will_wake(waker) => (),
+                        _ => *self.waker.get() = Some(waker.clone()),
+                    }
+
+                    // Release the lock. If the state transitioned to include
+                    // the `WAKING` bit, this means that at least one wake has
+                    // been called concurrently.
+                    //
+                    // Start by assuming that the state is `REGISTERING` as this
+                    // is what we just set it to. If this holds, we know that no
+                    // other writes were performed in the meantime, so there is
+                    // nothing to acquire, only release. In case of concurrent
+                    // wakers, we need to acquire their releases, so success needs
+                    // to do both.
+                    let res = self
+                        .state
+                        .compare_exchange(REGISTERING, WAITING, AcqRel, Acquire);
+
+                    match res {
+                        Ok(_) => {
+                            // memory ordering: acquired self.state during CAS
+                            // - if previous wakes went through it syncs with
+                            //   their final release (`fetch_and`)
+                            // - if there was no previous wake the next wake
+                            //   will wake us, no sync needed.
+                        }
+                        Err(actual) => {
+                            // This branch can only be reached if at least one
+                            // concurrent thread called `wake`. In this
+                            // case, `actual` **must** be `REGISTERING |
+                            // `WAKING`.
+                            debug_assert_eq!(actual, REGISTERING | WAKING);
+
+                            // Take the waker to wake once the atomic operation has
+                            // completed.
+                            let waker = (*self.waker.get()).take().unwrap();
+
+                            // We need to return to WAITING state (clear our lock and
+                            // concurrent WAKING flag). This needs to acquire all
+                            // WAKING fetch_or releases and it needs to release our
+                            // update to self.waker, so we need a `swap` operation.
+                            self.state.swap(WAITING, AcqRel);
+
+                            // memory ordering: we acquired the state for all
+                            // concurrent wakes, but future wakes might still
+                            // need to wake us in case we can't make progress
+                            // from the pending wakes.
+                            //
+                            // So we simply schedule to come back later (we could
+                            // also simply leave the registration in place above).
+                            waker.wake();
+                        }
+                    }
+                }
+            }
+            WAKING => {
+                // Currently in the process of waking the task, i.e.,
+                // `wake` is currently being called on the old task handle.
+                //
+                // memory ordering: we acquired the state for all
+                // concurrent wakes, but future wakes might still
+                // need to wake us in case we can't make progress
+                // from the pending wakes.
+                //
+                // So we simply schedule to come back later (we
+                // could also spin here trying to acquire the lock
+                // to register).
+                waker.wake_by_ref();
+            }
+            state => {
+                // In this case, a concurrent thread is holding the
+                // "registering" lock. This probably indicates a bug in the
+                // caller's code as racing to call `register` doesn't make much
+                // sense.
+                //
+                // memory ordering: don't care. a concurrent register() is going
+                // to succeed and provide proper memory ordering.
+                //
+                // We just want to maintain memory safety. It is ok to drop the
+                // call to `register`.
+                debug_assert!(state == REGISTERING || state == REGISTERING | WAKING);
+            }
+        }
+    }
+
+    /// Calls `wake` on the last `Waker` passed to `register`.
+    ///
+    /// If `register` has not been called yet, then this does nothing.
+    pub fn wake(&self) {
+        if let Some(waker) = self.take() {
+            waker.wake();
+        }
+    }
+
+    /// Returns the last `Waker` passed to `register`, so that the user can wake it.
+    ///
+    ///
+    /// Sometimes, just waking the AtomicWaker is not fine grained enough. This allows the user
+    /// to take the waker and then wake it separately, rather than performing both steps in one
+    /// atomic action.
+    ///
+    /// If a waker has not been registered, this returns `None`.
+    pub fn take(&self) -> Option<Waker> {
+        // AcqRel ordering is used in order to acquire the value of the `task`
+        // cell as well as to establish a `release` ordering with whatever
+        // memory the `AtomicWaker` is associated with.
+        match self.state.fetch_or(WAKING, AcqRel) {
+            WAITING => {
+                // The waking lock has been acquired.
+                let waker = unsafe { (*self.waker.get()).take() };
+
+                // Release the lock
+                self.state.fetch_and(!WAKING, Release);
+
+                waker
+            }
+            state => {
+                // There is a concurrent thread currently updating the
+                // associated task.
+                //
+                // Nothing more to do as the `WAKING` bit has been set. It
+                // doesn't matter if there are concurrent registering threads or
+                // not.
+                //
+                debug_assert!(
+                    state == REGISTERING || state == REGISTERING | WAKING || state == WAKING
+                );
+                None
+            }
+        }
+    }
+}
+
+impl Default for AtomicWaker {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl fmt::Debug for AtomicWaker {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "AtomicWaker")
+    }
+}
+
+unsafe impl Send for AtomicWaker {}
+unsafe impl Sync for AtomicWaker {}

--- a/core/src/runtime/schedular/atomic_waker.rs
+++ b/core/src/runtime/schedular/atomic_waker.rs
@@ -154,6 +154,7 @@ impl AtomicWaker {
     /// Create an `AtomicWaker`.
     pub const fn new() -> Self {
         // Make sure that task is Sync
+        #[allow(dead_code)]
         trait AssertSync: Sync {}
         impl AssertSync for Waker {}
 

--- a/core/src/runtime/schedular/queue.rs
+++ b/core/src/runtime/schedular/queue.rs
@@ -5,7 +5,7 @@ use std::{
     sync::atomic::{AtomicPtr, Ordering},
 };
 
-use atomic_waker::AtomicWaker;
+use super::atomic_waker::AtomicWaker;
 
 pub struct NodeHeader {
     next: AtomicPtr<NodeHeader>,

--- a/core/src/runtime/schedular/queue.rs
+++ b/core/src/runtime/schedular/queue.rs
@@ -1,0 +1,112 @@
+use std::{
+    cell::Cell,
+    pin::Pin,
+    ptr::{self, NonNull},
+    sync::atomic::{AtomicPtr, Ordering},
+};
+
+use atomic_waker::AtomicWaker;
+
+pub struct NodeHeader {
+    next: AtomicPtr<NodeHeader>,
+}
+
+impl NodeHeader {
+    pub fn new() -> NodeHeader {
+        NodeHeader {
+            next: AtomicPtr::new(ptr::null_mut()),
+        }
+    }
+}
+
+pub struct Queue {
+    waker: AtomicWaker,
+    head: AtomicPtr<NodeHeader>,
+    tail: Cell<*const NodeHeader>,
+    stub: NodeHeader,
+}
+
+unsafe impl Send for Queue {}
+unsafe impl Sync for Queue {}
+
+#[derive(Debug)]
+pub enum Pop {
+    Empty,
+    Value(NonNull<NodeHeader>),
+    Inconsistant,
+}
+
+/// Intrusive MPSC queue from 1024cores blog.
+/// Similar to the one used int the FuturesUnordered implementation
+impl Queue {
+    pub fn new() -> Self {
+        Queue {
+            waker: AtomicWaker::new(),
+            head: AtomicPtr::new(ptr::null_mut()),
+            tail: Cell::new(ptr::null_mut()),
+            stub: NodeHeader {
+                next: AtomicPtr::new(ptr::null_mut()),
+            },
+        }
+    }
+
+    pub fn waker(&self) -> &AtomicWaker {
+        &self.waker
+    }
+
+    pub unsafe fn init(self: Pin<&Self>) {
+        let ptr = &self.stub as *const _ as *mut _;
+        self.head.store(ptr, Ordering::Release);
+        self.tail.set(ptr);
+    }
+
+    /// # Safety
+    /// - node must be a valid pointer
+    /// - Queue must have been properly initialized.
+    pub unsafe fn push(self: Pin<&Self>, node: NonNull<NodeHeader>) {
+        node.as_ref().next.store(ptr::null_mut(), Ordering::Release);
+
+        let prev = self.get_ref().head.swap(node.as_ptr(), Ordering::AcqRel);
+
+        (*prev).next.store(node.as_ptr(), Ordering::Release);
+    }
+
+    /// # Safety
+    /// - Queue must have been properly initialized.
+    /// - Can only be called from a single thread.
+    pub unsafe fn pop(self: Pin<&Self>) -> Pop {
+        let mut tail = self.tail.get();
+        let mut next = (*tail).next.load(Ordering::Acquire);
+
+        if std::ptr::eq(tail, &self.get_ref().stub) {
+            if next.is_null() {
+                return Pop::Empty;
+            }
+
+            self.tail.set(next);
+            tail = next;
+            next = (*next).next.load(std::sync::atomic::Ordering::Acquire);
+        }
+
+        if !next.is_null() {
+            self.tail.set(next);
+            return Pop::Value(NonNull::new_unchecked(tail as *mut NodeHeader));
+        }
+
+        let head = self.head.load(Ordering::Acquire);
+        if !std::ptr::eq(head, tail) {
+            return Pop::Inconsistant;
+        }
+
+        self.push(NonNull::from(&self.get_ref().stub));
+
+        next = (*tail).next.load(Ordering::Acquire);
+
+        if !next.is_null() {
+            self.tail.set(next);
+            return Pop::Value(NonNull::new_unchecked(tail as *mut NodeHeader));
+        }
+
+        Pop::Empty
+    }
+}

--- a/core/src/runtime/schedular/vtable.rs
+++ b/core/src/runtime/schedular/vtable.rs
@@ -1,0 +1,41 @@
+use std::{
+    future::Future,
+    pin::Pin,
+    ptr::NonNull,
+    sync::Arc,
+    task::{Context, Poll},
+};
+
+use super::Task;
+
+#[derive(Debug, Clone)]
+pub(crate) struct VTable {
+    pub(crate) task_drive: unsafe fn(NonNull<Task<u8>>, cx: &mut Context) -> Poll<()>,
+    pub(crate) task_drop: unsafe fn(NonNull<Task<u8>>),
+}
+
+impl VTable {
+    pub const fn get<F: Future<Output = ()>>() -> &'static VTable {
+        trait HasVTable {
+            const V_TABLE: VTable;
+        }
+
+        impl<F: Future<Output = ()>> HasVTable for F {
+            const V_TABLE: VTable = VTable {
+                task_drop: VTable::drop::<F>,
+                task_drive: VTable::drive::<F>,
+            };
+        }
+
+        &<F as HasVTable>::V_TABLE
+    }
+
+    unsafe fn drop<F: Future<Output = ()>>(ptr: NonNull<Task<u8>>) {
+        Arc::decrement_strong_count(ptr.cast::<Task<F>>().as_ptr())
+    }
+
+    unsafe fn drive<F: Future<Output = ()>>(ptr: NonNull<Task<u8>>, cx: &mut Context) -> Poll<()> {
+        let ptr = ptr.cast::<Task<F>>();
+        Pin::new_unchecked(&mut (*ptr.as_ref().future.get())).poll(cx)
+    }
+}

--- a/core/src/runtime/schedular/waker.rs
+++ b/core/src/runtime/schedular/waker.rs
@@ -1,0 +1,62 @@
+use std::{
+    pin::Pin,
+    ptr::NonNull,
+    sync::{atomic::Ordering, Arc},
+    task::{RawWaker, RawWakerVTable, Waker},
+};
+
+use super::Task;
+
+unsafe fn schedular_clone(ptr: *const ()) -> RawWaker {
+    Arc::increment_strong_count(ptr.cast::<Task<u8>>());
+    RawWaker::new(ptr.cast(), &SCHEDULAR_WAKER_V_TABLE)
+}
+
+unsafe fn schedular_wake(ptr: *const ()) {
+    let task = NonNull::new_unchecked(ptr as *mut ()).cast::<Task<u8>>();
+
+    if task
+        .as_ref()
+        .body
+        .queued
+        .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
+        .is_err()
+    {
+        // Already awoken, skip!
+        schedular_drop(ptr);
+        return;
+    }
+
+    // retrieve the queue, if already dropped, just return as we don't need to awake anything.
+    let Some(queue) = task.as_ref().body.queue.upgrade() else {
+        schedular_drop(ptr);
+        return;
+    };
+
+    // push to the que
+    Pin::new_unchecked(&*queue).push(task.cast());
+
+    // wake up the schedular.
+    queue.waker().wake()
+}
+
+unsafe fn schedular_wake_ref(ptr: *const ()) {
+    Arc::increment_strong_count(ptr.cast::<Task<u8>>());
+    schedular_wake(ptr)
+}
+
+unsafe fn schedular_drop(ptr: *const ()) {
+    let ptr = ptr.cast::<Task<u8>>();
+    ((*ptr).body.vtable.task_drop)(NonNull::new_unchecked(ptr as *mut _))
+}
+
+static SCHEDULAR_WAKER_V_TABLE: RawWakerVTable = RawWakerVTable::new(
+    schedular_clone,
+    schedular_wake,
+    schedular_wake_ref,
+    schedular_drop,
+);
+
+pub unsafe fn get(ptr: NonNull<Task<u8>>) -> Waker {
+    unsafe { Waker::from_raw(RawWaker::new(ptr.as_ptr().cast(), &SCHEDULAR_WAKER_V_TABLE)) }
+}


### PR DESCRIPTION
Introduces a new scheduler for futures that is more efficient.

Unlike the old scheduler which polls every future when being woken up, this scheduler only polls the futures which where actually awoken, preventing quadratic complexity for polling futures. 