### PR TITLE
Fix rename option in qjs attribute when with function attribute not w…

### DIFF
--- a/macro/src/module/mod.rs
+++ b/macro/src/module/mod.rs
@@ -363,7 +363,7 @@ pub(crate) fn expand(options: OptionList<ModuleOption>, mut item: ItemMod) -> Re
         let mod_name = module.name.clone();
 
         module.export(
-            name,
+            js_name.clone(),
             f.sig.ident.span(),
             quote! {
                 _exports.export(#js_name,#mod_name::#ident)?;

--- a/tests/macros/pass_module.rs
+++ b/tests/macros/pass_module.rs
@@ -80,6 +80,12 @@ mod test_mod {
         1 + 1
     }
 
+    #[rquickjs::function]
+    #[qjs(rename = "renamedFoo")]
+    pub fn renamed_foo() -> u32 {
+        1 + 2
+    }
+
     /// You can make items public but not export them to JavaScript by adding the skip attribute.
     #[qjs(skip)]
     pub fn ignore_function() -> u32 {
@@ -98,8 +104,11 @@ fn main() {
             ctx.clone(),
             "test2",
             r"
-            import { foo,aManuallyExportedValue, aConstValue, aStaticValue, FooBar } from 'test';
+            import { foo, renamedFoo, aManuallyExportedValue, aConstValue, aStaticValue, FooBar } from 'test';
             if (foo() !== 2){
+                throw new Error(1);
+            }
+            if (abc() !== 2) {
                 throw new Error(1);
             }
             if (aManuallyExportedValue !== 'Some Value'){


### PR DESCRIPTION
Fix issue #362

Line 366 in file macro/src/module/mod.rs seems to be referencing an incorrect identifier name.

https://github.com/DelSkayn/rquickjs/blob/bece520772b2291bc7823669faabd0753acd71d3/macro/src/module/mod.rs#L356-L372