### PR TITLE
fix: place static getters and setters on the class constructor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed iterators to use correct IteratorPrototype chain
 - Fixed a latent ABI layout vulnerability in `JS_NewPromiseCapability` FFI boundary by replacing tuple with strictly compatible array
 - `#[rquickjs::class]` now rejects fields whose type implements `JsClass` with a clear compile error; such fields silently dropped nested mutations because the generated getter cloned the value. Wrap the field in `Class<'js, T>` instead #[532](https://github.com/DelSkayn/rquickjs/issues/532)
+- Fixed `#[qjs(static, get/set)]` accessors being placed on the class prototype instead of the constructor #[478](https://github.com/DelSkayn/rquickjs/issues/478)
 
 ## [0.11.0] - 2025-12-16
 

--- a/macro/src/methods.rs
+++ b/macro/src/methods.rs
@@ -213,6 +213,7 @@ pub(crate) fn expand(options: OptionList<ImplOption>, item: ItemImpl) -> Result<
         });
     let accessor_apply_proto = accessors
         .values()
+        .filter(|a| !a.is_static())
         .map(|access| access.expand_apply_to_proto(&crate_name, config.rename_all));
     let prop_apply_proto = props
         .iter()
@@ -238,11 +239,16 @@ pub(crate) fn expand(options: OptionList<ImplOption>, item: ItemImpl) -> Result<
                     )
                 });
 
+        let static_accessor_apply = accessors.values().filter(|a| a.is_static()).map(|access| {
+            access.expand_apply_to(&crate_name, &constructor_ident, config.rename_all)
+        });
+
         quote! {
             impl #js_added_generics #crate_name::class::impl_::ConstructorCreator<'js,#self_ty> for #crate_name::class::impl_::ConstructorCreate<#self_ty> {
                 fn create_constructor(&self, ctx: &#crate_name::Ctx<'js>) -> #crate_name::Result<Option<#crate_name::function::Constructor<'js>>>{
                     let constr = #crate_name::function::Constructor::new_class::<#self_ty,_,_>(ctx.clone(),#name)?;
                     #(#static_function_apply)*
+                    #(#static_accessor_apply)*
                     Ok(Some(constr))
                 }
             }

--- a/macro/src/methods/accessor.rs
+++ b/macro/src/methods/accessor.rs
@@ -30,6 +30,16 @@ impl JsAccessor {
             error.combine(Error::new(first_span, "Getter first defined here."));
             return Err(error);
         }
+        if let Some(set) = self.set.as_ref() {
+            if set.config.r#static != method.config.r#static {
+                let mut error = Error::new(
+                    method.attr_span,
+                    "getter and setter for the same property must agree on `static`.",
+                );
+                error.combine(Error::new(set.attr_span, "setter defined here."));
+                return Err(error);
+            }
+        }
         self.get = Some(method);
         Ok(())
     }
@@ -44,8 +54,26 @@ impl JsAccessor {
             error.combine(Error::new(first_span, "Setter first defined here."));
             return Err(error);
         }
+        if let Some(get) = self.get.as_ref() {
+            if get.config.r#static != method.config.r#static {
+                let mut error = Error::new(
+                    method.attr_span,
+                    "getter and setter for the same property must agree on `static`.",
+                );
+                error.combine(Error::new(get.attr_span, "getter defined here."));
+                return Err(error);
+            }
+        }
         self.set = Some(method);
         Ok(())
+    }
+
+    pub fn is_static(&self) -> bool {
+        self.get
+            .as_ref()
+            .map(|g| g.config.r#static)
+            .or_else(|| self.set.as_ref().map(|s| s.config.r#static))
+            .unwrap_or(false)
     }
 
     pub fn expand_impl(&self) -> TokenStream {
@@ -70,7 +98,12 @@ impl JsAccessor {
         res
     }
 
-    pub fn expand_apply_to_proto(&self, lib_crate: &Ident, case: Option<Case>) -> TokenStream {
+    pub fn expand_apply_to(
+        &self,
+        lib_crate: &Ident,
+        object_name: &Ident,
+        case: Option<Case>,
+    ) -> TokenStream {
         match (self.get.as_ref(), self.set.as_ref()) {
             (Some(get), Some(set)) => {
                 let configurable = get.config.configurable || set.config.configurable;
@@ -90,7 +123,7 @@ impl JsAccessor {
                 };
                 let get_name = get.function.expand_carry_type_name(GET_PREFIX);
                 let set_name = set.function.expand_carry_type_name(SET_PREFIX);
-                quote! {_proto.prop(#name,
+                quote! {#object_name.prop(#name,
                         #lib_crate::object::Accessor::new(#get_name,#set_name)
                         #configurable
                         #enumerable
@@ -113,7 +146,7 @@ impl JsAccessor {
                     Default::default()
                 };
                 let get_name = get.function.expand_carry_type_name(GET_PREFIX);
-                quote! {_proto.prop(#name,
+                quote! {#object_name.prop(#name,
                         #lib_crate::object::Accessor::new_get(#get_name)
                         #configurable
                         #enumerable
@@ -137,7 +170,7 @@ impl JsAccessor {
                 };
 
                 let set_name = set.function.expand_carry_type_name(GET_PREFIX);
-                quote! {_proto.prop(#name,
+                quote! {#object_name.prop(#name,
                         #lib_crate::object::Accessor::new_set(#set_name)
                         #configurable
                         #enumerable
@@ -145,5 +178,10 @@ impl JsAccessor {
             }
             (None, None) => TokenStream::new(),
         }
+    }
+
+    pub fn expand_apply_to_proto(&self, lib_crate: &Ident, case: Option<Case>) -> TokenStream {
+        let proto = Ident::new("_proto", proc_macro2::Span::call_site());
+        self.expand_apply_to(lib_crate, &proto, case)
     }
 }

--- a/tests/macros/pass_method.rs
+++ b/tests/macros/pass_method.rs
@@ -45,6 +45,19 @@ impl TestClass {
         a.value == b.value && a.another_value == b.another_value
     }
 
+    #[qjs(static, get, rename = "defaultValue")]
+    pub fn default_value() -> u32 {
+        42
+    }
+
+    #[qjs(static, get, rename = "staticPair")]
+    pub fn get_static_pair() -> u32 {
+        7
+    }
+
+    #[qjs(static, set, rename = "staticPair")]
+    pub fn set_static_pair(_v: u32) {}
+
     #[qjs(skip)]
     pub fn inner_function(&self) {}
 
@@ -147,6 +160,20 @@ pub fn main() {
             }
             if(kindDesc.configurable !== true || kindDesc.enumerable !== true || kindDesc.writable !== true){
                 throw new Error(14)
+            }
+            if(TestClass.defaultValue !== 42){
+                throw new Error(15)
+            }
+            let dvDesc = Object.getOwnPropertyDescriptor(TestClass, "defaultValue");
+            if(!dvDesc || typeof dvDesc.get !== "function" || dvDesc.set !== undefined){
+                throw new Error(16)
+            }
+            let spDesc = Object.getOwnPropertyDescriptor(TestClass, "staticPair");
+            if(!spDesc || typeof spDesc.get !== "function" || typeof spDesc.set !== "function"){
+                throw new Error(17)
+            }
+            if(proto.defaultValue !== undefined){
+                throw new Error(18)
             }
         "#,
         )


### PR DESCRIPTION
### Issue #

Fixes #478

### Description of changes

`#[qjs(static, get)]` and `#[qjs(static, set)]` accessors now attach to the class constructor (like regular static methods) instead of being silently placed on the prototype.

### Checklist

- [x] Added change to the changelog
- [x] Created unit tests for my feature if needed