### PR TITLE
Remove #[non_exhaustive] from EvalOptions

### DIFF
--- a/core/src/context/ctx.rs
+++ b/core/src/context/ctx.rs
@@ -17,7 +17,6 @@ use crate::{
 };
 
 /// Eval options.
-#[non_exhaustive]
 pub struct EvalOptions {
     /// Global code.
     pub global: bool,


### PR DESCRIPTION
I saw this was added in 0.6.0 update

Right now we can't eval as a promise but apply non-strict or non-global for instance.

