### PR TITLE
Support rope strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fixed QuickJS rope strings (`JS_TAG_STRING_ROPE`) not being recognized as strings, causing `type_of()`, `is_string()`, and `as_string()` to fail on large concatenated strings
 - Fixed interrupt handler causing GC assertion failure due to missing `JS_DupContext` on error context from `JS_ExecutePendingJob` #[664](https://github.com/DelSkayn/rquickjs/pull/664)
 - Fixed cross-thread stack overflow false positives in parallel mode by updating stack baseline before QuickJS C entry points
 - Fixed promise polling not returning Ready variant when exception occurs

--- a/core/src/value.rs
+++ b/core/src/value.rs
@@ -329,7 +329,8 @@ impl<'js> Value<'js> {
     /// Check if the value is a string
     #[inline]
     pub fn is_string(&self) -> bool {
-        qjs::JS_TAG_STRING == unsafe { qjs::JS_VALUE_GET_TAG(self.value) }
+        let tag = unsafe { qjs::JS_VALUE_GET_TAG(self.value) };
+        tag == qjs::JS_TAG_STRING || tag == qjs::JS_TAG_STRING_ROPE
     }
 
     /// Check if the value is a symbol
@@ -541,7 +542,7 @@ type_impls! {
     Bool: bool => JS_TAG_BOOL,
     Int: int => JS_TAG_INT,
     Float: float => JS_TAG_FLOAT64,
-    String: string => JS_TAG_STRING,
+    String: string => JS_TAG_STRING | JS_TAG_STRING_ROPE,
     Symbol: symbol => JS_TAG_SYMBOL,
     Array: array => JS_TAG_OBJECT,
     Constructor: constructor => JS_TAG_OBJECT,

--- a/core/src/value/string.rs
+++ b/core/src/value/string.rs
@@ -182,4 +182,28 @@ mod test {
             assert_eq!(text, "foobar".to_string());
         });
     }
+
+    #[test]
+    fn rope_string() {
+        test_with(|ctx| {
+            let val: Value = ctx
+                .eval(
+                    r#"
+                    let s = "";
+                    for (let i = 0; i < 10000; i++) s += "Line " + i + "\n";
+                    s
+                "#,
+                )
+                .unwrap();
+
+            assert_eq!(val.type_of(), Type::String);
+            assert!(val.is_string());
+            assert!(val.as_string().is_some());
+
+            let s: StdString = val.as_string().unwrap().to_string().unwrap();
+            assert!(s.starts_with("Line 0\n"));
+            assert!(s.contains("Line 999\n"));
+            assert!(s.len() > 8000);
+        });
+    }
 }

--- a/sys/src/inlines/common.rs
+++ b/sys/src/inlines/common.rs
@@ -65,7 +65,7 @@ pub unsafe fn JS_IsUninitialized(v: JSValue) -> bool {
 #[inline]
 pub unsafe fn JS_IsString(v: JSValue) -> bool {
     let tag = JS_VALUE_GET_TAG(v);
-    tag == JS_TAG_STRING
+    tag == JS_TAG_STRING || tag == JS_TAG_STRING_ROPE
 }
 
 #[inline]


### PR DESCRIPTION
### Description of changes

Fixed QuickJS rope strings (`JS_TAG_STRING_ROPE`) not being recognized as strings, causing `type_of()`, `is_string()`, and `as_string()` to fail on large concatenated strings

### Checklist

- [x] Added change to the changelog
- [x] Created unit tests for my feature if needed
