### PR TITLE
Implement JsLifetime for ()

### DIFF
--- a/core/src/js_lifetime.rs
+++ b/core/src/js_lifetime.rs
@@ -178,3 +178,7 @@ impl_outlive!(
 unsafe impl<'js, T: JsLifetime<'js>> JsLifetime<'js> for Module<'js, T> {
     type Changed<'to> = Module<'to, T::Changed<'to>>;
 }
+
+unsafe impl<'js> JsLifetime<'js> for () {
+    type Changed<'to> = ();
+}


### PR DESCRIPTION
We need that for https://github.com/rquickjs/rquickjs-moduledef-ext to allow users to not have options

```rust
use rquickjs_moduledef_ext::{ModuleLoader, ModuleDefExt, ModuleImpl};

struct MyModule;

impl ModuleDefExt for MyModule {
     type Implementation = ModuleImpl<()>;

     fn implementation() -> &'static Self::Implementation {
         &ModuleImpl {
             declare: |decl| {
                 decl.declare("hello")?;
                 Ok(())
             },
             evaluate: |ctx, exports, options| {
                 exports.export("hello", "world".to_string())?;
                 Ok(())
             },
             name: "my-module",
         }
     }

     fn options(self) -> () {}
 }

 let (loader, resolver, initializer) = ModuleLoader::builder()
     .with_module(MyModule)
     .build();
```