### PR TITLE
Add CString implementation

### DIFF
--- a/core/src/js_lifetime.rs
+++ b/core/src/js_lifetime.rs
@@ -1,6 +1,6 @@
 use crate::{
-    atom, value::Constructor, Array, Atom, BigInt, Exception, Function, Module, Object, Promise,
-    String, Symbol, Value,
+    atom, value::Constructor, Array, Atom, BigInt, CString, Exception, Function, Module, Object,
+    Promise, String, Symbol, Value,
 };
 
 /// The trait which signifies a type using the rquickjs `'js` lifetime trick for maintaining safety around Javascript values.
@@ -97,6 +97,7 @@ outlive_impls! {
     Value,
     Symbol,
     String,
+    CString,
     Object,
     Array,
     BigInt,

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -26,7 +26,7 @@ pub use js_lifetime::JsLifetime;
 pub use persistent::Persistent;
 pub use result::{CatchResultExt, CaughtError, CaughtResult, Error, Result, ThrowResultExt};
 pub use value::{
-    array, atom, convert, function, module, object, promise, Array, Atom, BigInt, Coerced,
+    array, atom, convert, function, module, object, promise, Array, Atom, BigInt, CString, Coerced,
     Exception, Filter, FromAtom, FromIteratorJs, FromJs, Function, IntoAtom, IntoJs, IteratorJs,
     Module, Null, Object, Promise, String, Symbol, Type, Undefined, Value,
 };

--- a/core/src/value.rs
+++ b/core/src/value.rs
@@ -22,7 +22,7 @@ pub use function::{Constructor, Function};
 pub use module::Module;
 pub use object::{Filter, Object};
 pub use promise::Promise;
-pub use string::String;
+pub use string::{CString, String};
 pub use symbol::Symbol;
 
 #[cfg(feature = "array-buffer")]

--- a/core/src/value/convert/from.rs
+++ b/core/src/value/convert/from.rs
@@ -1,6 +1,6 @@
 use crate::{
-    convert::List, Array, Ctx, Error, FromAtom, FromJs, Object, Result, StdString, String, Type,
-    Value,
+    convert::List, Array, CString, Ctx, Error, FromAtom, FromJs, Object, Result, StdString, String,
+    Type, Value,
 };
 use std::{
     cell::{Cell, RefCell},
@@ -45,6 +45,12 @@ impl<'js> FromJs<'js> for char {
                 message: Some("The length of the string converted to char must be 1".into()),
             }),
         }
+    }
+}
+
+impl<'js> FromJs<'js> for CString<'js> {
+    fn from_js(_ctx: &Ctx<'js>, value: Value<'js>) -> Result<Self> {
+        String::from_value(value)?.to_cstring()
     }
 }
 

--- a/core/src/value/convert/into.rs
+++ b/core/src/value/convert/into.rs
@@ -1,7 +1,8 @@
 use crate::{
     convert::{IteratorJs, List},
     value::Constructor,
-    Array, Ctx, Error, IntoAtom, IntoJs, Object, Result, StdResult, StdString, String, Value,
+    Array, CString, Ctx, Error, IntoAtom, IntoJs, Object, Result, StdResult, StdString, String,
+    Value,
 };
 use std::{
     cell::{Cell, RefCell},
@@ -49,6 +50,18 @@ impl<'js> IntoJs<'js> for &str {
 impl<'js> IntoJs<'js> for char {
     fn into_js(self, ctx: &Ctx<'js>) -> Result<Value<'js>> {
         String::from_str(ctx.clone(), self.to_string().as_str()).map(|String(value)| value)
+    }
+}
+
+impl<'js> IntoJs<'js> for CString<'js> {
+    fn into_js(self, ctx: &Ctx<'js>) -> Result<Value<'js>> {
+        String::from_str(ctx.clone(), self.as_str()).map(|String(value)| value)
+    }
+}
+
+impl<'js> IntoJs<'js> for &CString<'js> {
+    fn into_js(self, ctx: &Ctx<'js>) -> Result<Value<'js>> {
+        String::from_str(ctx.clone(), self.as_str()).map(|String(value)| value)
     }
 }
 

--- a/core/src/value/string.rs
+++ b/core/src/value/string.rs
@@ -1,5 +1,5 @@
 use crate::{qjs, Ctx, Error, Result, StdString, Value};
-use std::{mem, slice, str};
+use std::{ffi::c_char, mem, ptr::NonNull, slice, str};
 
 /// Rust representation of a JavaScript string.
 #[derive(Debug, Clone, PartialEq, Hash)]
@@ -25,6 +25,11 @@ impl<'js> String<'js> {
         Ok(result?)
     }
 
+    /// Convert the Javascript string to a Javascript C string.
+    pub fn to_cstring(self) -> Result<CString<'js>> {
+        CString::from_string(self)
+    }
+
     /// Create a new JavaScript string from an Rust string.
     pub fn from_str(ctx: Ctx<'js>, s: &str) -> Result<Self> {
         let len = s.as_bytes().len();
@@ -34,6 +39,65 @@ impl<'js> String<'js> {
             let js_val = ctx.handle_exception(js_val)?;
             String::from_js_value(ctx, js_val)
         })
+    }
+}
+
+/// Rust representation of a JavaScript C string.
+#[derive(Debug)]
+pub struct CString<'js> {
+    ptr: NonNull<c_char>,
+    len: usize,
+    ctx: Ctx<'js>,
+}
+
+impl<'js> CString<'js> {
+    /// Create a new JavaScript C string from a JavaScript string.
+    pub fn from_string(string: String<'js>) -> Result<Self> {
+        let mut len = mem::MaybeUninit::uninit();
+        // SAFETY: The pointer points to a JSString content which is ref counted
+        let ptr = unsafe {
+            qjs::JS_ToCStringLen(string.0.ctx.as_ptr(), len.as_mut_ptr(), string.as_raw())
+        };
+        if ptr.is_null() {
+            // Might not ever happen but I am not 100% sure
+            // so just incase check it.
+            return Err(Error::Unknown);
+        }
+        let len = unsafe { len.assume_init() };
+        Ok(Self {
+            ptr: unsafe { NonNull::new_unchecked(ptr as *mut _) },
+            len,
+            ctx: string.0.ctx.clone(),
+        })
+    }
+
+    /// Converts a `CString` to a raw pointer.
+    pub fn as_ptr(&self) -> *const c_char {
+        self.ptr.as_ptr() as *const _
+    }
+
+    /// Returns the length of this `CString`, in bytes (not chars or graphemes).
+    pub fn len(&self) -> usize {
+        self.len
+    }
+
+    /// Returns `true` if this `CString` has a length of zero, and `false` otherwise.
+    pub fn is_empty(&self) -> bool {
+        self.len == 0
+    }
+
+    /// Extracts a string slice containing the entire `CString`.
+    pub fn as_str(&self) -> &str {
+        // SAFETY: The pointer points to a JSString content which is ref counted
+        let bytes = unsafe { slice::from_raw_parts(self.ptr.as_ptr() as *const u8, self.len) };
+        // SAFETY: The bytes are garanteed to be valid utf8 by QuickJS
+        unsafe { str::from_utf8_unchecked(bytes) }
+    }
+}
+
+impl<'js> Drop for CString<'js> {
+    fn drop(&mut self) {
+        unsafe { qjs::JS_FreeCString(self.ctx.as_ptr(), self.ptr.as_ptr()) };
     }
 }
 
@@ -52,6 +116,27 @@ mod test {
     fn to_javascript() {
         test_with(|ctx| {
             let string = String::from_str(ctx.clone(), "foo").unwrap();
+            let func: Function = ctx.eval("x =>  x + 'bar'").unwrap();
+            let text: StdString = (string,).apply(&func).unwrap();
+            assert_eq!(text, "foobar".to_string());
+        });
+    }
+
+    #[test]
+    fn from_javascript_c() {
+        test_with(|ctx| {
+            let s: CString = ctx.eval(" 'foo bar baz' ").unwrap();
+            assert_eq!(s.as_str(), "foo bar baz");
+        });
+    }
+
+    #[test]
+    fn to_javascript_c() {
+        test_with(|ctx| {
+            let string = String::from_str(ctx.clone(), "foo")
+                .unwrap()
+                .to_cstring()
+                .unwrap();
             let func: Function = ctx.eval("x =>  x + 'bar'").unwrap();
             let text: StdString = (string,).apply(&func).unwrap();
             assert_eq!(text, "foobar".to_string());


### PR DESCRIPTION
This allows users to avoid a double allocation for strings when you don't need to mutate the string.