### PR TITLE
fix big int test: support JS_TAG_SHORT_BIG_INT

### DIFF
--- a/sys/src/inlines/common.rs
+++ b/sys/src/inlines/common.rs
@@ -29,7 +29,7 @@ pub unsafe fn JS_IsInt(v: JSValue) -> bool {
 #[inline]
 pub unsafe fn JS_IsBigInt(v: JSValue) -> bool {
     let tag = JS_VALUE_GET_TAG(v);
-    tag == JS_TAG_BIG_INT
+    tag == JS_TAG_BIG_INT || tag == JS_TAG_SHORT_BIG_INT
 }
 
 #[inline]


### PR DESCRIPTION
There is now a new tag `JS_TAG_SHORT_BIG_INT` for integers within 64-bit: quickjs-ng/quickjs#997
