### PR TITLE
Fix some issues in the schedular

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -194,7 +194,7 @@ jobs:
             rust: stable
             target: x86_64-pc-windows-msvc
             features: full-async
-          - task: bindings
+          - task: test 
             os: windows-latest
             rust: stable
             target: x86_64-pc-windows-msvc

--- a/core/src/allocator.rs
+++ b/core/src/allocator.rs
@@ -4,6 +4,7 @@ use crate::qjs;
 use std::ptr;
 
 mod rust;
+
 pub use rust::RustAllocator;
 
 /// Raw memory pointer

--- a/core/src/class.rs
+++ b/core/src/class.rs
@@ -1,8 +1,10 @@
 //! JavaScript classes defined from Rust.
 
 use crate::{
-    function::StaticJsFn, qjs, value::Constructor, Ctx, Error, FromJs, IntoJs, Object, Outlive,
-    Result, Value,
+    function::StaticJsFn,
+    qjs::{self, JS_VALUE_GET_TAG},
+    value::Constructor,
+    Ctx, Error, FromJs, IntoJs, Object, Outlive, Result, Value,
 };
 use std::{
     ffi::CString,
@@ -12,16 +14,15 @@ use std::{
     ptr::{self, NonNull},
 };
 
-mod id;
-pub use id::ClassId;
-
 mod cell;
+mod ffi;
+mod id;
+mod trace;
+
 pub use cell::{
     Borrow, BorrowMut, JsCell, Mutability, OwnedBorrow, OwnedBorrowMut, Readable, Writable,
 };
-mod ffi;
-mod trace;
-use rquickjs_sys::JS_VALUE_GET_TAG;
+pub use id::ClassId;
 pub use trace::{Trace, Tracer};
 #[doc(hidden)]
 pub mod impl_;

--- a/core/src/class/cell.rs
+++ b/core/src/class/cell.rs
@@ -1,13 +1,11 @@
+use super::{Class, JsClass};
+use crate::{result::BorrowError, Ctx, Error, FromJs, IntoJs, Value};
 use std::{
     cell::{Cell, UnsafeCell},
     marker::PhantomData,
     mem::ManuallyDrop,
     ops::{Deref, DerefMut},
 };
-
-use crate::{result::BorrowError, Ctx, Error, FromJs, IntoJs, Value};
-
-use super::{Class, JsClass};
 
 /// A trait to allow classes to choose there borrowing implementation.
 ///

--- a/core/src/class/ffi.rs
+++ b/core/src/class/ffi.rs
@@ -1,8 +1,6 @@
-use std::mem;
-
-use crate::{class::JsCell, qjs};
-
 use super::{JsClass, Mutability, Tracer};
+use crate::{class::JsCell, qjs};
+use std::mem;
 
 /// FFI finalizer, destroying the object once it is delete by the Gc.
 pub(crate) unsafe extern "C" fn finalizer<'js, C: JsClass<'js>>(

--- a/core/src/class/id.rs
+++ b/core/src/class/id.rs
@@ -1,6 +1,5 @@
-use std::{cell::Cell, sync::Once};
-
 use crate::qjs;
+use std::{cell::Cell, sync::Once};
 
 /// The type of identifier of class
 #[cfg_attr(feature = "doc-cfg", doc(cfg(feature = "classes")))]

--- a/core/src/class/impl_.rs
+++ b/core/src/class/impl_.rs
@@ -1,8 +1,7 @@
 //! Helper classes and functions for use inside the macros.
 
-use std::marker::PhantomData;
-
 use crate::{value::Constructor, Ctx, Object, Result};
+use std::marker::PhantomData;
 
 /// Trait used for borrow specialization for implementing methods without access to the class.
 pub trait MethodImplementor<T>: Sized {

--- a/core/src/class/trace.rs
+++ b/core/src/class/trace.rs
@@ -1,11 +1,9 @@
+use super::JsClass;
+use crate::{markers::Invariant, qjs, Class, Ctx, Module, Value};
 use std::marker::PhantomData;
 
 #[cfg(feature = "either")]
 use either::{Either, Left, Right};
-
-use crate::{markers::Invariant, qjs, Class, Ctx, Module, Value};
-
-use super::JsClass;
 
 /// A trait for classes for tracing references to QuickJS objects.
 ///

--- a/core/src/context.rs
+++ b/core/src/context.rs
@@ -1,10 +1,12 @@
 //! JS Contexts related types.
 
+mod base;
 mod builder;
-pub use builder::{intrinsic, ContextBuilder, Intrinsic};
 mod ctx;
 mod r#ref;
-pub use ctx::{Ctx, EvalOptions};
+
+#[cfg(feature = "futures")]
+mod r#async;
 #[cfg(feature = "multi-ctx")]
 mod multi_with_impl;
 
@@ -20,10 +22,9 @@ pub trait MultiWith<'js> {
     fn with<R, F: FnOnce(Self::Arg) -> R>(self, f: F) -> R;
 }
 
-mod base;
 pub use base::Context;
+pub use builder::{intrinsic, ContextBuilder, Intrinsic};
+pub use ctx::{Ctx, EvalOptions};
 
-#[cfg(feature = "futures")]
-mod r#async;
 #[cfg(feature = "futures")]
 pub use r#async::AsyncContext;

--- a/core/src/context/async.rs
+++ b/core/src/context/async.rs
@@ -1,12 +1,10 @@
+use super::{intrinsic, r#ref::ContextRef, ContextBuilder, Intrinsic};
+use crate::{markers::ParallelSend, qjs, runtime::AsyncRuntime, Ctx, Error, Result};
 use std::{future::Future, mem, pin::Pin, ptr::NonNull};
 
-use crate::{markers::ParallelSend, qjs, runtime::AsyncRuntime, Ctx, Error, Result};
-
-use self::future::WithFuture;
-
-use super::{intrinsic, r#ref::ContextRef, ContextBuilder, Intrinsic};
-
 mod future;
+
+use future::WithFuture;
 
 /// A macro for safely using an asynchronous context while capturing the environment.
 ///

--- a/core/src/context/base.rs
+++ b/core/src/context/base.rs
@@ -1,8 +1,6 @@
-use std::{mem, ptr::NonNull};
-
-use crate::{class::Class, function::RustFunction, qjs, Ctx, Error, Result, Runtime};
-
 use super::{intrinsic, r#ref::ContextRef, ContextBuilder, Intrinsic};
+use crate::{class::Class, function::RustFunction, qjs, Ctx, Error, Result, Runtime};
+use std::{mem, ptr::NonNull};
 
 pub(crate) struct Inner {
     pub(crate) ctx: NonNull<qjs::JSContext>,

--- a/core/src/context/ctx.rs
+++ b/core/src/context/ctx.rs
@@ -1,3 +1,5 @@
+#[cfg(feature = "futures")]
+use std::future::Future;
 use std::{
     ffi::{CStr, CString},
     fs,
@@ -5,9 +7,6 @@ use std::{
     path::Path,
     ptr::NonNull,
 };
-
-#[cfg(feature = "futures")]
-use std::future::Future;
 
 #[cfg(feature = "futures")]
 use crate::AsyncContext;

--- a/core/src/context/ctx.rs
+++ b/core/src/context/ctx.rs
@@ -11,8 +11,8 @@ use std::{
 #[cfg(feature = "futures")]
 use crate::AsyncContext;
 use crate::{
-    atom::PredefinedAtom, markers::Invariant, qjs, runtime::raw::Opaque, Atom, Context, Error,
-    FromJs, Function, IntoJs, Object, Promise, Result, String, Value,
+    atom::PredefinedAtom, cstr, markers::Invariant, qjs, runtime::raw::Opaque, Atom, Context,
+    Error, FromJs, Function, IntoJs, Object, Promise, Result, String, Value,
 };
 
 /// Eval options.

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -40,6 +40,7 @@ macro_rules! cstr {
 
 pub mod markers;
 mod result;
+mod util;
 pub use result::{CatchResultExt, CaughtError, CaughtResult, Error, Result, ThrowResultExt};
 mod safe_ref;
 pub(crate) use safe_ref::*;

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -6,6 +6,48 @@
 #![allow(clippy::needless_lifetimes)]
 #![cfg_attr(feature = "doc-cfg", feature(doc_cfg))]
 
+pub(crate) use std::{result::Result as StdResult, string::String as StdString};
+
+pub mod markers;
+mod persistent;
+mod result;
+mod safe_ref;
+mod util;
+mod value;
+pub(crate) use safe_ref::*;
+pub mod runtime;
+pub use runtime::Runtime;
+pub mod context;
+pub use context::{Context, Ctx};
+pub mod class;
+pub use class::Class;
+pub use persistent::{Outlive, Persistent};
+pub use result::{CatchResultExt, CaughtError, CaughtResult, Error, Result, ThrowResultExt};
+pub use value::{
+    array, atom, convert, function, module, object, promise, Array, Atom, BigInt, Coerced,
+    Exception, Filter, FromAtom, FromIteratorJs, FromJs, Function, IntoAtom, IntoJs, IteratorJs,
+    Module, Null, Object, Promise, String, Symbol, Type, Undefined, Value,
+};
+
+#[cfg(feature = "allocator")]
+#[cfg_attr(feature = "doc-cfg", doc(cfg(feature = "allocator")))]
+pub mod allocator;
+#[cfg(feature = "loader")]
+#[cfg_attr(feature = "doc-cfg", doc(cfg(feature = "loader")))]
+pub mod loader;
+
+#[cfg(feature = "futures")]
+#[cfg_attr(feature = "doc-cfg", doc(cfg(feature = "futures")))]
+pub use context::AsyncContext;
+#[cfg(feature = "multi-ctx")]
+pub use context::MultiWith;
+#[cfg(feature = "futures")]
+#[cfg_attr(feature = "doc-cfg", doc(cfg(feature = "futures")))]
+pub use runtime::AsyncRuntime;
+#[cfg(feature = "array-buffer")]
+#[cfg_attr(feature = "doc-cfg", doc(cfg(feature = "array-buffer")))]
+pub use value::{ArrayBuffer, TypedArray};
+
 //#[doc(hidden)]
 pub mod qjs {
     //! Native low-level bindings
@@ -38,55 +80,12 @@ macro_rules! cstr {
     }};
 }
 
-pub mod markers;
-mod result;
-mod util;
-pub use result::{CatchResultExt, CaughtError, CaughtResult, Error, Result, ThrowResultExt};
-mod safe_ref;
-pub(crate) use safe_ref::*;
-pub mod runtime;
-#[cfg(feature = "futures")]
-#[cfg_attr(feature = "doc-cfg", doc(cfg(feature = "futures")))]
-pub use runtime::AsyncRuntime;
-pub use runtime::Runtime;
-pub mod context;
-#[cfg(feature = "futures")]
-#[cfg_attr(feature = "doc-cfg", doc(cfg(feature = "futures")))]
-pub use context::AsyncContext;
-#[cfg(feature = "multi-ctx")]
-pub use context::MultiWith;
-pub use context::{Context, Ctx};
-mod persistent;
-mod value;
-pub use persistent::{Outlive, Persistent};
-pub use value::{
-    array, atom, convert, function, module, object, promise, Array, Atom, BigInt, Coerced,
-    Exception, Filter, FromAtom, FromIteratorJs, FromJs, Function, IntoAtom, IntoJs, IteratorJs,
-    Module, Null, Object, Promise, String, Symbol, Type, Undefined, Value,
-};
-
-pub mod class;
-pub use class::Class;
-
-#[cfg(feature = "array-buffer")]
-#[cfg_attr(feature = "doc-cfg", doc(cfg(feature = "array-buffer")))]
-pub use value::{ArrayBuffer, TypedArray};
-
-pub(crate) use std::{result::Result as StdResult, string::String as StdString};
-
-#[cfg(feature = "allocator")]
-#[cfg_attr(feature = "doc-cfg", doc(cfg(feature = "allocator")))]
-pub mod allocator;
-
-#[cfg(feature = "loader")]
-#[cfg_attr(feature = "doc-cfg", doc(cfg(feature = "loader")))]
-pub mod loader;
-
 pub mod prelude {
     //! A group of often used types.
     #[cfg(feature = "multi-ctx")]
     pub use crate::context::MultiWith;
     pub use crate::{
+        context::Ctx,
         convert::{Coerced, FromAtom, FromIteratorJs, FromJs, IntoAtom, IntoJs, IteratorJs, List},
         function::{
             Exhaustive, Flat, Func, FuncArg, IntoArg, IntoArgs, MutFn, OnceFn, Opt, Rest, This,

--- a/core/src/loader.rs
+++ b/core/src/loader.rs
@@ -4,31 +4,28 @@ use std::{ffi::CStr, ptr};
 
 use crate::{module::Declared, qjs, Ctx, Module, Result};
 
-mod builtin_resolver;
-pub use builtin_resolver::BuiltinResolver;
-
-mod file_resolver;
-pub use file_resolver::FileResolver;
-
-mod script_loader;
-pub use script_loader::ScriptLoader;
-
 mod builtin_loader;
-pub use builtin_loader::BuiltinLoader;
-
-mod module_loader;
-pub use module_loader::ModuleLoader;
-
+mod builtin_resolver;
+pub mod bundle;
 mod compile;
-pub use compile::Compile;
+mod file_resolver;
+mod module_loader;
+mod script_loader;
+mod util;
 
 #[cfg(feature = "dyn-load")]
 mod native_loader;
+
+pub use builtin_loader::BuiltinLoader;
+pub use builtin_resolver::BuiltinResolver;
+pub use compile::Compile;
+pub use file_resolver::FileResolver;
+pub use module_loader::ModuleLoader;
+pub use script_loader::ScriptLoader;
+
 #[cfg(feature = "dyn-load")]
 #[cfg_attr(feature = "doc-cfg", doc(cfg(feature = "dyn-load")))]
 pub use native_loader::NativeLoader;
-
-pub mod bundle;
 
 #[cfg(feature = "phf")]
 /// The type of bundle that the `embed!` macro returns
@@ -37,8 +34,6 @@ pub type Bundle = bundle::Bundle<bundle::PhfBundleData<&'static [u8]>>;
 #[cfg(not(feature = "phf"))]
 /// The type of bundle that the `embed!` macro returns
 pub type Bundle = bundle::Bundle<bundle::ScaBundleData<&'static [u8]>>;
-
-mod util;
 
 /// Module resolver interface
 #[cfg_attr(feature = "doc-cfg", doc(cfg(feature = "loader")))]

--- a/core/src/result.rs
+++ b/core/src/result.rs
@@ -11,13 +11,12 @@ use std::{
 
 #[cfg(feature = "futures")]
 use crate::context::AsyncContext;
+#[cfg(feature = "array-buffer")]
+use crate::value::array_buffer::AsSliceError;
 use crate::{
     atom::PredefinedAtom, qjs, value::exception::ERROR_FORMAT_STR, Context, Ctx, Exception, Object,
     StdResult, StdString, Type, Value,
 };
-
-#[cfg(feature = "array-buffer")]
-use crate::value::array_buffer::AsSliceError;
 
 /// Result type used throughout the library.
 pub type Result<T> = StdResult<T, Error>;

--- a/core/src/runtime.rs
+++ b/core/src/runtime.rs
@@ -1,9 +1,19 @@
 //! QuickJS runtime related types.
 
-pub(crate) mod raw;
-
+#[cfg(feature = "futures")]
+mod r#async;
 mod base;
+pub(crate) mod raw;
+#[cfg(feature = "futures")]
+pub(crate) mod schedular;
+
 pub use base::{Runtime, WeakRuntime};
+#[cfg(feature = "futures")]
+pub(crate) use r#async::InnerRuntime;
+#[cfg(feature = "futures")]
+pub use r#async::{AsyncRuntime, AsyncWeakRuntime};
+#[cfg(feature = "futures")]
+mod spawner;
 
 /// The type of the interrupt handler.
 #[cfg(not(feature = "parallel"))]
@@ -11,17 +21,6 @@ pub type InterruptHandler = Box<dyn FnMut() -> bool + 'static>;
 /// The type of the interrupt handler.
 #[cfg(feature = "parallel")]
 pub type InterruptHandler = Box<dyn FnMut() -> bool + Send + 'static>;
-
-#[cfg(feature = "futures")]
-mod r#async;
-#[cfg(feature = "futures")]
-pub(crate) use r#async::InnerRuntime;
-#[cfg(feature = "futures")]
-pub use r#async::{AsyncRuntime, AsyncWeakRuntime};
-#[cfg(feature = "futures")]
-pub(crate) mod schedular;
-#[cfg(feature = "futures")]
-mod spawner;
 
 /// A struct with information about the runtimes memory usage.
 pub type MemoryUsage = crate::qjs::JSMemoryUsage;

--- a/core/src/runtime.rs
+++ b/core/src/runtime.rs
@@ -19,7 +19,7 @@ pub(crate) use r#async::InnerRuntime;
 #[cfg(feature = "futures")]
 pub use r#async::{AsyncRuntime, AsyncWeakRuntime};
 #[cfg(feature = "futures")]
-mod schedular;
+pub(crate) mod schedular;
 #[cfg(feature = "futures")]
 mod spawner;
 

--- a/core/src/runtime/async.rs
+++ b/core/src/runtime/async.rs
@@ -11,6 +11,12 @@ use std::sync::mpsc::{self, Receiver, Sender};
 
 use async_lock::Mutex;
 
+use super::{
+    raw::{Opaque, RawRuntime},
+    schedular::SchedularPoll,
+    spawner::DriveFuture,
+    InterruptHandler, MemoryUsage,
+};
 #[cfg(feature = "allocator")]
 use crate::allocator::Allocator;
 #[cfg(feature = "loader")]
@@ -23,13 +29,6 @@ use crate::{
 use crate::{
     qjs,
     util::{AssertSendFuture, AssertSyncFuture},
-};
-
-use super::{
-    raw::{Opaque, RawRuntime},
-    schedular::SchedularPoll,
-    spawner::DriveFuture,
-    InterruptHandler, MemoryUsage,
 };
 
 #[derive(Debug)]

--- a/core/src/runtime/async.rs
+++ b/core/src/runtime/async.rs
@@ -559,24 +559,6 @@ mod test {
 
                 globals.set("inc_count", Func::from(inc_count))?;
 
-                globals.set(
-                    "blockUntilComplete",
-                    Func::from(move |ctx, promise| {
-                        struct Args<'js>(Ctx<'js>, Promise<'js>);
-                        let Args(ctx, promise) = Args(ctx, promise);
-
-                        loop {
-                            if let Some(x) = promise.result::<Value>() {
-                                return x;
-                            }
-
-                            if !ctx.execute_pending_job() {
-                                return Undefined.into_js(&ctx);
-                            }
-                        }
-                    }),
-                )?;
-
                 globals.set("setTimeout", Func::from(set_timeout_spawn))?;
                 let options = EvalOptions{
                     promise: true,

--- a/core/src/runtime/base.rs
+++ b/core/src/runtime/base.rs
@@ -1,17 +1,15 @@
 //! QuickJS runtime related types.
 
-#[cfg(feature = "loader")]
-use crate::loader::{Loader, Resolver};
-use crate::{result::JobException, Context, Error, Mut, Ref, Result, Weak};
-use std::{ffi::CString, ptr::NonNull, result::Result as StdResult};
-
-#[cfg(feature = "allocator")]
-use crate::allocator::Allocator;
-
 use super::{
     raw::{Opaque, RawRuntime},
     InterruptHandler, MemoryUsage,
 };
+#[cfg(feature = "allocator")]
+use crate::allocator::Allocator;
+#[cfg(feature = "loader")]
+use crate::loader::{Loader, Resolver};
+use crate::{result::JobException, Context, Error, Mut, Ref, Result, Weak};
+use std::{ffi::CString, ptr::NonNull, result::Result as StdResult};
 
 /// A weak handle to the runtime.
 ///

--- a/core/src/runtime/raw.rs
+++ b/core/src/runtime/raw.rs
@@ -3,13 +3,11 @@ use std::{
     result::Result as StdResult,
 };
 
-use rquickjs_sys::size_t;
-
 #[cfg(feature = "allocator")]
 use crate::allocator::{Allocator, AllocatorHolder};
 #[cfg(feature = "loader")]
 use crate::loader::{Loader, LoaderHolder, Resolver};
-use crate::qjs;
+use crate::qjs::{self, size_t};
 
 #[cfg(feature = "futures")]
 use super::spawner::Spawner;

--- a/core/src/runtime/schedular.rs
+++ b/core/src/runtime/schedular.rs
@@ -1,102 +1,50 @@
 use std::{
-    cell::{Cell, UnsafeCell},
+    cell::Cell,
     future::Future,
-    mem::{offset_of, ManuallyDrop},
+    mem::offset_of,
     pin::Pin,
-    ptr::NonNull,
-    sync::{
-        atomic::{AtomicBool, Ordering},
-        Arc, Weak,
-    },
+    sync::{atomic::Ordering, Arc},
     task::{Context, Poll},
 };
+
+mod task;
 
 mod queue;
 use queue::Queue;
 
 mod vtable;
-use vtable::VTable;
 
 mod waker;
 
 mod atomic_waker;
 
-use self::queue::NodeHeader;
+use crate::{
+    runtime::schedular::task::{ErasedTask, Task},
+    util::Defer,
+};
 
-use std::ops::{Deref, DerefMut};
+use self::task::ErasedTaskPtr;
 
-pub struct Defer<T, F: FnOnce(&mut T)> {
-    value: ManuallyDrop<T>,
-    f: Option<F>,
-}
-
-impl<T, F: FnOnce(&mut T)> Defer<T, F> {
-    pub fn new(value: T, func: F) -> Self {
-        Defer {
-            value: ManuallyDrop::new(value),
-            f: Some(func),
-        }
-    }
-
-    pub fn take(mut self) -> T {
-        self.f = None;
-        unsafe { ManuallyDrop::take(&mut self.value) }
-    }
-}
-
-impl<T, F: FnOnce(&mut T)> Deref for Defer<T, F> {
-    type Target = T;
-
-    fn deref(&self) -> &Self::Target {
-        &self.value
-    }
-}
-
-impl<T, F: FnOnce(&mut T)> DerefMut for Defer<T, F> {
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut self.value
-    }
-}
-
-impl<T, F> Drop for Defer<T, F>
-where
-    F: FnOnce(&mut T),
-{
-    fn drop(&mut self) {
-        if let Some(x) = self.f.take() {
-            (x)(&mut *self.value);
-            unsafe { ManuallyDrop::drop(&mut self.value) }
-        }
-    }
-}
-
-#[repr(C)]
-struct Task<F> {
-    head: NodeHeader,
-    body: TaskBody,
-    future: UnsafeCell<F>,
-}
-
-// Seperate struct to not have everything be repr(C)
-struct TaskBody {
-    queue: Weak<Queue>,
-    vtable: &'static VTable,
-    // The double linked list of tasks.
-    next: Cell<Option<NonNull<Task<u8>>>>,
-    prev: Cell<Option<NonNull<Task<u8>>>>,
-    // wether the task is currently in the queue to be re-polled.
-    queued: AtomicBool,
-    done: Cell<bool>,
+pub enum SchedularPoll {
+    /// Returns that the schedular should yield back to the root schedular.
+    ShouldYield,
+    /// There was no work to be done.
+    Empty,
+    /// No work could be done.
+    Pending,
+    /// Work was done, but we didn't finish.
+    PendingProgress,
 }
 
 pub struct Schedular {
     len: Cell<usize>,
     should_poll: Arc<Queue>,
-    all_next: Cell<Option<NonNull<Task<u8>>>>,
-    all_prev: Cell<Option<NonNull<Task<u8>>>>,
+    all_next: Cell<Option<ErasedTaskPtr>>,
+    all_prev: Cell<Option<ErasedTaskPtr>>,
 }
 
 impl Schedular {
+    /// Create a new schedular.
     pub fn new() -> Self {
         let queue = Arc::new(Queue::new());
         unsafe {
@@ -110,6 +58,7 @@ impl Schedular {
         }
     }
 
+    /// Returns if there are no pending tasks.
     pub fn is_empty(&self) -> bool {
         self.all_next.get().is_none()
     }
@@ -123,36 +72,30 @@ impl Schedular {
     {
         let queue = Arc::downgrade(&self.should_poll);
 
-        debug_assert_eq!(offset_of!(Task<F>, future), offset_of!(Task<u8>, future));
+        // These should always be the same as task has a repr(C);
+        assert_eq!(offset_of!(Task<F>, head), offset_of!(Task<u8>, head));
+        assert_eq!(offset_of!(Task<F>, body), offset_of!(Task<u8>, body));
 
-        let task = Arc::new(Task {
-            head: NodeHeader::new(),
-            body: TaskBody {
-                queue,
-                vtable: VTable::get::<F>(),
-                next: Cell::new(None),
-                prev: Cell::new(None),
-                queued: AtomicBool::new(true),
-                done: Cell::new(false),
-            },
-            future: UnsafeCell::new(ManuallyDrop::new(f)),
-        });
+        let task = Arc::new(Task::new(queue, f));
 
         // One count for the all list and one for the should_poll list.
-        let task = NonNull::new_unchecked(Arc::into_raw(task) as *mut Task<F>).cast::<Task<u8>>();
-        Arc::increment_strong_count(task.as_ptr());
+        let task = ErasedTask::new(task);
+        self.push_task_to_all(task.clone());
 
-        self.push_task_to_all(task);
-
-        Pin::new_unchecked(&*self.should_poll).push(task.cast());
+        let task_ptr = ErasedTask::into_ptr(task);
+        Pin::new_unchecked(&*self.should_poll).push(task_ptr.as_node_ptr());
         self.len.set(self.len.get() + 1);
     }
 
-    unsafe fn push_task_to_all(&self, task: NonNull<Task<u8>>) {
-        task.as_ref().body.next.set(self.all_next.get());
+    /// Add a new task to the all task list.
+    /// The all task list owns a reference to the task while it is in the list.
+    unsafe fn push_task_to_all(&self, task: ErasedTask) {
+        let task = ErasedTask::into_ptr(task);
+
+        task.body().next.set(self.all_next.get());
 
         if let Some(x) = self.all_next.get() {
-            x.as_ref().body.prev.set(Some(task));
+            x.body().prev.set(Some(task));
         }
         self.all_next.set(Some(task));
         if self.all_prev.get().is_none() {
@@ -160,37 +103,33 @@ impl Schedular {
         }
     }
 
-    unsafe fn pop_task_all(&self, task: NonNull<Task<u8>>) {
-        task.as_ref().body.queued.store(true, Ordering::Release);
-        task.as_ref().body.done.set(true);
+    /// Removes the task from the all task list.
+    /// Dropping the ownership the list has.
+    unsafe fn pop_task_all(&self, task: ErasedTaskPtr) {
+        task.body().queued.store(true, Ordering::Release);
+        if !task.body().done.replace(true) {
+            task.task_drop();
+        }
 
         // detach the task from the all list
-        if let Some(next) = task.as_ref().body.next.get() {
-            next.as_ref().body.prev.set(task.as_ref().body.prev.get())
+        if let Some(next) = task.body().next.get() {
+            next.body().prev.set(task.body().prev.get())
         } else {
-            self.all_prev.set(task.as_ref().body.prev.get());
+            self.all_prev.set(task.body().prev.get());
         }
-        if let Some(prev) = task.as_ref().body.prev.get() {
-            prev.as_ref().body.next.set(task.as_ref().body.next.get())
+        if let Some(prev) = task.body().prev.get() {
+            prev.body().next.set(task.body().next.get())
         } else {
-            self.all_next.set(task.as_ref().body.next.get());
+            self.all_next.set(task.body().next.get());
         }
 
+        let _ = unsafe { ErasedTask::from_ptr(task) };
         // drop the ownership of the all list,
         // Task is now dropped or only owned by wakers or
-        Self::drop_task(task);
         self.len.set(self.len.get() - 1);
     }
 
-    unsafe fn drop_task(ptr: NonNull<Task<u8>>) {
-        (ptr.as_ref().body.vtable.task_drop)(ptr)
-    }
-
-    unsafe fn drive_task(ptr: NonNull<Task<u8>>, ctx: &mut Context) -> Poll<()> {
-        (ptr.as_ref().body.vtable.task_drive)(ptr, ctx)
-    }
-
-    pub unsafe fn poll(&self, cx: &mut Context) -> Poll<bool> {
+    pub unsafe fn poll(&self, cx: &mut Context) -> SchedularPoll {
         // During polling ownership is upheld by making sure arc counts are properly tranfered.
         // Both ques, should_poll and all, have ownership of the arc count.
         // Whenever a task is pushed onto the should_poll queue ownership is transfered.
@@ -199,76 +138,84 @@ impl Schedular {
 
         if self.is_empty() {
             // No tasks, nothing to be done.
-            return Poll::Ready(false);
+            return SchedularPoll::Empty;
         }
 
         self.should_poll.waker().register(cx.waker());
 
         let mut iteration = 0;
         let mut yielded = 0;
-        let mut pending = false;
 
         loop {
             // Popped a task, ownership taken from the que
             let cur = match Pin::new_unchecked(&*self.should_poll).pop() {
                 queue::Pop::Empty => {
-                    if pending {
-                        return Poll::Pending;
+                    if iteration > 0 {
+                        return SchedularPoll::PendingProgress;
                     } else {
-                        return Poll::Ready(iteration > 0);
+                        return SchedularPoll::Pending;
                     }
                 }
                 queue::Pop::Value(x) => x,
                 queue::Pop::Inconsistant => {
                     cx.waker().wake_by_ref();
-                    return Poll::Pending;
+                    return SchedularPoll::ShouldYield;
                 }
             };
 
-            let cur = cur.cast::<Task<u8>>();
+            // Take ownership of the task from the schedular.
+            let cur_ptr = ErasedTaskPtr::from_nonnull(cur.cast());
+            let cur = ErasedTask::from_ptr(cur_ptr);
 
-            if cur.as_ref().body.done.get() {
-                // Task was already done, we con drop the ownership we got from the que.
-                Self::drop_task(cur);
+            if cur.body().done.get() {
                 continue;
             }
 
-            let prev = cur.as_ref().body.queued.swap(false, Ordering::AcqRel);
+            let prev = cur.body().queued.swap(false, Ordering::AcqRel);
             assert!(prev);
 
-            // ownership transfered into the waker, which won't drop until the iteration completes.
+            // wakers owns cur until the end of the scope.
+            // So we can use cur_ptr until the end of the scope as both remain valid.
             let waker = waker::get(cur);
+            let mut ctx = Context::from_waker(&waker);
+
             // if drive_task panics we still want to remove the task from the list.
             // So handle it with a drop
-            let remove = Defer::new(self, |this| (*this).pop_task_all(cur));
-            let mut ctx = Context::from_waker(&waker);
+            let remove = Defer::new((), |_| self.pop_task_all(cur_ptr));
 
             iteration += 1;
 
-            match Self::drive_task(cur, &mut ctx) {
+            match cur_ptr.task_drive(&mut ctx) {
                 Poll::Ready(_) => {
                     // Nothing todo the defer will remove the task from the list.
                 }
                 Poll::Pending => {
                     // don't remove task from the list.
                     remove.take();
-                    pending = true;
-                    yielded += cur.as_ref().body.queued.load(Ordering::Relaxed) as usize;
+
+                    // we had a pending and test if a yielded future immediatily queued itself
+                    // again.
+                    yielded += cur_ptr.body().queued.load(Ordering::Relaxed) as usize;
+
+                    // If we polled all the futures atleas once,
+                    // or more then one future immediatily queued itself after being polled,
+                    // yield back to the parent schedular.
                     if yielded > 2 || iteration > self.len.get() {
                         cx.waker().wake_by_ref();
-                        return Poll::Pending;
+                        return SchedularPoll::ShouldYield;
                     }
                 }
             }
         }
     }
 
+    /// Remove all tasks from the list.
     pub fn clear(&self) {
         // Clear all pending futures from the all list
         let mut cur = self.all_next.get();
         while let Some(c) = cur {
             unsafe {
-                cur = c.as_ref().body.next.get();
+                cur = c.body().next.get();
                 self.pop_task_all(c)
             }
         }
@@ -283,7 +230,7 @@ impl Schedular {
                 }
             };
 
-            unsafe { Self::drop_task(cur.cast()) };
+            unsafe { ErasedTask::from_ptr(ErasedTaskPtr::from_nonnull(cur.cast())) };
         }
     }
 }

--- a/core/src/runtime/schedular.rs
+++ b/core/src/runtime/schedular.rs
@@ -7,21 +7,17 @@ use std::{
     task::{Context, Poll},
 };
 
-mod task;
-
-mod queue;
-use queue::Queue;
-
-mod vtable;
-
-mod waker;
-
 mod atomic_waker;
+mod queue;
+mod task;
+mod vtable;
+mod waker;
 
 use crate::{
     runtime::schedular::task::{ErasedTask, Task},
     util::Defer,
 };
+use queue::Queue;
 
 use self::task::ErasedTaskPtr;
 

--- a/core/src/runtime/schedular/atomic_waker.rs
+++ b/core/src/runtime/schedular/atomic_waker.rs
@@ -3,14 +3,11 @@
 //!
 //! All copyright of this file belongs to the futures authors.
 
-use core::cell::UnsafeCell;
-use core::fmt;
-use core::task::Waker;
-
-use atomic::AtomicUsize;
-use atomic::Ordering::{AcqRel, Acquire, Release};
-
-use core::sync::atomic;
+use atomic::{
+    AtomicUsize,
+    Ordering::{AcqRel, Acquire, Release},
+};
+use core::{cell::UnsafeCell, fmt, sync::atomic, task::Waker};
 
 /// A synchronization primitive for task wakeup.
 ///

--- a/core/src/runtime/schedular/task.rs
+++ b/core/src/runtime/schedular/task.rs
@@ -1,0 +1,134 @@
+use std::{
+    cell::{Cell, UnsafeCell},
+    future::Future,
+    mem::ManuallyDrop,
+    ptr::{addr_of_mut, NonNull},
+    sync::{atomic::AtomicBool, Arc, Weak},
+    task::{Context, Poll},
+};
+
+use super::{
+    queue::{NodeHeader, Queue},
+    vtable::VTable,
+};
+
+#[repr(C)]
+pub struct Task<F> {
+    /// Header for the intrusive list,
+    /// Must be first.
+    pub(crate) head: NodeHeader,
+    /// Data the schedular uses to run the future.
+    pub(crate) body: TaskBody,
+    /// The future itself.
+    pub(crate) future: UnsafeCell<ManuallyDrop<F>>,
+}
+
+impl<F: Future<Output = ()>> Task<F> {
+    pub fn new(queue: Weak<Queue>, f: F) -> Self {
+        Self {
+            head: NodeHeader::new(),
+            body: TaskBody {
+                queue,
+                vtable: VTable::get::<F>(),
+                next: Cell::new(None),
+                prev: Cell::new(None),
+                queued: AtomicBool::new(true),
+                done: Cell::new(false),
+            },
+            future: UnsafeCell::new(ManuallyDrop::new(f)),
+        }
+    }
+}
+
+// Seperate struct to not have everything in task be repr(C)
+pub struct TaskBody {
+    pub(crate) queue: Weak<Queue>,
+    pub(crate) vtable: &'static VTable,
+    // The double linked list of tasks.
+    pub(crate) next: Cell<Option<ErasedTaskPtr>>,
+    pub(crate) prev: Cell<Option<ErasedTaskPtr>>,
+    // wether the task is currently in the queue to be re-polled.
+    pub(crate) queued: AtomicBool,
+    pub(crate) done: Cell<bool>,
+}
+
+/// A raw pointer to a task with it's type erased.
+#[derive(Clone, Copy, Debug)]
+#[repr(transparent)]
+pub struct ErasedTaskPtr(NonNull<Task<()>>);
+
+impl ErasedTaskPtr {
+    pub fn from_nonnull(ptr: NonNull<Task<()>>) -> Self {
+        Self(ptr)
+    }
+
+    pub unsafe fn body<'a>(self) -> &'a TaskBody {
+        let ptr = self.0.as_ptr();
+        unsafe { &*addr_of_mut!((*ptr).body) }
+    }
+
+    pub fn as_node_ptr(self) -> NonNull<NodeHeader> {
+        self.0.cast()
+    }
+
+    pub fn as_nonnull(self) -> NonNull<Task<()>> {
+        self.0
+    }
+
+    pub unsafe fn task_drive(self, cx: &mut Context) -> Poll<()> {
+        unsafe { (self.body().vtable.task_drive)(self.0, cx) }
+    }
+
+    pub unsafe fn task_incr(self) {
+        unsafe { (self.body().vtable.task_incr)(self.0) }
+    }
+
+    pub unsafe fn task_decr(self) {
+        unsafe { (self.body().vtable.task_decr)(self.0) }
+    }
+
+    pub unsafe fn task_drop(self) {
+        unsafe { (self.body().vtable.task_drop)(self.0) }
+    }
+}
+
+/// An owning pointer to a task with it's type erased.
+pub struct ErasedTask(ErasedTaskPtr);
+
+impl ErasedTask {
+    pub unsafe fn from_ptr(ptr: ErasedTaskPtr) -> Self {
+        Self(ptr)
+    }
+
+    pub fn into_ptr(this: Self) -> ErasedTaskPtr {
+        let res = this.0;
+        std::mem::forget(this);
+        res
+    }
+
+    pub fn new<F>(task: Arc<Task<F>>) -> Self {
+        unsafe {
+            let ptr = NonNull::new_unchecked(Arc::into_raw(task) as *mut Task<F>).cast();
+            Self(ErasedTaskPtr(ptr))
+        }
+    }
+
+    pub fn body(&self) -> &TaskBody {
+        unsafe { self.0.body() }
+    }
+}
+
+impl Clone for ErasedTask {
+    fn clone(&self) -> Self {
+        unsafe {
+            self.0.task_incr();
+            Self(self.0)
+        }
+    }
+}
+
+impl Drop for ErasedTask {
+    fn drop(&mut self) {
+        unsafe { self.0.task_decr() }
+    }
+}

--- a/core/src/runtime/schedular/vtable.rs
+++ b/core/src/runtime/schedular/vtable.rs
@@ -1,5 +1,6 @@
 use std::{
     future::Future,
+    mem::ManuallyDrop,
     pin::Pin,
     ptr::NonNull,
     sync::Arc,
@@ -10,8 +11,10 @@ use super::Task;
 
 #[derive(Debug, Clone)]
 pub(crate) struct VTable {
-    pub(crate) task_drive: unsafe fn(NonNull<Task<u8>>, cx: &mut Context) -> Poll<()>,
-    pub(crate) task_drop: unsafe fn(NonNull<Task<u8>>),
+    pub(crate) task_drive: unsafe fn(NonNull<Task<()>>, cx: &mut Context) -> Poll<()>,
+    pub(crate) task_decr: unsafe fn(NonNull<Task<()>>),
+    pub(crate) task_incr: unsafe fn(NonNull<Task<()>>),
+    pub(crate) task_drop: unsafe fn(NonNull<Task<()>>),
 }
 
 impl VTable {
@@ -22,20 +25,31 @@ impl VTable {
 
         impl<F: Future<Output = ()>> HasVTable for F {
             const V_TABLE: VTable = VTable {
-                task_drop: VTable::drop::<F>,
+                task_decr: VTable::decr::<F>,
                 task_drive: VTable::drive::<F>,
+                task_incr: VTable::incr::<F>,
+                task_drop: VTable::drop::<F>,
             };
         }
 
         &<F as HasVTable>::V_TABLE
     }
 
-    unsafe fn drop<F: Future<Output = ()>>(ptr: NonNull<Task<u8>>) {
+    unsafe fn decr<F: Future<Output = ()>>(ptr: NonNull<Task<()>>) {
         Arc::decrement_strong_count(ptr.cast::<Task<F>>().as_ptr())
     }
 
-    unsafe fn drive<F: Future<Output = ()>>(ptr: NonNull<Task<u8>>, cx: &mut Context) -> Poll<()> {
+    unsafe fn incr<F: Future<Output = ()>>(ptr: NonNull<Task<()>>) {
+        Arc::increment_strong_count(ptr.cast::<Task<F>>().as_ptr())
+    }
+
+    unsafe fn drive<F: Future<Output = ()>>(ptr: NonNull<Task<()>>, cx: &mut Context) -> Poll<()> {
         let ptr = ptr.cast::<Task<F>>();
-        Pin::new_unchecked(&mut (*ptr.as_ref().future.get())).poll(cx)
+        Pin::new_unchecked(&mut *(*ptr.as_ref().future.get())).poll(cx)
+    }
+
+    unsafe fn drop<F: Future<Output = ()>>(ptr: NonNull<Task<()>>) {
+        let ptr = ptr.cast::<Task<F>>();
+        unsafe { ManuallyDrop::drop(&mut (*ptr.as_ref().future.get())) }
     }
 }

--- a/core/src/runtime/spawner.rs
+++ b/core/src/runtime/spawner.rs
@@ -1,14 +1,17 @@
 use std::{
     future::Future,
-    pin::{pin, Pin},
-    task::{ready, Poll, Waker},
+    pin::Pin,
+    task::{ready, Context, Poll, Waker},
 };
 
 use async_lock::futures::LockArc;
 
 use crate::AsyncRuntime;
 
-use super::{schedular::Schedular, AsyncWeakRuntime, InnerRuntime};
+use super::{
+    schedular::{Schedular, SchedularPoll},
+    AsyncWeakRuntime, InnerRuntime,
+};
 
 /// A structure to hold futures spawned inside the runtime.
 pub struct Spawner {
@@ -36,23 +39,12 @@ impl Spawner {
         self.wakeup.push(wake);
     }
 
-    // Drives the runtime futures forward, returns false if their where no futures
-    pub fn drive<'a>(&'a self) -> SpawnFuture<'a> {
-        SpawnFuture(self)
-    }
-
     pub fn is_empty(&mut self) -> bool {
         self.schedular.is_empty()
     }
-}
 
-pub struct SpawnFuture<'a>(&'a Spawner);
-
-impl<'a> Future for SpawnFuture<'a> {
-    type Output = bool;
-
-    fn poll(self: Pin<&mut Self>, cx: &mut std::task::Context<'_>) -> Poll<Self::Output> {
-        unsafe { self.0.schedular.poll(cx) }
+    pub fn poll(&mut self, cx: &mut Context) -> SchedularPoll {
+        unsafe { self.schedular.poll(cx) }
     }
 }
 
@@ -130,24 +122,13 @@ impl Future for DriveFuture {
                     continue;
                 }
 
-                let drive = pin!(unsafe { lock.runtime.get_opaque_mut() }.spawner().drive());
-
                 // TODO: Handle error.
-                match drive.poll(cx) {
-                    Poll::Pending => {
-                        // Execute pending jobs to ensure we don't dead lock when waiting on
-                        // QuickJS futures.
-                        while let Ok(true) = lock.runtime.execute_pending_job() {}
-                        this.state = DriveFutureState::Initial;
-                        return Poll::Pending;
+                match unsafe { lock.runtime.get_opaque_mut() }.spawner().poll(cx) {
+                    SchedularPoll::ShouldYield | SchedularPoll::Empty | SchedularPoll::Pending => {
+                        break
                     }
-                    Poll::Ready(false) => {}
-                    Poll::Ready(true) => {
-                        continue;
-                    }
+                    SchedularPoll::PendingProgress => {}
                 }
-
-                break;
             }
 
             this.state = DriveFutureState::Initial;

--- a/core/src/runtime/spawner.rs
+++ b/core/src/runtime/spawner.rs
@@ -1,3 +1,8 @@
+use super::{
+    schedular::{Schedular, SchedularPoll},
+    AsyncWeakRuntime, InnerRuntime,
+};
+use crate::AsyncRuntime;
 use std::{
     future::Future,
     pin::Pin,
@@ -5,13 +10,6 @@ use std::{
 };
 
 use async_lock::futures::LockArc;
-
-use crate::AsyncRuntime;
-
-use super::{
-    schedular::{Schedular, SchedularPoll},
-    AsyncWeakRuntime, InnerRuntime,
-};
 
 /// A structure to hold futures spawned inside the runtime.
 pub struct Spawner {

--- a/core/src/util.rs
+++ b/core/src/util.rs
@@ -1,0 +1,146 @@
+//! Crate with some util types.
+
+#[cfg(feature = "futures")]
+pub use self::futures::*;
+
+#[cfg(feature = "futures")]
+mod futures {
+    use std::{
+        future::Future,
+        marker::PhantomData,
+        mem::ManuallyDrop,
+        ops::{Deref, DerefMut},
+        pin::Pin,
+        task::{Context, Poll},
+    };
+
+    /// Future which allows one to bail out of a async context, back to manually calling poll.
+    pub struct ManualPoll<F, R> {
+        f: F,
+        _marker: PhantomData<R>,
+    }
+
+    impl<F, R> ManualPoll<F, R>
+    where
+        F: FnMut(&mut Context) -> Poll<R>,
+    {
+        pub fn new(f: F) -> Self {
+            ManualPoll {
+                f,
+                _marker: PhantomData,
+            }
+        }
+    }
+
+    impl<F: Unpin, R> Unpin for ManualPoll<F, R> {}
+
+    impl<F, R> Future for ManualPoll<F, R>
+    where
+        F: FnMut(&mut Context) -> Poll<R>,
+    {
+        type Output = R;
+
+        fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+            let p = unsafe { self.get_unchecked_mut() };
+            (p.f)(cx)
+        }
+    }
+
+    #[cfg(feature = "parallel")]
+    pub use self::parallel::*;
+
+    #[cfg(feature = "parallel")]
+    mod parallel {
+        use super::*;
+
+        pub struct AssertSyncFuture<F>(F);
+
+        impl<F> AssertSyncFuture<F> {
+            pub unsafe fn assert(f: F) -> Self {
+                Self(f)
+            }
+        }
+
+        unsafe impl<F> Sync for AssertSyncFuture<F> {}
+        unsafe impl<F: Send> Send for AssertSyncFuture<F> {}
+
+        impl<F> Future for AssertSyncFuture<F>
+        where
+            F: Future,
+        {
+            type Output = F::Output;
+
+            fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+                let f = unsafe { self.map_unchecked_mut(|x| &mut x.0) };
+                f.poll(cx)
+            }
+        }
+
+        pub struct AssertSendFuture<F>(F);
+
+        impl<F> AssertSendFuture<F> {
+            pub unsafe fn assert(f: F) -> Self {
+                Self(f)
+            }
+        }
+
+        unsafe impl<F> Send for AssertSendFuture<F> {}
+        unsafe impl<F: Sync> Sync for AssertSendFuture<F> {}
+
+        impl<F> Future for AssertSendFuture<F>
+        where
+            F: Future,
+        {
+            type Output = F::Output;
+
+            fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+                let f = unsafe { self.map_unchecked_mut(|x| &mut x.0) };
+                f.poll(cx)
+            }
+        }
+    }
+
+    pub struct Defer<T, F: FnOnce(T)> {
+        value: ManuallyDrop<T>,
+        f: Option<F>,
+    }
+
+    impl<T, F: FnOnce(T)> Defer<T, F> {
+        pub fn new(value: T, func: F) -> Self {
+            Defer {
+                value: ManuallyDrop::new(value),
+                f: Some(func),
+            }
+        }
+
+        pub fn take(mut self) -> T {
+            self.f = None;
+            unsafe { ManuallyDrop::take(&mut self.value) }
+        }
+    }
+
+    impl<T, F: FnOnce(T)> Deref for Defer<T, F> {
+        type Target = T;
+
+        fn deref(&self) -> &Self::Target {
+            &self.value
+        }
+    }
+
+    impl<T, F: FnOnce(T)> DerefMut for Defer<T, F> {
+        fn deref_mut(&mut self) -> &mut Self::Target {
+            &mut self.value
+        }
+    }
+
+    impl<T, F> Drop for Defer<T, F>
+    where
+        F: FnOnce(T),
+    {
+        fn drop(&mut self) {
+            if let Some(x) = self.f.take() {
+                unsafe { (x)(ManuallyDrop::take(&mut self.value)) };
+            }
+        }
+    }
+}

--- a/core/src/util.rs
+++ b/core/src/util.rs
@@ -1,4 +1,4 @@
-//! Crate with some util types.
+//! Module with some util types.
 
 #[cfg(feature = "futures")]
 pub use self::futures::*;

--- a/core/src/value/object.rs
+++ b/core/src/value/object.rs
@@ -5,6 +5,7 @@ use crate::{
     Value,
 };
 use std::{iter::FusedIterator, marker::PhantomData, mem};
+
 mod property;
 pub use property::{Accessor, AsProperty, Property, PropertyFlags};
 

--- a/core/src/value/promise.rs
+++ b/core/src/value/promise.rs
@@ -1,4 +1,9 @@
 //! Javascript promises and future integration.
+use crate::{
+    atom::PredefinedAtom, qjs, Ctx, Error, FromJs, Function, IntoJs, Object, Result, Value,
+};
+#[cfg(feature = "futures")]
+use crate::{function::This, CatchResultExt, CaughtError};
 #[cfg(feature = "futures")]
 use std::{
     cell::RefCell,
@@ -8,12 +13,6 @@ use std::{
     rc::Rc,
     task::{Context as TaskContext, Poll, Waker},
 };
-
-use crate::{
-    atom::PredefinedAtom, qjs, Ctx, Error, FromJs, Function, IntoJs, Object, Result, Value,
-};
-#[cfg(feature = "futures")]
-use crate::{function::This, CatchResultExt, CaughtError};
 
 /// The execution state of a promise.
 #[derive(Clone, Copy, Eq, PartialEq, Debug)]


### PR DESCRIPTION
This PR fixes some problems with the schedular.

- Fixes a issue where rquickjs spawned futures could outlive the context resulting in an abort.
- Fixes an issue where idle could miss futures returning early.
- Fixes the futures returned from idle and execute_pending_job not being send/sync when parallel was enabled. Fixes #276 
- Removes an unneeded assertion which would sometimes trigger.