### PR TITLE
refactor: use array instead of tuple for JS_NewPromiseCapability resolving_funcs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fixed cross-thread stack overflow false positives in parallel mode by updating stack baseline before QuickJS C entry points
 - Fixed iterators to use correct IteratorPrototype chain
+- Fixed a latent ABI layout vulnerability in `JS_NewPromiseCapability` FFI boundary by replacing tuple with strictly compatible array
 
 ## [0.11.0] - 2025-12-16
 

--- a/core/src/context/ctx.rs
+++ b/core/src/context/ctx.rs
@@ -376,14 +376,14 @@ impl<'js> Ctx<'js> {
 
     /// Creates javascipt promise along with its reject and resolve functions.
     pub fn promise(&self) -> Result<(Promise<'js>, Function<'js>, Function<'js>)> {
-        let mut funcs = mem::MaybeUninit::<(qjs::JSValue, qjs::JSValue)>::uninit();
+        let mut funcs = mem::MaybeUninit::<[qjs::JSValue; 2]>::uninit();
 
         Ok(unsafe {
             let promise = self.handle_exception(qjs::JS_NewPromiseCapability(
                 self.ctx.as_ptr(),
                 funcs.as_mut_ptr() as _,
             ))?;
-            let (resolve, reject) = funcs.assume_init();
+            let [resolve, reject] = funcs.assume_init();
             (
                 Promise::from_js_value(self.clone(), promise),
                 Function::from_js_value(self.clone(), resolve),


### PR DESCRIPTION
### Issue # (if available)

N/A (Discovered via automated FFI analysis)

### Description of changes

Hi team! Thanks for the amazing work on `rquickjs`.

While reviewing the FFI boundaries, I noticed a minor detail in how we allocate `funcs` for `JS_NewPromiseCapability`. Currently, it uses a tuple `(qjs::JSValue, qjs::JSValue)` and casts it to a pointer.

Since `rustc` doesn't strictly guarantee the memory layout of tuples (`repr(Rust)`), passing a tuple pointer to a C array parameter might theoretically cause unexpected reordering on some niche architectures or future compiler versions (even though it works perfectly fine on current versions for homogeneous tuples).

To make the FFI boundary absolutely strict and future-proof, this PR simply replaces the tuple with a `[qjs::JSValue; 2]` array. With modern Rust's array pattern matching, the destructuring remains just as clean:
`let [resolve, reject] = funcs.assume_init();`

It's a zero-cost change that just adds strict ABI safety. Existing Promise unit tests cover the validation. Let me know if everything looks good!

### Checklist

- [x] Added change to the changelog
- [x] Created unit tests for my feature if needed (Note: Existing Promise tests act as full regression tests since this is purely a zero-cost ABI layout fix)
