### PR TITLE
fix: js atom null

### DIFF
--- a/core/src/context/ctx.rs
+++ b/core/src/context/ctx.rs
@@ -429,7 +429,7 @@ impl<'js> Ctx<'js> {
     pub fn script_or_module_name(&self, stack_level: isize) -> Option<Atom<'js>> {
         let stack_level = std::os::raw::c_int::try_from(stack_level).unwrap();
         let atom = unsafe { qjs::JS_GetScriptOrModuleName(self.as_ptr(), stack_level) };
-        if PredefinedAtom::Null as u32 == atom {
+        if qjs::__JS_ATOM_NULL as u32 == atom {
             unsafe { qjs::JS_FreeAtom(self.as_ptr(), atom) };
             return None;
         }


### PR DESCRIPTION
Hi, I've ran into an issue on Linux where calling `Module::import` resulted in an error with UTF8. After closer inspection I've noticed that  `Ctx::script_or_module_name` generated what appeared to be pseudo-random values. I've dug into `JS_GetScriptOrModuleName` in c:

```c
/* return JS_ATOM_NULL if the name cannot be found. Only works with
   not striped bytecode functions. */
JSAtom JS_GetScriptOrModuleName(JSContext *ctx, int n_stack_levels)
{
    JSStackFrame *sf;
    JSFunctionBytecode *b;
    JSObject *p;
    /* XXX: currently we just use the filename of the englobing
       function from the debug info. May need to add a ScriptOrModule
       info in JSFunctionBytecode. */
    sf = ctx->rt->current_stack_frame;
    if (!sf)
        return JS_ATOM_NULL;
    while (n_stack_levels-- > 0) {
        sf = sf->prev_frame;
        if (!sf)
            return JS_ATOM_NULL;
    }
    for(;;) {
        if (JS_VALUE_GET_TAG(sf->cur_func) != JS_TAG_OBJECT)
            return JS_ATOM_NULL;
        p = JS_VALUE_GET_OBJ(sf->cur_func);
        if (!js_class_has_bytecode(p->class_id))
            return JS_ATOM_NULL;
        b = p->u.func.function_bytecode;
        if (!b->is_direct_or_indirect_eval) {
            if (!b->has_debug)
                return JS_ATOM_NULL;
            return JS_DupAtom(ctx, b->debug.filename);
        } else {
            sf = sf->prev_frame;
            if (!sf)
                return JS_ATOM_NULL;
        }
    }
}
```

We can see that JS_ATOM_NULL is returned in case script name cannot be resolved. This is not the same value as the one currently being checked against (JS_ATOM_null = 1, __JS_ATOM_NULL = 0). As is defined in .h.

```c
#define JS_ATOM_NULL 0
```