### PR TITLE
Fix test for wasm32

### DIFF
--- a/core/src/value/convert/from.rs
+++ b/core/src/value/convert/from.rs
@@ -434,9 +434,6 @@ chrono_from_js_impls! {
 
 #[cfg(test)]
 mod test {
-    #[cfg(target_arch = "wasm32")]
-    use super::Error;
-
     #[test]
     fn js_to_system_time() {
         use crate::{Context, Runtime};


### PR DESCRIPTION
### Description of changes

The STD for wasm32 will change dramatically in 1.94, they are now using wasi-libc (https://github.com/WebAssembly/wasi-libc) which mimics the unix libc.