### PR TITLE
Only increment userdata count if we actually have it

### DIFF
--- a/core/src/runtime/userdata.rs
+++ b/core/src/runtime/userdata.rs
@@ -195,8 +195,8 @@ impl UserDataMap {
 
     pub fn get<'js, U: UserData<'js>>(&self) -> Option<UserDataGuard<U>> {
         let id = TypeId::of::<U::Static>();
-        self.count.set(self.count.get() + 1);
         unsafe { (*self.map.get()).get(&id) }.map(|x| {
+            self.count.set(self.count.get() + 1);
             let u = x
                 .downcast_ref()
                 .expect("type confusion! userdata not stored under the right type id");


### PR DESCRIPTION
If we don't have specific userdata, we still increment the count causing errors if we then try to insert it.