### PR TITLE
Reject JsClass types as class fields; guide users to Class<'js, T>

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed promise future aborting on stale pending exceptions by only bailing on uncatchable errors (e.g. interrupt handler)
 - Fixed iterators to use correct IteratorPrototype chain
 - Fixed a latent ABI layout vulnerability in `JS_NewPromiseCapability` FFI boundary by replacing tuple with strictly compatible array
+- `#[rquickjs::class]` now rejects fields whose type implements `JsClass` with a clear compile error; such fields silently dropped nested mutations because the generated getter cloned the value. Wrap the field in `Class<'js, T>` instead #[532](https://github.com/DelSkayn/rquickjs/issues/532)
 
 ## [0.11.0] - 2025-12-16
 

--- a/core/src/class/impl_.rs
+++ b/core/src/class/impl_.rs
@@ -1,6 +1,6 @@
 //! Helper classes and functions for use inside the macros.
 
-use crate::{value::Constructor, Ctx, Object, Result};
+use crate::{class::JsClass, value::Constructor, Ctx, Object, Result};
 use core::marker::PhantomData;
 
 /// Trait used for borrow specialization for implementing methods without access to the class.
@@ -72,4 +72,52 @@ impl<'a, T: Clone> CloneTrait<T> for CloneWrapper<'a, T> {
     fn wrap_clone(&self) -> T {
         self.0.clone()
     }
+}
+
+/// Compile-time check used by the `#[rquickjs::class]` macro to reject
+/// fields with `#[qjs(get)]`/`#[qjs(set)]` that are themselves a [`JsClass`]
+/// type.
+///
+/// Such fields do not round-trip with reference semantics: the generated
+/// getter clones the value and wraps the clone in a fresh class instance, so
+/// nested mutations (e.g. `obj.b.c = x`) are discarded. Wrap the field in a
+/// [`Class<'js, T>`](crate::class::Class) instead to share the underlying cell.
+///
+/// Uses autoref-specialization: the inherent `check` (deprecated) is picked
+/// when `T: JsClass`, otherwise the trait fallback below is used.
+#[derive(Default)]
+pub struct JsClassFieldCheck<T>(PhantomData<T>);
+
+impl<T> JsClassFieldCheck<T> {
+    pub fn new() -> Self {
+        Self(PhantomData)
+    }
+}
+
+/// Marker trait with no implementations. Used purely for its
+/// [`on_unimplemented`](https://doc.rust-lang.org/reference/attributes/diagnostics.html#the-diagnosticon_unimplemented-attribute)
+/// diagnostic: when `JsClassFieldCheck::<T>::check()` is selected via
+/// autoref-specialization for a `T: JsClass`, its `where T: NotAJsClassField`
+/// bound fails and rustc emits this custom message.
+#[diagnostic::on_unimplemented(
+    message = "using a `JsClass` type directly as a class field is not supported",
+    label = "`{Self}` implements `JsClass` \u{2014} wrap the field in `Class<'js, T>` instead",
+    note = "nested mutations are lost because the generated getter clones the value"
+)]
+pub trait NotAJsClassField {}
+
+impl<'js, T: JsClass<'js>> JsClassFieldCheck<T> {
+    pub fn check(self)
+    where
+        T: NotAJsClassField,
+    {
+    }
+}
+
+pub trait JsClassFieldCheckFallback {
+    fn check(self);
+}
+
+impl<T> JsClassFieldCheckFallback for &JsClassFieldCheck<T> {
+    fn check(self) {}
 }

--- a/macro/src/fields.rs
+++ b/macro/src/fields.rs
@@ -232,7 +232,7 @@ impl Field {
     }
 
     pub fn expand_accessor(&self, field: &Ident, crate_name: &Ident, ty: &Type) -> TokenStream {
-        if self.config.get && self.config.set {
+        let accessor = if self.config.get && self.config.set {
             quote! {
                 #crate_name::object::Accessor::new(
                     |this: #crate_name::function::This<#crate_name::class::OwnedBorrow<'js, Self>>|{
@@ -261,7 +261,22 @@ impl Field {
             }
         } else {
             panic!("called expand_accessor on non accessor field")
-        }
+        };
+
+        // Reject fields whose type implements `JsClass` (see
+        // `JsClassFieldCheck`). Autoref-specialization picks the inherent
+        // `check` (bounded on `T: NotAJsClassField`, which has no impls) for
+        // `JsClass` types, producing a custom `E0277` via
+        // `#[diagnostic::on_unimplemented]`. For any other type, the trait
+        // fallback is selected and compiles cleanly. Trait-bound checks run
+        // during type-check so the closure body never needs to execute.
+        quote! {{
+            let _ = || {
+                use #crate_name::class::impl_::JsClassFieldCheckFallback as _;
+                #crate_name::class::impl_::JsClassFieldCheck::<#ty>::new().check();
+            };
+            #accessor
+        }}
     }
 
     pub fn expand_attrs(&self) -> TokenStream {

--- a/tests/compile.rs
+++ b/tests/compile.rs
@@ -15,13 +15,19 @@ pub mod pass_method;
 pub mod pass_module;
 
 #[cfg(target_arch = "wasm32")]
+#[path = "macros/pass_nested_class.rs"]
+pub mod pass_nested_class;
+
+#[cfg(target_arch = "wasm32")]
 #[path = "macros/pass_trace.rs"]
 pub mod pass_trace;
 
 #[cfg(feature = "macro")]
 mod macro_tests {
     #[cfg(target_arch = "wasm32")]
-    use crate::{pass_class, pass_convert, pass_method, pass_module, pass_trace};
+    use crate::{
+        pass_class, pass_convert, pass_method, pass_module, pass_nested_class, pass_trace,
+    };
 
     #[cfg(not(target_arch = "wasm32"))]
     #[test]
@@ -58,6 +64,12 @@ mod macro_tests {
     #[test]
     fn macros_pass_module() {
         pass_module::main();
+    }
+
+    #[cfg(target_arch = "wasm32")]
+    #[test]
+    fn macros_pass_nested_class() {
+        pass_nested_class::main();
     }
 
     #[cfg(target_arch = "wasm32")]

--- a/tests/compile_fail/nested_class_field.rs
+++ b/tests/compile_fail/nested_class_field.rs
@@ -1,0 +1,17 @@
+use rquickjs::{class::Trace, JsLifetime};
+
+#[derive(Trace, JsLifetime, Default, Clone)]
+#[rquickjs::class]
+struct Outer {
+    #[qjs(get, set)]
+    inner: Inner,
+}
+
+#[derive(Trace, JsLifetime, Default, Clone)]
+#[rquickjs::class]
+struct Inner {
+    #[qjs(get, set)]
+    value: String,
+}
+
+fn main() {}

--- a/tests/compile_fail/nested_class_field.stderr
+++ b/tests/compile_fail/nested_class_field.stderr
@@ -1,0 +1,21 @@
+error[E0277]: using a `JsClass` type directly as a class field is not supported
+  --> tests/compile_fail/nested_class_field.rs:4:1
+   |
+ 4 | #[rquickjs::class]
+   | ^^^^^^^^^^^^^^^^^^ `Inner` implements `JsClass` — wrap the field in `Class<'js, T>` instead
+   |
+help: the trait `rquickjs::class::impl_::NotAJsClassField` is not implemented for `Inner`
+  --> tests/compile_fail/nested_class_field.rs:11:1
+   |
+11 | #[rquickjs::class]
+   | ^^^^^^^^^^^^^^^^^^
+   = note: nested mutations are lost because the generated getter clones the value
+note: required by a bound in `rquickjs::class::impl_::JsClassFieldCheck::<T>::check`
+  --> core/src/class/impl_.rs
+   |
+   |     pub fn check(self)
+   |            ----- required by a bound in this associated function
+   |     where
+   |         T: NotAJsClassField,
+   |            ^^^^^^^^^^^^^^^^ required by this bound in `JsClassFieldCheck::<T>::check`
+   = note: this error originates in the attribute macro `rquickjs::class` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/macros/pass_nested_class.rs
+++ b/tests/macros/pass_nested_class.rs
@@ -1,0 +1,57 @@
+use rquickjs::{class::Trace, CatchResultExt, Class, Context, JsLifetime, Object, Runtime};
+
+#[derive(Trace, JsLifetime)]
+#[rquickjs::class]
+pub struct Outer<'js> {
+    #[qjs(get, set)]
+    inner: Class<'js, Inner>,
+}
+
+#[derive(Trace, JsLifetime, Default, Clone)]
+#[rquickjs::class]
+pub struct Inner {
+    #[qjs(get, set)]
+    value: String,
+}
+
+pub fn main() {
+    let rt = Runtime::new().unwrap();
+    let ctx = Context::full(&rt).unwrap();
+
+    ctx.with(|ctx| {
+        let inner = Class::instance(
+            ctx.clone(),
+            Inner {
+                value: "initial".into(),
+            },
+        )
+        .unwrap();
+        let outer = Class::instance(ctx.clone(), Outer { inner }).unwrap();
+        ctx.globals().set("o", outer.clone()).unwrap();
+
+        ctx.eval::<(), _>(
+            r#"
+            if (o.inner.value !== "initial") throw new Error("get");
+            o.inner.value = "changed";
+            if (o.inner.value !== "changed") throw new Error("nested set");
+        "#,
+        )
+        .catch(&ctx)
+        .unwrap();
+
+        // Rust side observes the nested mutation.
+        assert_eq!(outer.borrow().inner.borrow().value, "changed");
+
+        // Mutation from Rust is visible from JS.
+        outer.borrow().inner.borrow_mut().value = "from rust".into();
+        let v: String = outer
+            .as_value()
+            .as_object()
+            .unwrap()
+            .get::<_, Object>("inner")
+            .unwrap()
+            .get("value")
+            .unwrap();
+        assert_eq!(v, "from rust");
+    });
+}


### PR DESCRIPTION
### Issue # (if available)

Fixes #532

### Description of changes

`#[rquickjs::class]` fields typed directly as a `JsClass` silently dropped nested mutations because the generated getter cloned the value and wrapped the clone in a fresh class instance. Now such fields produce a clear compile error (`E0277` via `#[diagnostic::on_unimplemented]`) directing users to wrap the field in `Class<'js, T>` to share the underlying cell. Implemented with autoref-specialization: a `JsClassFieldCheck<T>` helper whose inherent `check` method is bounded on an unimplementable marker trait `NotAJsClassField` when `T: JsClass`, and otherwise falls back to a trivial trait impl.

### Checklist

- [x] Added change to the changelog
- [x] Created unit tests for my feature if needed