### PR TITLE
Fix/prototype lookup causing prototype missmatch across crates

### DIFF
--- a/core/src/allocator/rust.rs
+++ b/core/src/allocator/rust.rs
@@ -62,8 +62,7 @@ unsafe impl Allocator for RustAllocator {
         let header = unsafe { &mut *(ptr as *mut Header) };
         header.size = total_size;
 
-        let ptr = unsafe { ptr.add(HEADER_SIZE) };
-        ptr
+        unsafe { ptr.add(HEADER_SIZE) }
     }
 
     fn alloc(&mut self, size: usize) -> *mut u8 {

--- a/core/src/class/ffi.rs
+++ b/core/src/class/ffi.rs
@@ -76,7 +76,7 @@ pub(crate) type CallFunc = for<'a> unsafe fn(
 pub(crate) type TypeIdFn = fn() -> TypeId;
 
 pub(crate) struct VTable {
-    id: TypeIdFn,
+    id_fn: TypeIdFn,
     finalizer: FinalizerFunc,
     trace: TraceFunc,
     call: CallFunc,
@@ -125,7 +125,7 @@ impl VTable {
 
         impl<'js, C: JsClass<'js>> HasVTable for C {
             const VTABLE: VTable = VTable {
-                id: TypeId::of::<C::Changed<'static>>,
+                id_fn: TypeId::of::<C::Changed<'static>>,
                 finalizer: VTable::finalizer_impl::<'js, C>,
                 trace: VTable::trace_impl::<C>,
                 call: VTable::call_impl::<C>,
@@ -134,8 +134,12 @@ impl VTable {
         &<C as HasVTable>::VTABLE
     }
 
+    pub fn id(&self) -> TypeId {
+        (self.id_fn)()
+    }
+
     pub fn is_of_class<'js, C: JsClass<'js>>(&self) -> bool {
-        (self.id)() == TypeId::of::<C::Changed<'static>>()
+        (self.id_fn)() == TypeId::of::<C::Changed<'static>>()
     }
 }
 


### PR DESCRIPTION
When running tests for LLRT i discovered that classes living in different crates got different TypeId function pointers. This messed up the prototypes. Invoking the TypeId function pointer however resulted in the same ID. This may have to do with optimizations and rust compiler internals.

Safest thing to do with now be to use the actual TypeId as key for the prototype table.
