### PR TITLE
String as_str function

### DIFF
--- a/core/src/value/string.rs
+++ b/core/src/value/string.rs
@@ -6,14 +6,28 @@ use std::{mem, slice, str};
 #[repr(transparent)]
 pub struct String<'js>(pub(crate) Value<'js>);
 
+impl<'js> AsRef<str> for String<'js>{
+    fn as_ref(&self) -> &str {
+        self.as_str().unwrap()
+    }
+}
+
 impl<'js> String<'js> {
     /// Convert the JavaScript string to a Rust string.
     pub fn to_string(&self) -> Result<StdString> {
-        self.as_str().map(|s| s.into())
+        let (str, ptr) = self.get_str_ref()?;
+        let string = str.to_string();
+        unsafe { qjs::JS_FreeCString(self.0.ctx.as_ptr(), ptr) };
+        Ok(string)
     }
 
     /// Convert the JavaScript string to a string slice.
     pub fn as_str(&self) -> Result<&str> {
+        let (str,_) = self.get_str_ref()?;
+        Ok(str)
+    }
+
+    fn get_str_ref(&self) -> Result<(&str,*const i8)> {
         let mut len = mem::MaybeUninit::uninit();
         let ptr = unsafe {
             qjs::JS_ToCStringLen(self.0.ctx.as_ptr(), len.as_mut_ptr(), self.0.as_js_value())
@@ -25,17 +39,14 @@ impl<'js> String<'js> {
         }
         let len = unsafe { len.assume_init() };
         let bytes: &[u8] = unsafe { slice::from_raw_parts(ptr as _, len as _) };
-
         let result = if cfg!(debug_assertions) {
             str::from_utf8(bytes)?
         } else {
             unsafe { str::from_utf8_unchecked(bytes) }
         };
-        unsafe { qjs::JS_FreeCString(self.0.ctx.as_ptr(), ptr) };
-
-        Ok(result)
+        Ok((result,ptr))
     }
-
+    
     /// Create a new JavaScript string from an Rust string.
     pub fn from_str(ctx: Ctx<'js>, s: &str) -> Result<Self> {
         let len = s.as_bytes().len();
@@ -67,6 +78,19 @@ mod test {
             let func: Function = ctx.eval("x =>  x + 'bar'").unwrap();
             let text: StdString = (string,).apply(&func).unwrap();
             assert_eq!(text, "foobar".to_string());
+
+            let s: String = ctx.eval(" '▧ ▧' ").unwrap();
+
+            let str = s.as_str().unwrap();
+    
+            // alloc some memory to mangle the string.
+            for _ in 0..100 {
+                let s: String = ctx.eval(" 'foo' ").unwrap();
+                s.to_string().unwrap();
+            }
+    
+            assert_eq!(str, "▧ ▧");
+
         });
     }
 }

--- a/core/src/value/string.rs
+++ b/core/src/value/string.rs
@@ -9,11 +9,11 @@ pub struct String<'js>(pub(crate) Value<'js>);
 impl<'js> String<'js> {
     /// Convert the JavaScript string to a Rust string.
     pub fn to_string(&self) -> Result<StdString> {
-       self.as_str().map(|s|s.into())
+        self.as_str().map(|s| s.into())
     }
 
-     /// Convert the JavaScript string to a string slice.
-     pub fn as_str(&self) -> Result<&str> {
+    /// Convert the JavaScript string to a string slice.
+    pub fn as_str(&self) -> Result<&str> {
         let mut len = mem::MaybeUninit::uninit();
         let ptr = unsafe {
             qjs::JS_ToCStringLen(self.0.ctx.as_ptr(), len.as_mut_ptr(), self.0.as_js_value())
@@ -26,14 +26,14 @@ impl<'js> String<'js> {
         let len = unsafe { len.assume_init() };
         let bytes: &[u8] = unsafe { slice::from_raw_parts(ptr as _, len as _) };
 
-        let result = if cfg!(debug_assertions) { 
+        let result = if cfg!(debug_assertions) {
             str::from_utf8(bytes)?
-        } else { 
-            unsafe {str::from_utf8_unchecked(bytes)}
+        } else {
+            unsafe { str::from_utf8_unchecked(bytes) }
         };
         unsafe { qjs::JS_FreeCString(self.0.ctx.as_ptr(), ptr) };
 
-       Ok(result)
+        Ok(result)
     }
 
     /// Create a new JavaScript string from an Rust string.


### PR DESCRIPTION
Expose a `as_str` function for JavaScript strings.
Also assume data is valid utf8 on production builds.