### PR TITLE
Add bindings for aarch64-linux-android

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,7 @@ members = [
     "macro",
     "examples/native-module",
     "examples/module-loader",
+    "examples/rquickjs-cli",
 ]
 
 [features]

--- a/examples/rquickjs-cli/Cargo.toml
+++ b/examples/rquickjs-cli/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "rquickjs-cli"
+version = "0.1.0"
+authors = ["K. <kayo@illumium.org>"]
+edition = "2018"
+publish = false
+
+[dependencies.rquickjs]
+path = "../.."

--- a/examples/rquickjs-cli/src/main.rs
+++ b/examples/rquickjs-cli/src/main.rs
@@ -1,0 +1,42 @@
+use std::io::{stdout, Write};
+
+use rquickjs::{Context, Function, Object, Result, Runtime, Value};
+
+fn print(s: String) {
+    println!("{s}");
+}
+
+fn main() -> Result<()> {
+    let rt = Runtime::new()?;
+    let ctx = Context::full(&rt)?;
+
+    ctx.with(|ctx| -> Result<()> {
+        let global = ctx.globals();
+        global.set(
+            "print",
+            Function::new(ctx.clone(), print)?.with_name("log")?,
+        )?;
+        ctx.eval::<(), _>(
+            r#"
+globalThis.console = {
+  log(v){
+    globalThis.print(`${v}`);
+  }
+}
+"#,
+        )?;
+
+        let console: Object = global.get("console")?;
+        let js_log: Function = console.get("log")?;
+        loop {
+            let mut input = String::new();
+            stdout().write(b"> ")?;
+            stdout().flush()?;
+            std::io::stdin().read_line(&mut input)?;
+            let ret = ctx.eval::<Value, _>(input.as_bytes())?;
+            js_log.call::<(Value<'_>,), ()>((ret,))?;
+        }
+    })?;
+
+    Ok(())
+}


### PR DESCRIPTION

Although you can use the bindgen feature https://github.com/DelSkayn/rquickjs/issues/266 , bindgen_rs fails to compile in some scenarios, adding aarch64-linux-android will make compiling faster and easier.