### PR TITLE
Add wasi-sdk download on aarch64-linux

### DIFF
--- a/sys/build.rs
+++ b/sys/build.rs
@@ -29,6 +29,7 @@ fn download_wasi_sdk() -> PathBuf {
             ("linux", "x86") | ("linux", "x86_64") => "x86_64-linux",
             ("macos", "x86") | ("macos", "x86_64") => "x86_64-macos",
             ("macos", "aarch64") => "arm64-macos",
+            ("linux", "aarch64") => "arm64-linux",
             ("windows", "x86") | ("windows", "x86_64") => "x86_64-windows",
             other => panic!("Unsupported platform tuple {:?}", other),
         };

--- a/sys/build.rs
+++ b/sys/build.rs
@@ -27,9 +27,9 @@ fn download_wasi_sdk() -> PathBuf {
     if !archive_path.try_exists().unwrap() {
         let file_suffix = match (env::consts::OS, env::consts::ARCH) {
             ("linux", "x86") | ("linux", "x86_64") => "x86_64-linux",
+            ("linux", "aarch64") => "arm64-linux",
             ("macos", "x86") | ("macos", "x86_64") => "x86_64-macos",
             ("macos", "aarch64") => "arm64-macos",
-            ("linux", "aarch64") => "arm64-linux",
             ("windows", "x86") | ("windows", "x86_64") => "x86_64-windows",
             other => panic!("Unsupported platform tuple {:?}", other),
         };


### PR DESCRIPTION
This allow users to build `wasm32-wasip2` target on `aarch64-linux` devices.