### PR TITLE
fix strip debug and expose WriteOptions::to_flag

### DIFF
--- a/core/src/value/module.rs
+++ b/core/src/value/module.rs
@@ -43,7 +43,7 @@ pub struct WriteOptions {
 }
 
 impl WriteOptions {
-    fn to_flag(&self) -> i32 {
+    pub fn to_flag(&self) -> i32 {
         let mut flag = qjs::JS_WRITE_OBJ_BYTECODE;
 
         let should_swap = match &self.endianness {
@@ -68,7 +68,7 @@ impl WriteOptions {
             flag |= qjs::JS_WRITE_OBJ_STRIP_SOURCE;
         }
 
-        if self.strip_source {
+        if self.strip_debug {
             flag |= qjs::JS_WRITE_OBJ_STRIP_DEBUG;
         }
 


### PR DESCRIPTION
Fix this:

```diff
-        if self.strip_source {
+        if self.strip_debug {
             flag |= qjs::JS_WRITE_OBJ_STRIP_DEBUG;
         }
```

As some bytecode-related operations are not provided by rquickjs yet (like #398), it is still necessary to expose some APIs.