### PR TITLE
Fix namespace resolution for JsLifetime in derive macro

### DIFF
--- a/macro/src/js_lifetime.rs
+++ b/macro/src/js_lifetime.rs
@@ -165,7 +165,7 @@ pub(crate) fn expand(mut input: DeriveInput) -> Result<TokenStream> {
             impl<#lt> ValidJsLifetimeImpl for #name<#lt>
                 where
                     #(
-                        #types: JsLifetime<#lt>
+                        #types: #crate_name::JsLifetime<#lt>
                     ),*
             {
             }


### PR DESCRIPTION
The derive macro for JsLifetime does not always use the fully qualified name.