### PR TITLE
fix: add missing Trace and JsLifetime impls for JS wrapper types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed iterators to use correct IteratorPrototype chain
 - Fixed a latent ABI layout vulnerability in `JS_NewPromiseCapability` FFI boundary by replacing tuple with strictly compatible array
 - `#[rquickjs::class]` now rejects fields whose type implements `JsClass` with a clear compile error; such fields silently dropped nested mutations because the generated getter cloned the value. Wrap the field in `Class<'js, T>` instead #[532](https://github.com/DelSkayn/rquickjs/issues/532)
+- Added missing `Trace` implementations for `Constructor`, `Promise`, `Proxy`, `ArrayBuffer`, and `TypedArray`; added `JsLifetime` for `Proxy`; re-exported `Constructor` at the crate root
 
 ## [0.11.0] - 2025-12-16
 

--- a/core/src/class/trace.rs
+++ b/core/src/class/trace.rs
@@ -108,6 +108,24 @@ impl<'js> Trace<'js> for Atom<'js> {
     }
 }
 
+impl<'js> Trace<'js> for crate::Constructor<'js> {
+    fn trace<'a>(&self, tracer: Tracer<'a, 'js>) {
+        self.0.trace(tracer)
+    }
+}
+
+impl<'js> Trace<'js> for crate::Proxy<'js> {
+    fn trace<'a>(&self, tracer: Tracer<'a, 'js>) {
+        self.0.trace(tracer)
+    }
+}
+
+impl<'js, T> Trace<'js> for crate::TypedArray<'js, T> {
+    fn trace<'a>(&self, tracer: Tracer<'a, 'js>) {
+        self.as_value().trace(tracer)
+    }
+}
+
 #[cfg(feature = "either")]
 #[cfg_attr(feature = "doc-cfg", doc(cfg(feature = "either")))]
 impl<'js, L, R> Trace<'js> for Either<L, R>
@@ -227,6 +245,8 @@ trace_impls! {
     crate::Symbol,
     crate::Exception,
     crate::String,
+    crate::Promise,
+    crate::ArrayBuffer,
 }
 
 trace_impls! {

--- a/core/src/js_lifetime.rs
+++ b/core/src/js_lifetime.rs
@@ -1,6 +1,6 @@
 use crate::{
     atom, value::Constructor, Array, Atom, BigInt, CString, Exception, Function, Module, Object,
-    Promise, String, Symbol, Value,
+    Promise, Proxy, String, Symbol, Value,
 };
 
 /// The trait which signifies a type using the rquickjs `'js` lifetime trick for maintaining safety around Javascript values.
@@ -104,6 +104,7 @@ outlive_impls! {
     Function,
     Constructor,
     Promise,
+    Proxy,
     Exception,
     Atom,
 }

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -39,9 +39,9 @@ pub use persistent::Persistent;
 pub use result::{CatchResultExt, CaughtError, CaughtResult, Error, Result, ThrowResultExt};
 pub use value::{
     array, atom, convert, function, module, object, promise, proxy, Array, Atom, BigInt, CString,
-    Coerced, Exception, Filter, FromAtom, FromIteratorJs, FromJs, Function, IntoAtom, IntoJs,
-    IteratorJs, Module, Null, Object, Promise, Proxy, String, Symbol, Type, Undefined, Value,
-    WriteOptions, WriteOptionsEndianness,
+    Coerced, Constructor, Exception, Filter, FromAtom, FromIteratorJs, FromJs, Function, IntoAtom,
+    IntoJs, IteratorJs, Module, Null, Object, Promise, Proxy, String, Symbol, Type, Undefined,
+    Value, WriteOptions, WriteOptionsEndianness,
 };
 
 pub mod allocator;

--- a/tests/macros/pass_trace.rs
+++ b/tests/macros/pass_trace.rs
@@ -63,6 +63,16 @@ pub enum TraceEnum {
     C,
 }
 
+#[derive(Trace, JsLifetime)]
+#[allow(dead_code)]
+pub struct TraceBuiltins<'js> {
+    constructor: rquickjs::Constructor<'js>,
+    promise: rquickjs::Promise<'js>,
+    proxy: rquickjs::Proxy<'js>,
+    array_buffer: rquickjs::ArrayBuffer<'js>,
+    typed_array: rquickjs::TypedArray<'js, u8>,
+}
+
 impl<'js> JsClass<'js> for TraceEnum {
     const NAME: &'static str = "TraceEnum";
 


### PR DESCRIPTION
### Description of changes

Adds the missing `Trace` implementations for `Constructor`, `Promise`, `Proxy`, `ArrayBuffer`, and `TypedArray`, the missing `JsLifetime` impl for `Proxy`, and re-exports `Constructor` at the crate root so these types can be used as fields inside `#[derive(Trace, JsLifetime)] #[rquickjs::class]` structs.

### Checklist

- [x] Added change to the changelog
- [x] Created unit tests for my feature if needed