### PR TITLE
feat(core, value): add as_bytes_mut() to array buffer and typed array

### DIFF
--- a/core/src/value/array_buffer.rs
+++ b/core/src/value/array_buffer.rs
@@ -106,6 +106,14 @@ impl<'js> ArrayBuffer<'js> {
     /// Returns `None` if the array is detached.
     pub fn as_bytes(&self) -> Option<&[u8]> {
         let raw = Self::get_raw(self.as_value())?;
+        Some(unsafe { slice::from_raw_parts(raw.ptr.as_ptr(), raw.len) })
+    }
+
+    /// Returns the underlying bytes of the buffer as a mutable slice,
+    ///
+    /// Returns `None` if the array is detached.
+    pub fn as_bytes_mut(&self) -> Option<&mut [u8]> {
+        let raw = Self::get_raw(self.as_value())?;
         Some(unsafe { slice::from_raw_parts_mut(raw.ptr.as_ptr(), raw.len) })
     }
 

--- a/core/src/value/typed_array.rs
+++ b/core/src/value/typed_array.rs
@@ -171,6 +171,14 @@ impl<'js, T> TypedArray<'js, T> {
         Some(unsafe { slice::from_raw_parts(ptr.as_ptr(), len) })
     }
 
+    /// Returns the underlying bytes of the buffer as a mutable slice,
+    ///
+    /// Returns `None` if the array is detached.
+    pub fn as_bytes_mut(&self) -> Option<&mut [u8]> {
+        let (_, len, ptr) = Self::get_raw_bytes(self.as_value())?;
+        Some(unsafe { slice::from_raw_parts_mut(ptr.as_ptr(), len) })
+    }
+
     pub fn as_raw(&self) -> Option<RawArrayBuffer> {
         let (_, len, ptr) = Self::get_raw_bytes(self.as_value())?;
         Some(RawArrayBuffer { len, ptr })


### PR DESCRIPTION
# Overview

There's currently not a way to modify the bytes of an `ArrayBuffer` or a typed array like `Uint8Array`, so this PR adds new `as_bytes_mut()` methods that follows the typical convention in Rust.