### PR TITLE
fix: Update dependencies and modify native loader to use dlopen2

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -21,7 +21,7 @@ indexmap = { version = "2", optional = true }
 either = { version = "1", optional = true }
 async-lock = { version = "3", optional = true, default-features = false }
 chrono = { version = "0.4", optional = true }
-dlopen = { version = "0.1", optional = true }
+dlopen2 = { version = "0.8", optional = true }
 relative-path = { version = "2.0", optional = true, default-features = false, features = [
     "alloc",
 ] }
@@ -63,7 +63,7 @@ parallel = ["std", "tokio/rt-multi-thread"]
 loader = ["relative-path"]
 
 # Enable native module loading support
-dyn-load = ["loader", "dlopen"]
+dyn-load = ["loader", "dlopen2"]
 
 # Use Rust global allocator by default
 # otherwise libc allocator will be used

--- a/core/src/loader/native_loader.rs
+++ b/core/src/loader/native_loader.rs
@@ -10,7 +10,7 @@ use super::Loader;
 #[derive(Debug)]
 pub struct NativeLoader {
     extensions: Vec<String>,
-    libs: Vec<dlopen::raw::Library>,
+    libs: Vec<dlopen2::raw::Library>,
 }
 
 impl NativeLoader {
@@ -49,7 +49,7 @@ impl Default for NativeLoader {
 
 impl Loader for NativeLoader {
     fn load<'js>(&mut self, ctx: &Ctx<'js>, path: &str) -> Result<Module<'js>> {
-        use dlopen::raw::Library;
+        use dlopen2::raw::Library;
 
         if !check_extensions(path, &self.extensions) {
             return Err(Error::new_loading(path));

--- a/macro/Cargo.toml
+++ b/macro/Cargo.toml
@@ -29,7 +29,7 @@ phf_generator = { version = "0.13", optional = true }
 [dev-dependencies]
 rquickjs = { path = "../", features = ["macro", "futures", "phf"] }
 difference = "2"
-async-std = { version = "1", features = ["attributes"] }
+
 
 [features]
 phf = ["phf_shared", "phf_generator"]

--- a/sys/build.rs
+++ b/sys/build.rs
@@ -123,7 +123,7 @@ fn main() {
 
     let header_files = [
         "builtin-array-fromasync.h",
-        "xsum.h",
+        "dtoa.h",
         "libregexp-opcode.h",
         "libregexp.h",
         "libunicode-table.h",
@@ -141,7 +141,7 @@ fn main() {
         "libunicode.c",
         "cutils.c",
         "quickjs.c",
-        "xsum.c",
+        "dtoa.c",
     ];
 
     let mut defines: Vec<(String, Option<&str>)> = vec![("_GNU_SOURCE".into(), None)];

--- a/tests/async_compile_fail/async_nested_contexts.stderr
+++ b/tests/async_compile_fail/async_nested_contexts.stderr
@@ -1,9 +1,9 @@
 error[E0521]: borrowed data escapes outside of closure
-  --> tests/async_compile_fail/async_nested_contexts.rs:11:13
+Error:   --> tests/async_compile_fail/async_nested_contexts.rs:11:13
    |
-7  | /      async_with!(ctx_1 => |ctx_1|{
-8  | |/         async_with!(ctx_2 => |ctx_2|{
-9  | ||             // It is disallowed to use multiple ctx object together from different with closures.
+ 7 | /      async_with!(ctx_1 => |ctx_1|{
+ 8 | |/         async_with!(ctx_2 => |ctx_2|{
+ 9 | ||             // It is disallowed to use multiple ctx object together from different with closures.
 10 | ||             // Lifetime on ctx should be unique.
 11 | ||             ctx_1.globals().set("t", ctx_2.globals());
    | ||             ^^^^^^^^^^^^^^^ `ctx_2` escapes the closure body here
@@ -13,10 +13,10 @@ error[E0521]: borrowed data escapes outside of closure
    | |_______- `ctx_1` declared here, outside of the closure body
 
 error[E0521]: borrowed data escapes outside of closure
-  --> tests/async_compile_fail/async_nested_contexts.rs:11:38
+Error:   --> tests/async_compile_fail/async_nested_contexts.rs:11:38
    |
-7  | /     async_with!(ctx_1 => |ctx_1|{
-8  | |         async_with!(ctx_2 => |ctx_2|{
+ 7 | /     async_with!(ctx_1 => |ctx_1|{
+ 8 | |         async_with!(ctx_2 => |ctx_2|{
 ...  |
 11 | |             ctx_1.globals().set("t", ctx_2.globals());
    | |                                      ^^^^^^^^^^^^^^^

--- a/tests/async_compile_fail/async_nested_contexts.stderr
+++ b/tests/async_compile_fail/async_nested_contexts.stderr
@@ -1,5 +1,5 @@
 error[E0521]: borrowed data escapes outside of closure
-Error:   --> tests/async_compile_fail/async_nested_contexts.rs:11:13
+  --> tests/async_compile_fail/async_nested_contexts.rs:11:13
    |
  7 | /      async_with!(ctx_1 => |ctx_1|{
  8 | |/         async_with!(ctx_2 => |ctx_2|{
@@ -13,7 +13,7 @@ Error:   --> tests/async_compile_fail/async_nested_contexts.rs:11:13
    | |_______- `ctx_1` declared here, outside of the closure body
 
 error[E0521]: borrowed data escapes outside of closure
-Error:   --> tests/async_compile_fail/async_nested_contexts.rs:11:38
+  --> tests/async_compile_fail/async_nested_contexts.rs:11:38
    |
  7 | /     async_with!(ctx_1 => |ctx_1|{
  8 | |         async_with!(ctx_2 => |ctx_2|{

--- a/tests/async_compile_fail/captured_variable.stderr
+++ b/tests/async_compile_fail/captured_variable.stderr
@@ -1,11 +1,11 @@
 error[E0597]: `var` does not live long enough
-  --> tests/async_compile_fail/captured_variable.rs:9:23
+Error:   --> tests/async_compile_fail/captured_variable.rs:9:23
    |
-7  |     let fut = {
+ 7 |     let fut = {
    |         --- borrow later stored here
-8  |         let mut var = 1u32;
+ 8 |         let mut var = 1u32;
    |             ------- binding `var` declared here
-9  |         let var_ref = &mut var;
+ 9 |         let var_ref = &mut var;
    |                       ^^^^^^^^ borrowed value does not live long enough
 ...
 13 |     };

--- a/tests/async_compile_fail/captured_variable.stderr
+++ b/tests/async_compile_fail/captured_variable.stderr
@@ -1,5 +1,5 @@
 error[E0597]: `var` does not live long enough
-Error:   --> tests/async_compile_fail/captured_variable.rs:9:23
+  --> tests/async_compile_fail/captured_variable.rs:9:23
    |
  7 |     let fut = {
    |         --- borrow later stored here

--- a/tests/async_compile_fail/captured_variable_func.stderr
+++ b/tests/async_compile_fail/captured_variable_func.stderr
@@ -1,5 +1,5 @@
 error[E0597]: `var` does not live long enough
-Error:   --> tests/async_compile_fail/captured_variable_func.rs:8:19
+  --> tests/async_compile_fail/captured_variable_func.rs:8:19
    |
  7 |       let mut var = 1u32;
    |           ------- binding `var` declared here

--- a/tests/async_compile_fail/captured_variable_func.stderr
+++ b/tests/async_compile_fail/captured_variable_func.stderr
@@ -1,11 +1,11 @@
 error[E0597]: `var` does not live long enough
-  --> tests/async_compile_fail/captured_variable_func.rs:8:19
+Error:   --> tests/async_compile_fail/captured_variable_func.rs:8:19
    |
-7  |       let mut var = 1u32;
+ 7 |       let mut var = 1u32;
    |           ------- binding `var` declared here
-8  |       let var_ref = &mut var;
+ 8 |       let var_ref = &mut var;
    |                     ^^^^^^^^ borrowed value does not live long enough
-9  |       async_with!(ctx => |ctx|{
+ 9 |       async_with!(ctx => |ctx|{
 10 | /         ctx.spawn(async move {
 11 | |             *var_ref += 1;
 12 | |         })

--- a/tests/async_compile_fail/captured_variable_spawn.stderr
+++ b/tests/async_compile_fail/captured_variable_spawn.stderr
@@ -1,9 +1,9 @@
 error[E0597]: `var` does not live long enough
-  --> tests/async_compile_fail/captured_variable_spawn.rs:8:19
+Error:   --> tests/async_compile_fail/captured_variable_spawn.rs:8:19
    |
-7  |     let mut var = 1u32;
+ 7 |     let mut var = 1u32;
    |         ------- binding `var` declared here
-8  |     let var_ref = &mut var;
+ 8 |     let var_ref = &mut var;
    |                   ^^^^^^^^ borrowed value does not live long enough
 ...
 13 |         ctx.globals().set("t",func).unwrap();

--- a/tests/async_compile_fail/captured_variable_spawn.stderr
+++ b/tests/async_compile_fail/captured_variable_spawn.stderr
@@ -1,5 +1,5 @@
 error[E0597]: `var` does not live long enough
-Error:   --> tests/async_compile_fail/captured_variable_spawn.rs:8:19
+  --> tests/async_compile_fail/captured_variable_spawn.rs:8:19
    |
  7 |     let mut var = 1u32;
    |         ------- binding `var` declared here


### PR DESCRIPTION
This change updates the build process to support the latest version of QuickJS.
Since dlopen has been abandoned, the implementation has been migrated to dlopen2 to ensure ongoing compatibility and maintenance.