### PR TITLE
Add #[qjs(prop)] for data properties on class prototypes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added `#[qjs(prop)]` method attribute to declare a JS data property on a class prototype.
+  Unlike `#[qjs(get)]`, which generates an accessor and requires a `FromJs<Self>` receiver,
+  `prop` is evaluated at class registration time and emits a plain data descriptor (matching
+  Web IDL semantics for `@@toStringTag`, `@@species`, etc.). Honours `rename`, `configurable`,
+  `enumerable`, and a new `writable` flag (which also gates `writable` on `prop`).
 - Added `FromJs` and `IntoJs` derive macros for plain-data structs
 - Added `RQUICKJS_SYS_NO_WASI_SDK` env variable that skips downloading and setting up the WASI SDK when set to `1` #[648](https://github.com/DelSkayn/rquickjs/pull/648)
 - Added `Object::new_proto` for creating objects with a custom or null prototype #[572](https://github.com/DelSkayn/rquickjs/issues/572)

--- a/macro/src/common.rs
+++ b/macro/src/common.rs
@@ -136,6 +136,8 @@ pub(crate) mod kw {
     syn::custom_keyword!(skip);
     syn::custom_keyword!(configurable);
     syn::custom_keyword!(enumerable);
+    syn::custom_keyword!(writable);
+    syn::custom_keyword!(prop);
     syn::custom_keyword!(prefix);
     syn::custom_keyword!(declare);
     syn::custom_keyword!(evaluate);

--- a/macro/src/lib.rs
+++ b/macro/src/lib.rs
@@ -194,8 +194,10 @@ pub fn function(attr: TokenStream1, item: TokenStream1) -> TokenStream1 {
 /// |----------------|-------------------------------------------------------------------|-------------------------------------------------------------------------------------------------|
 /// | `get`          | Flag                                                              | Makes this method a getter for a field of the same name.                                        |
 /// | `set`          | Flag                                                              | Makes this method a setter for a field of the same name.                                        |
-/// | `enumerable`   | Flag                                                              | Makes the method, if it is a getter or setter, enumerable in JavaScript.                        |
-/// | `configurable` | Flag                                                              | Makes the method, if it is a getter or setter, configurable in JavaScript.                      |
+/// | `prop`         | Flag                                                              | Declares a JS **data property** on the prototype. The function takes no receiver, is evaluated once at class registration time, and its return value becomes the property's value. Useful for Web IDL hooks like `Symbol.toStringTag` where the spec mandates a data (not accessor) descriptor. |
+/// | `enumerable`   | Flag                                                              | Makes the method, if it is a getter, setter or `prop`, enumerable in JavaScript.                |
+/// | `configurable` | Flag                                                              | Makes the method, if it is a getter, setter or `prop`, configurable in JavaScript (i.e. the descriptor can later be redefined or deleted). |
+/// | `writable`     | Flag                                                              | Only valid together with `prop`: makes the data property writable from JavaScript. Defaults to non-writable, matching Web IDL defaults for things like `@@toStringTag`. |
 /// | `rename`       | String or [`PredefinedAtom`](rquickjs_core::atom::PredefinedAtom) | Changes the name of the field getter and/or setter to the specified name in JavaScript.         |
 /// | `static`       | Flag                                                              | Makes the method a static method i.e. defined on the type constructor instead of the prototype. |
 /// | `constructor`  | Flag                                                              | Marks this method a the constructor for this type.                                              |
@@ -265,6 +267,24 @@ pub fn function(attr: TokenStream1, item: TokenStream1) -> TokenStream1 {
 ///     /// class. This attributes allows you to skip certain functions.
 ///     #[qjs(skip)]
 ///     pub fn inner_function(&self) {}
+///
+///     /// Declares a **data property** on the prototype. Unlike `get`, `prop` takes no
+///     /// receiver and is evaluated once at class registration time; the return value
+///     /// becomes the property's value. This is the correct shape for Web IDL hooks
+///     /// like `Symbol.toStringTag`, which the spec mandates be a non-writable,
+///     /// configurable *data* descriptor (so e.g.
+///     /// `Object.prototype.toString.call(Object.create(TestClass.prototype))`
+///     /// works without a real class instance).
+///     #[qjs(prop, rename = PredefinedAtom::SymbolToStringTag, configurable)]
+///     pub fn to_string_tag() -> &'static str {
+///         "TestClass"
+///     }
+///
+///     /// A named, writable data property with all three descriptor flags set.
+///     #[qjs(prop, rename = "kind", configurable, enumerable, writable)]
+///     pub fn kind() -> &'static str {
+///         "test"
+///     }
 ///
 ///     /// Functions can also be renamed to specific symbols. This allows you to make an Rust type
 ///     /// act like an iteratable value for example.

--- a/macro/src/methods.rs
+++ b/macro/src/methods.rs
@@ -133,7 +133,7 @@ pub(crate) fn expand(options: OptionList<ImplOption>, item: ItemImpl) -> Result<
 
     let mut accessors = HashMap::new();
     let mut functions = Vec::new();
-    let mut props = Vec::<Method>::new();
+    let mut props = Vec::new();
     let mut constructor: Option<Method> = None;
     let mut static_span: Option<Span> = None;
     //let mut consts = Vec::new();

--- a/macro/src/methods.rs
+++ b/macro/src/methods.rs
@@ -133,6 +133,7 @@ pub(crate) fn expand(options: OptionList<ImplOption>, item: ItemImpl) -> Result<
 
     let mut accessors = HashMap::new();
     let mut functions = Vec::new();
+    let mut props = Vec::<Method>::new();
     let mut constructor: Option<Method> = None;
     let mut static_span: Option<Span> = None;
     //let mut consts = Vec::new();
@@ -143,7 +144,9 @@ pub(crate) fn expand(options: OptionList<ImplOption>, item: ItemImpl) -> Result<
             syn::ImplItem::Fn(item) => {
                 let function = Method::parse_impl_fn(item, &self_ty)?;
                 let span = function.attr_span;
-                if function.config.get || function.config.set {
+                if function.config.prop {
+                    props.push(function);
+                } else if function.config.get || function.config.set {
                     let access = accessors
                         .entry(function.name(config.rename_all))
                         .or_insert_with(JsAccessor::new);
@@ -184,6 +187,7 @@ pub(crate) fn expand(options: OptionList<ImplOption>, item: ItemImpl) -> Result<
 
     let function_impls = functions.iter().map(|func| func.expand_impl());
     let accessor_impls = accessors.values().map(|access| access.expand_impl());
+    let prop_impls = props.iter().map(|p| p.expand_impl());
     let constructor_impl = constructor.as_ref().map(|constr| constr.expand_impl());
 
     let function_js_impls = functions
@@ -210,6 +214,9 @@ pub(crate) fn expand(options: OptionList<ImplOption>, item: ItemImpl) -> Result<
     let accessor_apply_proto = accessors
         .values()
         .map(|access| access.expand_apply_to_proto(&crate_name, config.rename_all));
+    let prop_apply_proto = props
+        .iter()
+        .map(|p| p.expand_apply_prop_to_object(&crate_name, &proto_ident, config.rename_all));
 
     let constructor_ident = format_ident!("constr");
 
@@ -252,6 +259,7 @@ pub(crate) fn expand(options: OptionList<ImplOption>, item: ItemImpl) -> Result<
         #impl_token #generics #self_ty {
             #(#function_impls)*
             #(#accessor_impls)*
+            #(#prop_impls)*
             #constructor_impl
         }
 
@@ -271,6 +279,7 @@ pub(crate) fn expand(options: OptionList<ImplOption>, item: ItemImpl) -> Result<
                 fn implement(&self, _proto: &#crate_name::Object<'_>) -> #crate_name::Result<()>{
                     #(#function_apply_proto)*
                     #(#accessor_apply_proto)*
+                    #(#prop_apply_proto)*
                     Ok(())
                 }
             }

--- a/macro/src/methods/method.rs
+++ b/macro/src/methods/method.rs
@@ -20,8 +20,10 @@ pub(crate) struct MethodConfig {
     pub r#static: bool,
     pub configurable: bool,
     pub enumerable: bool,
+    pub writable: bool,
     pub get: bool,
     pub set: bool,
+    pub prop: bool,
     pub rename: Option<Expr>,
 }
 
@@ -43,11 +45,17 @@ impl MethodConfig {
             MethodOption::Enumerable(x) => {
                 self.enumerable = x.is_true();
             }
+            MethodOption::Writable(x) => {
+                self.writable = x.is_true();
+            }
             MethodOption::Get(x) => {
                 self.get = x.is_true();
             }
             MethodOption::Set(x) => {
                 self.set = x.is_true();
+            }
+            MethodOption::Prop(x) => {
+                self.prop = x.is_true();
             }
             MethodOption::Rename(x) => {
                 self.rename = Some(x.value.clone());
@@ -62,8 +70,10 @@ pub(crate) enum MethodOption {
     Skip(FlagOption<kw::skip>),
     Configurable(FlagOption<kw::configurable>),
     Enumerable(FlagOption<kw::enumerable>),
+    Writable(FlagOption<kw::writable>),
     Get(FlagOption<kw::get>),
     Set(FlagOption<kw::set>),
+    Prop(FlagOption<kw::prop>),
     Rename(ValueOption<kw::rename, Expr>),
 }
 
@@ -79,10 +89,14 @@ impl Parse for MethodOption {
             input.parse().map(Self::Configurable)
         } else if input.peek(kw::enumerable) {
             input.parse().map(Self::Enumerable)
+        } else if input.peek(kw::writable) {
+            input.parse().map(Self::Writable)
         } else if input.peek(kw::get) {
             input.parse().map(Self::Get)
         } else if input.peek(kw::set) {
             input.parse().map(Self::Set)
+        } else if input.peek(kw::prop) {
+            input.parse().map(Self::Prop)
         } else if input.peek(kw::rename) {
             input.parse().map(Self::Rename)
         } else {
@@ -120,17 +134,31 @@ impl MethodConfig {
             ));
         }
 
-        if self.configurable && !(self.get || self.set) {
+        if self.configurable && !(self.get || self.set || self.prop) {
             return Err(Error::new(
                 span,
-                "configurable can only be set for getters and setters.",
+                "configurable can only be set for getters, setters and data properties.",
             ));
         }
 
-        if self.enumerable && !(self.get || self.set) {
+        if self.enumerable && !(self.get || self.set || self.prop) {
             return Err(Error::new(
                 span,
-                "enumerable can only be set for getters and setters.",
+                "enumerable can only be set for getters, setters and data properties.",
+            ));
+        }
+
+        if self.writable && !self.prop {
+            return Err(Error::new(
+                span,
+                "writable can only be set for data properties (`prop`).",
+            ));
+        }
+
+        if self.prop && (self.get || self.set || self.constructor || self.r#static) {
+            return Err(Error::new(
+                span,
+                "`prop` cannot be combined with `get`, `set`, `constructor` or `static`.",
             ));
         }
         Ok(())
@@ -279,6 +307,44 @@ impl Method {
         let js_func_name = self.function.expand_carry_type_name(prefix);
         quote! {
             #object_name.set(#func_name_str,<#self_ty>::#js_func_name)?;
+        }
+    }
+
+    /// Expand a data-property registration (`#[qjs(prop)]`) onto the given object.
+    pub(crate) fn expand_apply_prop_to_object(
+        &self,
+        lib_crate: &Ident,
+        object_name: &Ident,
+        case: Option<Case>,
+    ) -> TokenStream {
+        if self.config.skip {
+            return TokenStream::new();
+        }
+        let name = self.name(case);
+        let rust_function = &self.function.rust_function;
+        let configurable = if self.config.configurable {
+            quote!(.configurable())
+        } else {
+            TokenStream::new()
+        };
+        let enumerable = if self.config.enumerable {
+            quote!(.enumerable())
+        } else {
+            TokenStream::new()
+        };
+        let writable = if self.config.writable {
+            quote!(.writable())
+        } else {
+            TokenStream::new()
+        };
+        quote! {
+            #object_name.prop(
+                #name,
+                #lib_crate::object::Property::from(#rust_function())
+                    #configurable
+                    #enumerable
+                    #writable
+            )?;
         }
     }
 }

--- a/tests/macros/pass_method.rs
+++ b/tests/macros/pass_method.rs
@@ -48,6 +48,16 @@ impl TestClass {
     #[qjs(skip)]
     pub fn inner_function(&self) {}
 
+    #[qjs(prop, rename = PredefinedAtom::SymbolToStringTag, configurable)]
+    pub fn to_string_tag() -> &'static str {
+        "TestClass"
+    }
+
+    #[qjs(prop, rename = "kind", configurable, enumerable, writable)]
+    pub fn kind() -> &'static str {
+        "test"
+    }
+
     #[qjs(rename = PredefinedAtom::SymbolIterator)]
     pub fn iterate<'js>(&self, ctx: Ctx<'js>) -> Result<Object<'js>> {
         let res = Object::new(ctx)?;
@@ -112,6 +122,31 @@ pub fn main() {
             }
             for(const v of t){
                 throw new Error("iterator should be done immediately")
+            }
+            // --- data-property (`#[qjs(prop)]`) assertions ---
+            // @@toStringTag must be a data descriptor (value present, no get/set).
+            let tagDesc = Object.getOwnPropertyDescriptor(proto, Symbol.toStringTag);
+            if(!tagDesc || tagDesc.value !== "TestClass"){
+                throw new Error(9)
+            }
+            if(tagDesc.get !== undefined || tagDesc.set !== undefined){
+                throw new Error(10)
+            }
+            if(tagDesc.configurable !== true || tagDesc.enumerable !== false || tagDesc.writable !== false){
+                throw new Error(11)
+            }
+            // The regression case: calling toString on a fake instance must not throw.
+            let fake = Object.create(TestClass.prototype);
+            if(Object.prototype.toString.call(fake) !== "[object TestClass]"){
+                throw new Error(12)
+            }
+            // Named data property with writable + enumerable + configurable.
+            let kindDesc = Object.getOwnPropertyDescriptor(proto, "kind");
+            if(!kindDesc || kindDesc.value !== "test"){
+                throw new Error(13)
+            }
+            if(kindDesc.configurable !== true || kindDesc.enumerable !== true || kindDesc.writable !== true){
+                throw new Error(14)
             }
         "#,
         )


### PR DESCRIPTION
Adds a `#[qjs(prop)]` method attribute that declares a JS data property (evaluated at class registration time) on the prototype, enabling spec-correct `Symbol.toStringTag` and similar Web IDL hooks without the `FromJs<Self>` receiver accessor `#[qjs(get)]` requires.