### PR TITLE
Fix intrinsic loading order

### DIFF
--- a/core/src/context/base.rs
+++ b/core/src/context/base.rs
@@ -52,9 +52,9 @@ impl Context {
         let guard = runtime.inner.lock();
         let ctx = NonNull::new(unsafe { qjs::JS_NewContextRaw(guard.rt.as_ptr()) })
             .ok_or_else(|| Error::Allocation)?;
-        unsafe { I::add_intrinsic(ctx) };
         // rquickjs assumes the base objects exist, so we allways need to add this.
         unsafe { intrinsic::Base::add_intrinsic(ctx) };
+        unsafe { I::add_intrinsic(ctx) };
         unsafe { Self::init_raw(ctx.as_ptr()) }
         let res = Inner {
             ctx,


### PR DESCRIPTION
It is very sensible that since v0.6, the `BaseObject` intrinsic is always loaded. However, in a custom setup, the `BaseObject` intrinsic is loaded _after_ the custom intrinsics, which means all the custom intrinsics cannot assume `BaseObject`. If `BaseObject` is added to the list of custom intrinsics, `BaseObject` gets loaded twice, which causes a SIGABORT.

Additionally, `All` still contains `Base`, which similarly causes `SIGABORT`.

This PR loads `Base` _before_ the custom intrinsics. It also removes `Base` from `All` (and adds some tests for this).