### PR TITLE
Allow accessing the module from Declarations and Exports

### DIFF
--- a/core/src/value/module.rs
+++ b/core/src/value/module.rs
@@ -143,6 +143,11 @@ impl<'js> Declarations<'js> {
         unsafe { qjs::JS_AddModuleExport(self.0.ctx.as_ptr(), self.0.as_ptr(), name.as_ptr()) };
         Ok(self)
     }
+
+    /// Returns the module being declared.
+    pub fn module(&self) -> &Module<'js, Declared> {
+        &self.0
+    }
 }
 
 /// A struct used for setting the value of previously declared exporsts of a module.
@@ -173,6 +178,11 @@ impl<'js> Exports<'js> {
         }
 
         Ok(self)
+    }
+
+    /// Returns the module being exported.
+    pub fn module(&self) -> &Module<'js, Declared> {
+        &self.0
     }
 }
 
@@ -237,6 +247,11 @@ impl<'js, T> Module<'js, T> {
             )
         };
         N::from_atom(name)
+    }
+
+    /// Returns the context the module is associated with.
+    pub fn ctx(&self) -> &Ctx<'js> {
+        &self.ctx
     }
 }
 


### PR DESCRIPTION
### Issue # (if available)

<!--  **Please post the link to the resolved issue** -->

### Description of changes

<!-- **Please explain what your changes does** -->
This PR exposes the underlying `Module` from the `Declarations` and the `Exports` wrappers.
It also provides access to the module's `Ctx`.

This allows doing this like setting some userdata in the context, and accessing it during both module declaration and evaluation.
In particular, if that userdata is a HashMap, the module name can be used as a key to access module specific userdata, so that one `ModuleDef` can be shared across different modules.
This is useful in situations where the native modules can only be defined at runtime.

### Checklist

- [x] Added change to the changelog
- [ ] Created unit tests for my feature if needed
