### PR TITLE
expose promise rejection tracker

### DIFF
--- a/core/src/runtime.rs
+++ b/core/src/runtime.rs
@@ -20,6 +20,16 @@ pub(crate) use r#async::InnerRuntime;
 #[cfg(feature = "futures")]
 pub use r#async::{AsyncRuntime, AsyncWeakRuntime};
 
+use crate::{Ctx, Value};
+
+/// The type of the promise rejection tracker.
+#[cfg(not(feature = "parallel"))]
+pub type RejectionTracker = Box<dyn for<'a> Fn(Ctx<'a>, Value<'a>, Value<'a>, bool) + 'static>;
+/// The type of the promise rejection tracker.
+#[cfg(feature = "parallel")]
+pub type RejectionTracker =
+    Box<dyn for<'a> Fn(Ctx<'a>, Value<'a>, Value<'a>, bool) + Send + 'static>;
+
 /// The type of the interrupt handler.
 #[cfg(not(feature = "parallel"))]
 pub type InterruptHandler = Box<dyn FnMut() -> bool + 'static>;

--- a/core/src/runtime/base.rs
+++ b/core/src/runtime/base.rs
@@ -1,6 +1,6 @@
 //! QuickJS runtime related types.
 
-use super::{opaque::Opaque, raw::RawRuntime, InterruptHandler, MemoryUsage};
+use super::{opaque::Opaque, raw::RawRuntime, InterruptHandler, MemoryUsage, RejectionTracker};
 #[cfg(feature = "allocator")]
 use crate::allocator::Allocator;
 #[cfg(feature = "loader")]
@@ -62,6 +62,16 @@ impl Runtime {
     /// Get weak ref to runtime
     pub fn weak(&self) -> WeakRuntime {
         WeakRuntime(Ref::downgrade(&self.inner))
+    }
+
+    /// Set a closure which is called when a Promise is rejected.
+    #[inline]
+    pub fn set_host_promise_rejection_tracker(&self, tracker: Option<RejectionTracker>) {
+        unsafe {
+            self.inner
+                .lock()
+                .set_host_promise_rejection_tracker(tracker);
+        }
     }
 
     /// Set a closure which is regularly called by the engine when it is executing code.

--- a/core/src/runtime/opaque.rs
+++ b/core/src/runtime/opaque.rs
@@ -1,11 +1,11 @@
 use crate::{
     class::{self, ffi::VTable, JsClass},
-    qjs, Ctx, Error, JsLifetime, Object,
+    qjs, Ctx, Error, JsLifetime, Object, Value,
 };
 
 use super::{
     userdata::{UserDataGuard, UserDataMap},
-    InterruptHandler, UserDataError,
+    InterruptHandler, RejectionTracker, UserDataError,
 };
 use std::{
     any::{Any, TypeId},
@@ -29,6 +29,9 @@ pub(crate) struct Opaque<'js> {
     /// Used to carry a panic if a callback triggered one.
     panic: Cell<Option<Box<dyn Any + Send + 'static>>>,
 
+    /// The user provided rejection tracker, if any.
+    rejection_tracker: UnsafeCell<Option<RejectionTracker>>,
+
     /// The user provided interrupt handler, if any.
     interrupt_handler: UnsafeCell<Option<InterruptHandler>>,
 
@@ -51,6 +54,8 @@ impl<'js> Opaque<'js> {
     pub fn new() -> Self {
         Opaque {
             panic: Cell::new(None),
+
+            rejection_tracker: UnsafeCell::new(None),
 
             interrupt_handler: UnsafeCell::new(None),
 
@@ -162,6 +167,22 @@ impl<'js> Opaque<'js> {
         U::Changed<'static>: Any,
     {
         self.userdata.get()
+    }
+
+    pub fn set_rejection_tracker(&self, tracker: Option<RejectionTracker>) {
+        unsafe { (*self.rejection_tracker.get()) = tracker }
+    }
+
+    pub fn run_rejection_tracker<'a>(
+        &self,
+        ctx: Ctx<'a>,
+        promise: Value<'a>,
+        reason: Value<'a>,
+        is_handled: bool,
+    ) {
+        unsafe {
+            (*self.rejection_tracker.get()).as_mut().unwrap()(ctx, promise, reason, is_handled)
+        }
     }
 
     pub fn set_interrupt_handler(&self, interupt: Option<InterruptHandler>) {

--- a/core/src/runtime/opaque.rs
+++ b/core/src/runtime/opaque.rs
@@ -231,6 +231,7 @@ impl<'js> Opaque<'js> {
     /// Called before dropping the runtime to ensure that we drop everything before freeing the
     /// runtime.
     pub fn clear(&mut self) {
+        self.rejection_tracker.get_mut().take();
         self.interrupt_handler.get_mut().take();
         self.panic.take();
         self.prototypes.get_mut().clear();

--- a/core/src/runtime/raw.rs
+++ b/core/src/runtime/raw.rs
@@ -298,15 +298,15 @@ impl RawRuntime {
             is_handled: bool,
             opaque: *mut ::std::os::raw::c_void,
         ) {
-            let ctx = Ctx::from_ptr(ctx);
-
             let opaque = NonNull::new_unchecked(opaque).cast::<Opaque>();
 
             let catch_unwind = panic::catch_unwind(AssertUnwindSafe(move || {
+                let ctx = Ctx::from_ptr(ctx);
+
                 opaque.as_ref().run_rejection_tracker(
                     ctx.clone(),
                     Value::from_raw(ctx.clone(), promise),
-                    Value::from_raw(ctx.clone(), reason),
+                    Value::from_raw(ctx, reason),
                     is_handled,
                 );
             }));

--- a/core/src/runtime/raw.rs
+++ b/core/src/runtime/raw.rs
@@ -369,19 +369,19 @@ impl RawRuntime {
 
 #[cfg(test)]
 mod test {
-    use std::{cell::RefCell, rc::Rc};
+    use std::sync::{Arc, Mutex};
 
     use crate::{Context, Runtime};
 
     #[test]
     fn promise_rejection_handler() {
-        let counter = Rc::new(RefCell::new(0));
+        let counter = Arc::new(Mutex::new(0));
         let rt = Runtime::new().unwrap();
         {
             let counter = counter.clone();
             rt.set_host_promise_rejection_tracker(Some(Box::new(move |_, _, _, is_handled| {
                 if !is_handled {
-                    let mut c = counter.borrow_mut();
+                    let mut c = counter.lock().unwrap();
                     *c += 1;
                 }
             })));
@@ -398,6 +398,6 @@ mod test {
             "#,
             );
         });
-        assert_eq!(*counter.borrow(), 1);
+        assert_eq!(*counter.lock().unwrap(), 1);
     }
 }

--- a/core/src/runtime/raw.rs
+++ b/core/src/runtime/raw.rs
@@ -305,8 +305,8 @@ impl RawRuntime {
 
                 opaque.as_ref().run_rejection_tracker(
                     ctx.clone(),
-                    Value::from_raw(ctx.clone(), promise),
-                    Value::from_raw(ctx, reason),
+                    Value::from_js_value_const(ctx.clone(), promise),
+                    Value::from_js_value_const(ctx, reason),
                     is_handled,
                 );
             }));


### PR DESCRIPTION
this enables users to write a custom onerror handler for uncaught rejected promises

the parameters are currently the same as the C API has, this function receives both handled and unhandled rejections.

For the purpose of onerror, you would ignore all calls where is_handled is true as below

example usage:
```rust
use rquickjs::{Context, Runtime};

fn main() {
    let runtime = Runtime::new().unwrap();
    let context = Context::full(&runtime).unwrap();
    runtime.set_host_promise_rejection_tracker(Some(Box::new(
        |_ctx, _promise, reason, is_handled| {
            if !is_handled {
                dbg!(reason);
            }
        },
    )));
    context
        .with(|ctx| {
            let _: () = ctx
                .eval("function x() { new Promise(() => { throw new Error('42') }) }; x()")
                .unwrap();
        });
}

```