### PR TITLE
export DriveFuture as pub

### DIFF
--- a/core/src/runtime.rs
+++ b/core/src/runtime.rs
@@ -11,6 +11,8 @@ mod r#async;
 pub(crate) mod schedular;
 #[cfg(feature = "futures")]
 mod spawner;
+#[cfg(feature = "futures")]
+pub use spawner::DriveFuture;
 
 use alloc::boxed::Box;
 pub use base::{Runtime, WeakRuntime};


### PR DESCRIPTION
AsyncRuntime::drive returns DriveFuture, which is hidden behind a private module. Reexport it as pub for ease of use. Like passing it to other function.