### PR TITLE
chore: fixed the description of defer()

### DIFF
--- a/core/src/value/function.rs
+++ b/core/src/value/function.rs
@@ -81,7 +81,7 @@ impl<'js> Function<'js> {
     /// Defer call the function with given arguments.
     ///
     /// Calling a function with defer is equivalent to calling a JavaScript function with
-    /// `setTimeout(func,0)`.
+    /// `queueMicrotask()`.
     pub fn defer<A>(&self, args: A) -> Result<()>
     where
         A: IntoArgs<'js>,


### PR DESCRIPTION
This PR fixes the description of `Function::defer()`.

- The internal processing of `defer()` is to register the task in the QuickJS microtask queue.
- In Javascript, this is closer to the implementation of `queueMicrotask()` than `setTimeout(fn, 0)`, so we have revised it to avoid any misunderstandings.