### PR TITLE
Fix: interrupt handler causes GC assertion failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fixed interrupt handler causing GC assertion failure due to missing `JS_DupContext` on error context from `JS_ExecutePendingJob` #[664](https://github.com/DelSkayn/rquickjs/pull/664)
 - Fixed cross-thread stack overflow false positives in parallel mode by updating stack baseline before QuickJS C entry points
 - Fixed promise polling not returning Ready variant when exception occurs
 - Fixed iterators to use correct IteratorPrototype chain

--- a/core/src/runtime/async.rs
+++ b/core/src/runtime/async.rs
@@ -19,12 +19,11 @@ use super::{
 use crate::allocator::Allocator;
 #[cfg(feature = "loader")]
 use crate::loader::{Loader, Resolver};
-use crate::{
-    context::AsyncContext, qjs, result::AsyncJobException, util::ManualPoll, Ctx, Exception,
-    Result,
-};
 #[cfg(feature = "parallel")]
 use crate::util::{AssertSendFuture, AssertSyncFuture};
+use crate::{
+    context::AsyncContext, qjs, result::AsyncJobException, util::ManualPoll, Ctx, Exception, Result,
+};
 
 #[derive(Debug)]
 pub(crate) struct InnerRuntime {

--- a/core/src/runtime/async.rs
+++ b/core/src/runtime/async.rs
@@ -20,13 +20,11 @@ use crate::allocator::Allocator;
 #[cfg(feature = "loader")]
 use crate::loader::{Loader, Resolver};
 use crate::{
-    context::AsyncContext, result::AsyncJobException, util::ManualPoll, Ctx, Exception, Result,
+    context::AsyncContext, qjs, result::AsyncJobException, util::ManualPoll, Ctx, Exception,
+    Result,
 };
 #[cfg(feature = "parallel")]
-use crate::{
-    qjs,
-    util::{AssertSendFuture, AssertSyncFuture},
-};
+use crate::util::{AssertSendFuture, AssertSyncFuture};
 
 #[derive(Debug)]
 pub(crate) struct InnerRuntime {
@@ -287,6 +285,9 @@ impl AsyncRuntime {
             let job_res = lock.runtime.execute_pending_job().map_err(|e| {
                 let ptr = NonNull::new(e)
                     .expect("executing pending job returned a null context on error");
+                // JS_ExecutePendingJob returns a borrowed context pointer;
+                // dup it so AsyncContext can own a reference.
+                unsafe { qjs::JS_DupContext(ptr.as_ptr()) };
                 AsyncJobException(unsafe { AsyncContext::from_raw(ptr, self.clone()) })
             })?;
 
@@ -320,6 +321,9 @@ impl AsyncRuntime {
                 let pending = lock.runtime.execute_pending_job().map_err(|e| {
                     let ptr = NonNull::new(e)
                         .expect("executing pending job returned a null context on error");
+                    // JS_ExecutePendingJob returns a borrowed context pointer;
+                    // dup it so AsyncContext can own a reference.
+                    unsafe { qjs::JS_DupContext(ptr.as_ptr()) };
                     AsyncJobException(unsafe { AsyncContext::from_raw(ptr, self.clone()) })
                 });
                 match pending {
@@ -602,6 +606,32 @@ mod test {
         rt.idle().await;
 
         assert_eq!(COUNT.load(Ordering::Relaxed),2);
+    });
+
+    async_test_case!(interrupt_handler_idle => (rt, ctx) {
+        use std::time::Instant;
+
+        let timeout = Duration::from_millis(100);
+        let start_time = Instant::now();
+
+        rt.set_interrupt_handler(Some(Box::new(move || start_time.elapsed() >= timeout)))
+            .await;
+
+        let _ = ctx.async_with(async |ctx| {
+            ctx.eval::<(), _>(r#"
+                async function example() {
+                    while (true) {
+                        await Promise.resolve();
+                    }
+                }
+                example();
+            "#)
+        }).await;
+
+        // This previously caused an assertion failure in gc_decref_child
+        // due to the interrupt handler corrupting reference counts during
+        // pending job execution.
+        rt.idle().await;
     });
 
     #[cfg(feature = "parallel")]

--- a/core/src/runtime/base.rs
+++ b/core/src/runtime/base.rs
@@ -6,7 +6,7 @@ use super::{
 use crate::allocator::Allocator;
 #[cfg(feature = "loader")]
 use crate::loader::{Loader, Resolver};
-use crate::{result::JobException, Context, Mut, Ref, Result, Weak};
+use crate::{qjs, result::JobException, Context, Mut, Ref, Result, Weak};
 use alloc::{ffi::CString, vec::Vec};
 use core::{ptr::NonNull, result::Result as StdResult};
 
@@ -182,12 +182,11 @@ impl Runtime {
         let mut lock = self.inner.lock();
         lock.update_stack_top();
         lock.execute_pending_job().map_err(|e| {
-            JobException(unsafe {
-                Context::from_raw(
-                    NonNull::new(e).expect("QuickJS returned null ptr for job error"),
-                    self.clone(),
-                )
-            })
+            let ptr = NonNull::new(e).expect("QuickJS returned null ptr for job error");
+            // JS_ExecutePendingJob returns a borrowed context pointer;
+            // dup it so Context can own a reference.
+            unsafe { qjs::JS_DupContext(ptr.as_ptr()) };
+            JobException(unsafe { Context::from_raw(ptr, self.clone()) })
         })
     }
 }


### PR DESCRIPTION
### Issue #

Fixes #663

### Description of changes

The context pointer returned by `JS_ExecutePendingJob` on error is borrowed, but was passed to `Context::from_raw`/`AsyncContext::from_raw` which assume ownership. Their `Drop` calls `JS_FreeContext`, causing a ref_count underflow that later triggers `assert(p->ref_count > 0)` in `gc_decref_child` during GC.

Added `JS_DupContext` before wrapping the pointer so the reference count stays balanced.

### Checklist

- [x] Added change to the changelog
- [x] Created unit tests for my feature if needed