### PR TITLE
feat: Add lossy conversion between QJS string and Rust string

### DIFF
--- a/core/src/value/string.rs
+++ b/core/src/value/string.rs
@@ -259,9 +259,12 @@ mod test {
             let string = String::from_str(ctx.clone(), "🌍🌎🌏").unwrap();
 
             assert_eq!(string.to_string().unwrap(), "🌍🌎🌏".to_string());
+            assert_eq!(string.to_string_lossy().unwrap(), "🌍🌎🌏".to_string());
 
             let func: Function = ctx.eval("x => x.slice(1)").unwrap();
-            let text: StdString = (string,).apply(&func).unwrap();
+            let text: String = (string,).apply(&func).unwrap();
+            let text = text.to_string_lossy().unwrap();
+
             assert_eq!(text, "�🌎🌏".to_string());
         });
     }


### PR DESCRIPTION
`"🌍🌎🌏".slice(1)` currently produces a broken surrogate pair. When converting to a rust string, we get UTF8 error.
QJS handles this by just printing the invalid utf16 surrogate pair as a replacement char.

This PR introduces a new method `to_string_lossy` that will render a utf8 replacement char for broken surrogate pairs.