### PR TITLE
Fixed #[methods(crate = "...")].

### DIFF
--- a/macro/src/methods.rs
+++ b/macro/src/methods.rs
@@ -32,7 +32,7 @@ impl ImplConfig {
                 self.prefix = Some(x.value.value());
             }
             ImplOption::Crate(x) => {
-                self.prefix = Some(x.value.value());
+                self.crate_ = Some(x.value.value());
             }
             ImplOption::RenameAll(x) => {
                 self.rename_all = Some(x.value);


### PR DESCRIPTION
Fixed a typo so `#[methods(crate = "...")]` can work, instead of incorrectly update the configuration of the prefix.