### PR TITLE
Add support for specifying the rquickjs crate name in the Trace derive macro.

### DIFF
--- a/core/src/context/ctx.rs
+++ b/core/src/context/ctx.rs
@@ -11,8 +11,8 @@ use std::{
 #[cfg(feature = "futures")]
 use crate::AsyncContext;
 use crate::{
-    atom::PredefinedAtom, cstr, markers::Invariant, qjs, runtime::raw::Opaque, Atom, Context,
-    Error, FromJs, Function, IntoJs, Object, Promise, Result, String, Value,
+    cstr, markers::Invariant, qjs, runtime::raw::Opaque, Atom, Context, Error, FromJs, Function,
+    IntoJs, Object, Promise, Result, String, Value,
 };
 
 /// Eval options.


### PR DESCRIPTION
Fixes #339 