### PR TITLE
sys: let bindgen handle target triple mapping

### DIFF
--- a/sys/build.rs
+++ b/sys/build.rs
@@ -293,7 +293,7 @@ where
 }
 
 #[cfg(feature = "bindgen")]
-fn bindgen<'a, D, H, X, K, V>(out_dir: D, header_file: H, defines: X, mut add_cflags: Vec<String>)
+fn bindgen<'a, D, H, X, K, V>(out_dir: D, header_file: H, defines: X, add_cflags: Vec<String>)
 where
     D: AsRef<Path>,
     H: AsRef<Path>,
@@ -301,18 +301,10 @@ where
     K: AsRef<str> + 'a,
     V: AsRef<str> + 'a,
 {
-    let mut target = env::var("TARGET").unwrap();
     let out_dir = out_dir.as_ref();
     let header_file = header_file.as_ref();
 
-    // *-pc-windows-gnullvm is special for Rust, Clang accepts only
-    // *-pc-windows-gnu
-    if target.ends_with("windows-gnullvm") {
-        target = target.replace("llvm", "");
-    }
-
-    let mut cflags = vec![format!("--target={}", target)];
-    cflags.append(&mut add_cflags);
+    let mut cflags = add_cflags;
 
     //format!("-I{}", out_dir.parent().display()),
 
@@ -358,7 +350,7 @@ where
         let dest_dir = Path::new("src").join("bindings");
         fs::create_dir_all(&dest_dir).unwrap();
 
-        let dest_file = format!("{}.rs", target);
+        let dest_file = format!("{}.rs", env::var("TARGET").unwrap());
         fs::copy(&bindings_file, dest_dir.join(dest_file)).unwrap();
     }
 }


### PR DESCRIPTION
### Description of changes

The build script manually passed `--target={rust_triple}` to clang via `.clang_args()`, bypassing bindgen's `rust_to_clang_target()` which correctly maps Rust triples to clang-compatible ones (e.g. `riscv64gc-unknown-linux-gnu` to `riscv64-unknown-linux-gnu`, and `*-windows-gnullvm` to `*-windows-gnu`). This broke builds on riscv64 because clang does not recognize the `gc` ISA extension suffix in the target triple.

The manual `--target` and the gnullvm workaround from #506 are both unnecessary since bindgen 0.65+ handles these mappings internally.

(My use case is getting riscv64 bindings generated for tree-sitter now that we have a risc-v runner in theory)

### Checklist

- [ ] Added change to the changelog
- [ ] Created unit tests for my feature if needed
