### PR TITLE
Add `Module::write` options

### DIFF
--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -28,7 +28,8 @@ pub use result::{CatchResultExt, CaughtError, CaughtResult, Error, Result, Throw
 pub use value::{
     array, atom, convert, function, module, object, promise, Array, Atom, BigInt, CString, Coerced,
     Exception, Filter, FromAtom, FromIteratorJs, FromJs, Function, IntoAtom, IntoJs, IteratorJs,
-    Module, Null, Object, Promise, String, Symbol, Type, Undefined, Value,
+    Module, Null, Object, Promise, String, Symbol, Type, Undefined, Value, WriteOptions,
+    WriteOptionsEndianness,
 };
 
 pub mod allocator;

--- a/core/src/loader/compile.rs
+++ b/core/src/loader/compile.rs
@@ -1,6 +1,6 @@
 use crate::{
     loader::{util::resolve_simple, Loader, Resolver},
-    Ctx, Lock, Module, Mut, Ref, Result,
+    Ctx, Lock, Module, Mut, Ref, Result, WriteOptions,
 };
 use std::{
     collections::{hash_map::Iter as HashMapIter, HashMap},
@@ -186,7 +186,7 @@ where
 {
     fn load<'js>(&mut self, ctx: &Ctx<'js>, path: &str) -> Result<Module<'js>> {
         let module = self.inner.load(ctx, path)?;
-        let data = module.write(false)?;
+        let data = module.write(WriteOptions::default())?;
         self.data.lock().bytecodes.push((path.into(), data));
         Ok(module)
     }

--- a/core/src/value.rs
+++ b/core/src/value.rs
@@ -19,7 +19,7 @@ pub use bigint::BigInt;
 pub use convert::{Coerced, FromAtom, FromIteratorJs, FromJs, IntoAtom, IntoJs, IteratorJs};
 pub use exception::Exception;
 pub use function::{Constructor, Function};
-pub use module::Module;
+pub use module::{Module, WriteOptions, WriteOptionsEndianness};
 pub use object::{Filter, Object};
 pub use promise::Promise;
 pub use string::{CString, String};

--- a/core/src/value/module.rs
+++ b/core/src/value/module.rs
@@ -13,6 +13,68 @@ use crate::{
     Promise, Result, Value,
 };
 
+#[derive(Default)]
+pub enum WriteOptionsEndianness {
+    /// Native endian.
+    #[default]
+    Native,
+    /// Little endian.
+    Little,
+    /// Big endian.
+    Big,
+    /// Swaps from native to other kind.
+    Swap,
+}
+
+/// Module write options.
+#[derive(Default)]
+pub struct WriteOptions {
+    /// Endianness of bytecode.
+    pub endianness: WriteOptionsEndianness,
+    /// Allow SharedArrayBuffer.
+    pub allow_shared_array_buffer: bool,
+    /// Allow object references to encode arbitrary object graph.
+    pub object_reference: bool,
+    /// Do not write source code information.
+    pub strip_source: bool,
+    /// Do not write debug information.
+    pub strip_debug: bool,
+}
+
+impl WriteOptions {
+    fn to_flag(&self) -> i32 {
+        let mut flag = qjs::JS_WRITE_OBJ_BYTECODE;
+
+        let should_swap = match &self.endianness {
+            WriteOptionsEndianness::Native => false,
+            WriteOptionsEndianness::Little => cfg!(target_endian = "big"),
+            WriteOptionsEndianness::Big => cfg!(target_endian = "little"),
+            WriteOptionsEndianness::Swap => true,
+        };
+        if should_swap {
+            flag |= qjs::JS_WRITE_OBJ_BSWAP;
+        }
+
+        if self.allow_shared_array_buffer {
+            flag |= qjs::JS_WRITE_OBJ_SAB;
+        }
+
+        if self.object_reference {
+            flag |= qjs::JS_WRITE_OBJ_REFERENCE;
+        }
+
+        if self.strip_source {
+            flag |= qjs::JS_WRITE_OBJ_STRIP_SOURCE;
+        }
+
+        if self.strip_source {
+            flag |= qjs::JS_WRITE_OBJ_STRIP_DEBUG;
+        }
+
+        flag as i32
+    }
+}
+
 /// Helper macro to provide module init function.
 /// Use for exporting module definitions to be loaded as part of a dynamic library.
 /// ```
@@ -363,37 +425,36 @@ impl<'js> Module<'js, Declared> {
 }
 
 impl<'js, Evaluated> Module<'js, Evaluated> {
-    /// Write object bytecode for the module in little endian format.
-    pub fn write_le(&self) -> Result<Vec<u8>> {
-        let swap = cfg!(target_endian = "big");
-        self.write(swap)
-    }
-
-    /// Write object bytecode for the module in big endian format.
-    pub fn write_be(&self) -> Result<Vec<u8>> {
-        let swap = cfg!(target_endian = "little");
-        self.write(swap)
-    }
-
     /// Write object bytecode for the module.
     ///
-    /// `swap_endianess` swaps the endianness of the bytecode, if true, from native to the other
-    /// kind. Use if the bytecode is meant for a target with a different endianness than the
-    /// current.
-    pub fn write(&self, swap_endianess: bool) -> Result<Vec<u8>> {
+    /// # Examples
+    ///
+    /// ```
+    /// use rquickjs::{Context, Module, Result, Runtime, WriteOptions, WriteOptionsEndianness};
+    /// fn main() -> Result<()> {
+    ///     let rt = Runtime::new()?;
+    ///     let ctx = Context::full(&rt)?;
+    ///     let bytecode = ctx.with(|ctx| {
+    ///         let src = "console.log('hello world')";
+    ///         let module = Module::declare(ctx.clone(), "foo.js", src)?;
+    ///         module.write(WriteOptions {
+    ///             endianness: WriteOptionsEndianness::Little,
+    ///             ..Default::default()
+    ///         })
+    ///     })?;
+    ///     println!("bytecode: {bytecode:?}");
+    ///     Ok(())
+    /// }
+    /// ```
+    pub fn write(&self, options: WriteOptions) -> Result<Vec<u8>> {
         let ctx = &self.ctx;
         let mut len = MaybeUninit::uninit();
-        // TODO: Allow inclusion of other flags?
-        let mut flags = qjs::JS_WRITE_OBJ_BYTECODE;
-        if swap_endianess {
-            flags |= qjs::JS_WRITE_OBJ_BSWAP;
-        }
         let buf = unsafe {
             qjs::JS_WriteObject(
                 ctx.as_ptr(),
                 len.as_mut_ptr(),
                 qjs::JS_MKPTR(qjs::JS_TAG_MODULE, self.ptr.as_ptr().cast()),
-                flags as i32,
+                options.to_flag(),
             )
         };
         if buf.is_null() {

--- a/macro/src/embed.rs
+++ b/macro/src/embed.rs
@@ -3,7 +3,7 @@ use std::{env, path::Path};
 use crate::common::crate_ident;
 use proc_macro2::{Span, TokenStream};
 use quote::{format_ident, quote};
-use rquickjs_core::{Context, Module, Result as JsResult, Runtime};
+use rquickjs_core::{Context, Module, Result as JsResult, Runtime, WriteOptions};
 use syn::{
     parse::{Parse, ParseStream},
     punctuated::Punctuated,
@@ -99,7 +99,8 @@ pub fn embed(modules: EmbedModules) -> Result<TokenStream> {
 
         ctx.with(|ctx| -> JsResult<()> {
             for f in files.into_iter() {
-                let bc = Module::declare(ctx.clone(), f.0.clone(), f.1)?.write(false)?;
+                let bc = Module::declare(ctx.clone(), f.0.clone(), f.1)?
+                    .write(WriteOptions::default())?;
                 modules.push((f.0, bc));
             }
             Ok(())


### PR DESCRIPTION
Added `WriteOptions` struct that represents all flags that can be passed to `qjs::JS_WriteObject`, this is useful specially for the flags `JS_WRITE_OBJ_STRIP_SOURCE` and `JS_WRITE_OBJ_STRIP_DEBUG` which when enabled decreases the bytecode size significantly (see https://github.com/quickjs-ng/quickjs/pull/388), while adding it I've noticed two other flags (`JS_WRITE_OBJ_REFERENCE` and `JS_WRITE_OBJ_SAB`) that can be passed to it, so I've added as well ([ref](https://github.com/quickjs-ng/quickjs/blob/v0.8.0/quickjs.h#L875-L880)).