### PR TITLE
Add extend method for UserDataMap

### DIFF
--- a/core/src/context/ctx.rs
+++ b/core/src/context/ctx.rs
@@ -15,7 +15,7 @@ use crate::{
     cstr,
     markers::Invariant,
     qjs,
-    runtime::{opaque::Opaque, UserData, UserDataError, UserDataGuard},
+    runtime::{opaque::Opaque, UserData, UserDataError, UserDataGuard, UserDataMap},
     Atom, Error, FromJs, Function, IntoJs, Object, Promise, Result, String, Value,
 };
 
@@ -466,6 +466,13 @@ impl<'js> Ctx<'js> {
         data: U,
     ) -> StdResult<Option<Box<U>>, UserDataError<U>> {
         unsafe { self.get_opaque().insert_userdata(data) }
+    }
+
+    /// Store multiple types in the runtime which can be retrieved later with `Ctx::userdata`.
+    ///
+    /// Returns an error if the userdata is currently being accessed.
+    pub fn extend_userdata(&self, data: UserDataMap) -> StdResult<(), UserDataError<()>> {
+        unsafe { self.get_opaque().extend_userdata(data) }
     }
 
     /// Remove the userdata of the given type from the userdata storage.

--- a/core/src/runtime.rs
+++ b/core/src/runtime.rs
@@ -13,7 +13,7 @@ pub(crate) mod schedular;
 mod spawner;
 
 pub use base::{Runtime, WeakRuntime};
-pub use userdata::{UserData, UserDataError, UserDataGuard};
+pub use userdata::{UserData, UserDataError, UserDataGuard, UserDataMap};
 
 #[cfg(feature = "futures")]
 pub(crate) use r#async::InnerRuntime;

--- a/core/src/runtime/opaque.rs
+++ b/core/src/runtime/opaque.rs
@@ -94,6 +94,10 @@ impl<'js> Opaque<'js> {
         self.userdata.insert(data)
     }
 
+    pub fn extend_userdata(&self, data: UserDataMap) -> Result<(), UserDataError<()>> {
+        self.userdata.extend(data)
+    }
+
     pub fn remove_userdata<U>(&self) -> Result<Option<Box<U>>, UserDataError<()>>
     where
         U: UserData<'js>,

--- a/core/src/runtime/userdata.rs
+++ b/core/src/runtime/userdata.rs
@@ -152,7 +152,7 @@ impl Hasher for IdHasher {
 
 /// Typeid hashmap taken from axum.
 #[derive(Default)]
-pub(crate) struct UserDataMap {
+pub struct UserDataMap {
     map: UnsafeCell<HashMap<TypeId, Box<dyn Any>, BuildHasherDefault<IdHasher>>>,
     count: Cell<usize>,
 }
@@ -174,6 +174,14 @@ impl UserDataMap {
             unsafe { U::from_static_box(r) }
         });
         Ok(r)
+    }
+
+    pub fn extend(&self, other: Self) -> Result<(), UserDataError<()>> {
+        if self.count.get() > 0 || other.count.get() > 0 {
+            return Err(UserDataError(()));
+        }
+        unsafe { (*self.map.get()).extend((*other.map.get()).drain()) }
+        Ok(())
     }
 
     pub fn remove<'js, U>(&self) -> Result<Option<Box<U>>, UserDataError<()>>


### PR DESCRIPTION
I am working on a new `ModuleDef` extension that is stateful.
I decided to use the userdata to store the options that are later retrieved.
I faced an issue where I wanted my module loader builder to not have to lock the runtime on each new module.

My solution is to allow users to build a UserDataMap themselves and then allow to extend the runtime one when you get the lock. Lifetimes other than static obviously won't work, but my options are static anyway so I don't care about that.

I am open to other suggestions, it would obviously be easier if we made the `ModuleDef` stateful, but that would break a lot of existing code.

```rust
#[derive(Debug, Default)]
pub struct ModuleLoaderBuilder {
    definitions: HashMap<&'static str, LoadFn>,
    globals: HashMap<&'static str, GlobalFn>,
    // Accumulate the options in UserDataMap
}

impl ModuleLoaderBuilder {
    pub async fn add_module<M: ModuleDefExt>(&mut self, module: M, global: bool) -> &mut Self {
        self.definitions.insert(M::NAME, load_func::<M>);
        if global {
            self.globals.insert(M::NAME, global_func::<M>);
        }
        // Store the options
        self
    }
}
```

My trait
```rust
pub trait ModuleDefExt: ModuleDef {
    const NAME: &'static str;

    type Options<'js>: UserData<'js>;

    fn declare(decl: &Declarations<'_>) -> Result<()> {
        let _ = decl;
        Ok(())
    }

    fn evaluate<'js>(
        options: &Self::Options<'js>,
        ctx: &Ctx<'js>,
        exports: &Exports<'js>,
    ) -> Result<()> {
        let _ = (options, exports, ctx);
        Ok(())
    }

    fn globals<'js>(options: &Self::Options<'js>, globals: &Object<'js>) -> Result<()> {
        let _ = (globals);
        Ok(())
    }

    fn options(self) -> Result<Self::Options<'static>>;
}
```

Full code for my experiment is here: https://github.com/rquickjs/rquickjs-moduledef-ext