### PR TITLE
Revert to katyo action

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,7 +17,7 @@ jobs:
         with:
           toolchain: stable
       - name: Publish crates
-        run: |
-          cargo publish --workspace --no-verify
-        env:
-          CARGO_REGISTRY_TOKEN: ${{ secrets.CRATES_TOKEN }}
+        uses: katyo/publish-crates@v2
+        with:
+          registry-token: ${{ secrets.CRATES_TOKEN }}
+          no-verify: false # otherwise the dependencies are not sorted


### PR DESCRIPTION
The native action doesn't skip existing packages.....
See https://github.com/rust-lang/cargo/issues/13397