### PR TITLE
fix(build): strip llvm suffix for *-pc-windows-gnullvm target

### DIFF
--- a/sys/build.rs
+++ b/sys/build.rs
@@ -300,9 +300,15 @@ where
     K: AsRef<str> + 'a,
     V: AsRef<str> + 'a,
 {
-    let target = env::var("TARGET").unwrap();
+    let mut target = env::var("TARGET").unwrap();
     let out_dir = out_dir.as_ref();
     let header_file = header_file.as_ref();
+
+    // *-pc-windows-gnullvm is special for Rust, Clang accepts only
+    // *-pc-windows-gnu
+    if target.ends_with("windows-gnullvm") {
+        target = target.replace("llvm", "");
+    }
 
     let mut cflags = vec![format!("--target={}", target)];
     cflags.append(&mut add_cflags);


### PR DESCRIPTION
otherwise bindgen fails because clang reports this suffix as wrong in target name