### PR TITLE
fix: allow static methods renamed to predefined symbols on the constructor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed iterators to use correct IteratorPrototype chain
 - Fixed a latent ABI layout vulnerability in `JS_NewPromiseCapability` FFI boundary by replacing tuple with strictly compatible array
 - `#[rquickjs::class]` now rejects fields whose type implements `JsClass` with a clear compile error; such fields silently dropped nested mutations because the generated getter cloned the value. Wrap the field in `Class<'js, T>` instead #[532](https://github.com/DelSkayn/rquickjs/issues/532)
+- Fixed `#[qjs(static, rename = PredefinedAtom::...)]` methods failing when the target symbol exists as a non-writable property on `Function.prototype` (e.g. `Symbol.hasInstance`) by defining properties directly on the constructor instead of going through the prototype chain #[315](https://github.com/DelSkayn/rquickjs/issues/315)
 
 ## [0.11.0] - 2025-12-16
 

--- a/macro/src/methods.rs
+++ b/macro/src/methods.rs
@@ -209,7 +209,13 @@ pub(crate) fn expand(options: OptionList<ImplOption>, item: ItemImpl) -> Result<
         .iter()
         .filter(|&func| !func.config.r#static)
         .map(|func| {
-            func.expand_apply_to_object(&prefix, &self_ty, &proto_ident, config.rename_all)
+            func.expand_apply_to_object(
+                &prefix,
+                &crate_name,
+                &self_ty,
+                &proto_ident,
+                config.rename_all,
+            )
         });
     let accessor_apply_proto = accessors
         .values()
@@ -232,6 +238,7 @@ pub(crate) fn expand(options: OptionList<ImplOption>, item: ItemImpl) -> Result<
                 .map(|func| {
                     func.expand_apply_to_object(
                         &prefix,
+                        &crate_name,
                         &self_ty,
                         &constructor_ident,
                         config.rename_all,

--- a/macro/src/methods/method.rs
+++ b/macro/src/methods/method.rs
@@ -296,6 +296,7 @@ impl Method {
     pub(crate) fn expand_apply_to_object(
         &self,
         prefix: &str,
+        lib_crate: &Ident,
         self_ty: &Type,
         object_name: &Ident,
         case: Option<Case>,
@@ -306,7 +307,12 @@ impl Method {
         let func_name_str = self.name(case);
         let js_func_name = self.function.expand_carry_type_name(prefix);
         quote! {
-            #object_name.set(#func_name_str,<#self_ty>::#js_func_name)?;
+            #object_name.prop(
+                #func_name_str,
+                #lib_crate::object::Property::from(<#self_ty>::#js_func_name)
+                    .writable()
+                    .configurable(),
+            )?;
         }
     }
 

--- a/tests/macros/pass_method.rs
+++ b/tests/macros/pass_method.rs
@@ -45,6 +45,11 @@ impl TestClass {
         a.value == b.value && a.another_value == b.another_value
     }
 
+    #[qjs(static, rename = PredefinedAtom::SymbolHasInstance)]
+    pub fn has_instance<'js>(_value: rquickjs::Value<'js>) -> bool {
+        false
+    }
+
     #[qjs(skip)]
     pub fn inner_function(&self) {}
 
@@ -112,6 +117,12 @@ pub fn main() {
             }
             if(nv.inner_function !== undefined){
                 throw new Error(6)
+            }
+            if(typeof TestClass[Symbol.hasInstance] !== "function"){
+                throw new Error("static Symbol.hasInstance not attached")
+            }
+            if(TestClass[Symbol.hasInstance]({}) !== false){
+                throw new Error("static Symbol.hasInstance wrong return")
             }
             let proto = TestClass.prototype;
             if(!Object.keys(proto).includes("anotherValue")){


### PR DESCRIPTION
### Issue #

Fixes #315

### Description of changes

Static methods generated by `#[rquickjs::methods]` now define their property directly on the constructor via `JS_DefineProperty` instead of `obj.set`, which previously failed for names like `Symbol.hasInstance` because they exist as non-writable properties on `Function.prototype`.

### Checklist

- [x] Added change to the changelog
- [x] Created unit tests for my feature if needed