### PR TITLE
fix: clamp set_max_stack_size to avoid QuickJS stack limit underflow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed iterators to use correct IteratorPrototype chain
 - Fixed a latent ABI layout vulnerability in `JS_NewPromiseCapability` FFI boundary by replacing tuple with strictly compatible array
 - `#[rquickjs::class]` now rejects fields whose type implements `JsClass` with a clear compile error; such fields silently dropped nested mutations because the generated getter cloned the value. Wrap the field in `Class<'js, T>` instead #[532](https://github.com/DelSkayn/rquickjs/issues/532)
+- Fixed `Runtime::set_max_stack_size` crashing on large values (e.g. `usize::MAX`) by clamping to avoid a pointer underflow inside QuickJS's stack limit check #[437](https://github.com/DelSkayn/rquickjs/issues/437)
 
 ## [0.11.0] - 2025-12-16
 

--- a/core/src/runtime/base.rs
+++ b/core/src/runtime/base.rs
@@ -217,4 +217,26 @@ mod test {
         rt.set_gc_threshold(0xFF);
         rt.run_gc();
     }
+
+    #[test]
+    fn set_max_stack_size_large_values() {
+        let rt = Runtime::new().unwrap();
+        rt.set_max_stack_size(usize::MAX);
+        let ctx = crate::Context::full(&rt).unwrap();
+        ctx.with(|ctx| {
+            ctx.eval::<i32, _>("1 + 1").unwrap();
+        });
+        rt.set_max_stack_size(isize::MAX as usize);
+        ctx.with(|ctx| {
+            ctx.eval::<i32, _>("1 + 1").unwrap();
+        });
+        rt.set_max_stack_size(0);
+        ctx.with(|ctx| {
+            ctx.eval::<i32, _>("1 + 1").unwrap();
+        });
+        rt.set_max_stack_size(256 * 1024);
+        ctx.with(|ctx| {
+            ctx.eval::<i32, _>("1 + 1").unwrap();
+        });
+    }
 }

--- a/core/src/runtime/raw.rs
+++ b/core/src/runtime/raw.rs
@@ -250,9 +250,16 @@ impl RawRuntime {
 
     /// Set a limit on the max size of stack the runtime will use.
     ///
-    /// The default values is 256x1024 bytes.
+    /// The default value is 256x1024 bytes. A `limit` of `0` disables the
+    /// check. Values larger than 16 MiB are treated as `0` so QuickJS's
+    /// `stack_top - stack_size` subtraction cannot underflow.
     pub unsafe fn set_max_stack_size(&mut self, limit: usize) {
-        let limit: size_t = limit.try_into().unwrap_or(size_t::MAX);
+        const MAX_SANE: usize = 1 << 24;
+        let limit: size_t = if limit > MAX_SANE {
+            0
+        } else {
+            limit.try_into().unwrap_or(0)
+        };
         qjs::JS_SetMaxStackSize(self.rt.as_ptr(), limit);
     }
 


### PR DESCRIPTION
### Issue #

Fixes #437

### Description of changes

`Runtime::set_max_stack_size` now clamps its argument to a safe maximum so QuickJS's `stack_top - stack_size` subtraction cannot underflow when callers pass values like `usize::MAX`.

### Checklist

- [x] Added change to the changelog
- [x] Created unit tests for my feature if needed