### PR TITLE
Add JS_UpdateStackTop calls before QuickJS C entry points

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Deprecated `async_with!` macro #[602](https://github.com/DelSkayn/rquickjs/pull/602)
 
+### Fixed
+
+- Fixed cross-thread stack overflow false positives in parallel mode by updating stack baseline before QuickJS C entry points
+
 ## [0.11.0] - 2025-12-16
 
 ### Added

--- a/core/src/context/ctx.rs
+++ b/core/src/context/ctx.rs
@@ -147,6 +147,10 @@ impl<'js> Ctx<'js> {
         let src = source.into();
         let len = src.len();
         let src = CString::new(src)?;
+
+        #[cfg(feature = "parallel")]
+        qjs::JS_UpdateStackTop(qjs::JS_GetRuntime(self.ctx.as_ptr()));
+
         let val = qjs::JS_Eval(
             self.ctx.as_ptr(),
             src.as_ptr(),

--- a/core/src/value/function/args.rs
+++ b/core/src/value/function/args.rs
@@ -130,6 +130,9 @@ impl<'js> Args<'js> {
         R: FromJs<'js>,
     {
         let val = unsafe {
+            #[cfg(feature = "parallel")]
+            qjs::JS_UpdateStackTop(qjs::JS_GetRuntime(self.ctx.as_ptr()));
+
             let val = qjs::JS_Call(
                 self.ctx.as_ptr(),
                 func.as_js_value(),
@@ -168,6 +171,9 @@ impl<'js> Args<'js> {
     {
         let value = if unsafe { qjs::JS_VALUE_GET_TAG(self.this) != qjs::JS_TAG_UNDEFINED } {
             unsafe {
+                #[cfg(feature = "parallel")]
+                qjs::JS_UpdateStackTop(qjs::JS_GetRuntime(self.ctx.as_ptr()));
+
                 qjs::JS_CallConstructor2(
                     self.ctx.as_ptr(),
                     constructor.as_js_value(),
@@ -178,6 +184,9 @@ impl<'js> Args<'js> {
             }
         } else {
             unsafe {
+                #[cfg(feature = "parallel")]
+                qjs::JS_UpdateStackTop(qjs::JS_GetRuntime(self.ctx.as_ptr()));
+
                 qjs::JS_CallConstructor(
                     self.ctx.as_ptr(),
                     constructor.as_js_value(),

--- a/core/src/value/module.rs
+++ b/core/src/value/module.rs
@@ -362,6 +362,9 @@ impl<'js> Module<'js, Declared> {
     /// The return value of the promise is the JavaScript value undefined.
     pub fn eval(self) -> Result<(Module<'js, Evaluated>, Promise<'js>)> {
         let ret = unsafe {
+            #[cfg(feature = "parallel")]
+            qjs::JS_UpdateStackTop(qjs::JS_GetRuntime(self.ctx.as_ptr()));
+
             // JS_EvalFunction `free's` the module so we should dup first
             let v = qjs::JS_MKPTR(qjs::JS_TAG_MODULE, self.ptr.as_ptr().cast());
             qjs::JS_DupValue(self.ctx.as_ptr(), v);


### PR DESCRIPTION
### Description of changes

Fixes cross-thread stack overflow false positives by ensuring stack_top baseline is updated whenever execution moves between tokio threads during async operations. Only active when 'parallel' feature is enabled.

### Checklist

- [x] Added change to the changelog
- [x] Created unit tests for my feature if needed
