### PR TITLE
Add import attributes to resolver

### DIFF
--- a/core/src/loader/builtin_resolver.rs
+++ b/core/src/loader/builtin_resolver.rs
@@ -1,4 +1,4 @@
-use crate::{loader::Resolver, Ctx, Error, Result};
+use crate::{loader::{ImportAttributes, Resolver}, Ctx, Error, Result};
 use alloc::string::{String, ToString as _};
 #[cfg(not(feature = "std"))]
 use hashbrown::HashSet;
@@ -30,7 +30,7 @@ impl BuiltinResolver {
 }
 
 impl Resolver for BuiltinResolver {
-    fn resolve<'js>(&mut self, _ctx: &Ctx<'js>, base: &str, name: &str) -> Result<String> {
+    fn resolve<'js>(&mut self, _ctx: &Ctx<'js>, base: &str, name: &str, _attributes: ImportAttributes<'js>) -> Result<String> {
         let full = if !name.starts_with('.') {
             name.to_string()
         } else {

--- a/core/src/loader/bundle.rs
+++ b/core/src/loader/bundle.rs
@@ -1,6 +1,6 @@
 //! Utilities for embedding JS modules.
 
-use super::{util::resolve_simple, Loader, Resolver};
+use super::{util::resolve_simple, ImportAttributes, Loader, Resolver};
 use crate::{Ctx, Error, Module, Result};
 use alloc::string::String;
 use core::ops::Deref;
@@ -42,7 +42,7 @@ impl<T> Deref for Bundle<T> {
 }
 
 impl<D> Resolver for Bundle<ScaBundleData<D>> {
-    fn resolve<'js>(&mut self, _ctx: &Ctx<'js>, base: &str, name: &str) -> Result<String> {
+    fn resolve<'js>(&mut self, _ctx: &Ctx<'js>, base: &str, name: &str, _attributes: ImportAttributes<'js>) -> Result<String> {
         let path = resolve_simple(base, name);
         if self.iter().any(|(name, _)| *name == path) {
             Ok(path)
@@ -54,7 +54,7 @@ impl<D> Resolver for Bundle<ScaBundleData<D>> {
 
 #[cfg(feature = "phf")]
 impl<D> Resolver for Bundle<PhfBundleData<D>> {
-    fn resolve<'js>(&mut self, _ctx: &Ctx<'js>, base: &str, name: &str) -> Result<String> {
+    fn resolve<'js>(&mut self, _ctx: &Ctx<'js>, base: &str, name: &str, _attributes: ImportAttributes<'js>) -> Result<String> {
         let path = resolve_simple(base, name);
         if self.contains_key(path.as_str()) {
             Ok(path)

--- a/core/src/loader/compile.rs
+++ b/core/src/loader/compile.rs
@@ -1,5 +1,5 @@
 use crate::{
-    loader::{util::resolve_simple, Loader, Resolver},
+    loader::{util::resolve_simple, ImportAttributes, Loader, Resolver},
     Ctx, Lock, Module, Mut, Ref, Result, WriteOptions,
 };
 use alloc::{string::String, vec::Vec};
@@ -176,8 +176,8 @@ impl<R> Resolver for Compile<R>
 where
     R: Resolver,
 {
-    fn resolve<'js>(&mut self, ctx: &Ctx<'js>, base: &str, name: &str) -> Result<String> {
-        self.inner.resolve(ctx, base, name).inspect(|path| {
+    fn resolve<'js>(&mut self, ctx: &Ctx<'js>, base: &str, name: &str, attributes: ImportAttributes<'js>) -> Result<String> {
+        self.inner.resolve(ctx, base, name, attributes).inspect(|path| {
             let name = resolve_simple(base, name);
             self.data.lock().modules.insert(path.clone(), name);
         })

--- a/core/src/loader/file_resolver.rs
+++ b/core/src/loader/file_resolver.rs
@@ -1,4 +1,4 @@
-use crate::{loader::Resolver, Ctx, Error, Result};
+use crate::{loader::{ImportAttributes, Resolver}, Ctx, Error, Result};
 use alloc::{
     string::{String, ToString as _},
     vec,
@@ -124,7 +124,7 @@ impl Default for FileResolver {
 }
 
 impl Resolver for FileResolver {
-    fn resolve<'js>(&mut self, _ctx: &Ctx<'js>, base: &str, name: &str) -> Result<String> {
+    fn resolve<'js>(&mut self, _ctx: &Ctx<'js>, base: &str, name: &str, _attributes: ImportAttributes<'js>) -> Result<String> {
         let path = if !name.starts_with('.') {
             self.paths.iter().find_map(|path| {
                 let path = path.join_normalized(name);


### PR DESCRIPTION
quickjs recently added support for accessing import attributes in the normalize function: https://github.com/quickjs-ng/quickjs/pull/1349

this pr adds the corresponding support in the resolver trait