### PR TITLE
Use up to date version config in build.rs

### DIFF
--- a/sys/build.rs
+++ b/sys/build.rs
@@ -151,7 +151,7 @@ fn main() {
 
     let mut defines = vec![
         ("_GNU_SOURCE".into(), None),
-        ("CONFIG_VERSION".into(), Some("\"2020-01-19\"")),
+        ("CONFIG_VERSION".into(), Some("\"2024-02-14\"")),
         ("CONFIG_BIGNUM".into(), None),
     ];
 


### PR DESCRIPTION
This commit fixes the QuickJS version used in the build file, which should match the version defined in [quickjs/VERSION](https://github.com/bellard/quickjs/blob/3b45d155c77bbdfe9177b1e03db830d2aff0b2a8/VERSION)