### PR TITLE
feat: add ArrayBuffer::from_raw_parts and from_raw_parts_shared for external buffers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `RQUICKJS_SYS_NO_WASI_SDK` env variable that skips downloading and setting up the WASI SDK when set to `1` #[648](https://github.com/DelSkayn/rquickjs/pull/648)
 - Added `Object::new_proto` for creating objects with a custom or null prototype #[572](https://github.com/DelSkayn/rquickjs/issues/572)
 - Added `Symbol::new`, `Symbol::with_description`, and `Symbol::new_global` for creating local and global symbols from Rust #[672](https://github.com/DelSkayn/rquickjs/pull/672)
+- Added `ArrayBuffer::from_raw_parts`, `from_raw_parts_shared`, and `from_raw_parts_immutable` for wrapping external, caller-owned buffers via a safe Rust closure drop. Added the `ArrayBufferSource` trait and `from_source` / `from_source_shared` / `from_source_immutable` safe constructors with built-in impls for `Vec<u8>`, `Box<[u8]>`, `Arc<[u8]>`, `Arc<Vec<u8>>`, and (behind the `bytes` feature) `bytes::Bytes`
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `RQUICKJS_SYS_NO_WASI_SDK` env variable that skips downloading and setting up the WASI SDK when set to `1` #[648](https://github.com/DelSkayn/rquickjs/pull/648)
 - Added `Object::new_proto` for creating objects with a custom or null prototype #[572](https://github.com/DelSkayn/rquickjs/issues/572)
 - Added `Symbol::new`, `Symbol::with_description`, and `Symbol::new_global` for creating local and global symbols from Rust #[672](https://github.com/DelSkayn/rquickjs/pull/672)
-- Added `ArrayBuffer::from_raw_parts`, `from_raw_parts_shared`, and `from_raw_parts_immutable` for wrapping external, caller-owned buffers via a safe Rust closure drop. Added the `ArrayBufferSource` trait and `from_source` / `from_source_shared` / `from_source_immutable` safe constructors with built-in impls for `Vec<u8>`, `Box<[u8]>`, `Arc<[u8]>`, `Arc<Vec<u8>>`, and (behind the `bytes` feature) `bytes::Bytes`
+- Added `ArrayBufferSource` trait and `ArrayBuffer::from_source` / `from_source_shared` / `from_source_immutable` safe constructors for wrapping external, caller-owned buffers, with built-in impls for `Vec<u8>`, `Box<[u8]>`, `Arc<[u8]>`, `Arc<Vec<u8>>`, and (behind the `bytes` feature) `bytes::Bytes`
 
 ### Changed
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -105,6 +105,9 @@ macro = ["rquickjs-macro"]
 # Enable hallf (f16) support
 half = ["rquickjs-core/half"]
 
+# Enable `ArrayBufferSource` impl for `bytes::Bytes`
+bytes = ["rquickjs-core/bytes"]
+
 # Enable interop between Rust futures and JS Promises
 futures = ["rquickjs-core/futures"]
 

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -26,6 +26,7 @@ relative-path = { version = "2.0", optional = true, default-features = false, fe
   "alloc",
 ] }
 half = { version = "2.7.1", optional = true }
+bytes = { version = "1", optional = true, default-features = false }
 
 [dev-dependencies]
 futures-rs = { package = "futures", version = "0.3" }
@@ -75,6 +76,9 @@ rust-alloc = []
 # Enable half (f16) support
 
 half = ["dep:half"]
+
+# Enable `ArrayBufferSource` impl for `bytes::Bytes`
+bytes = ["dep:bytes"]
 
 # Enable interop between Rust futures and JS Promises
 futures = ["dep:async-lock"]

--- a/core/src/context/owner.rs
+++ b/core/src/context/owner.rs
@@ -14,12 +14,25 @@ pub(crate) trait DropContext: Clone {
 #[cfg(feature = "parallel")]
 unsafe impl<R: Send + DropContext> Send for ContextOwner<R> {}
 
+/// Newtype so `Arc<CtxPtr>` is `Send + Sync` without tripping
+/// `clippy::arc_with_non_send_sync`. Access to the underlying QuickJS context
+/// is protected by the runtime lock, so sharing the pointer between threads
+/// is sound as long as callers go through `ContextOwner`.
+#[cfg(feature = "parallel")]
+#[repr(transparent)]
+pub(crate) struct CtxPtr(pub(crate) NonNull<qjs::JSContext>);
+
+#[cfg(feature = "parallel")]
+unsafe impl Send for CtxPtr {}
+#[cfg(feature = "parallel")]
+unsafe impl Sync for CtxPtr {}
+
 /// Struct in charge of dropping contexts when they go out of scope
 pub(crate) struct ContextOwner<R: DropContext> {
     #[cfg(not(feature = "parallel"))]
     ctx: NonNull<qjs::JSContext>,
     #[cfg(feature = "parallel")]
-    pub(crate) ctx: Arc<NonNull<qjs::JSContext>>,
+    pub(crate) ctx: Arc<CtxPtr>,
     pub(crate) rt: R,
 }
 
@@ -31,7 +44,7 @@ impl<R: DropContext> ContextOwner<R> {
     #[cfg(feature = "parallel")]
     pub(crate) unsafe fn new(ctx: NonNull<qjs::JSContext>, rt: R) -> Self {
         Self {
-            ctx: Arc::new(ctx),
+            ctx: Arc::new(CtxPtr(ctx)),
             rt,
         }
     }
@@ -43,7 +56,7 @@ impl<R: DropContext> ContextOwner<R> {
 
     #[cfg(feature = "parallel")]
     pub(crate) fn ctx(&self) -> NonNull<qjs::JSContext> {
-        *self.ctx
+        self.ctx.0
     }
 
     pub(crate) fn rt(&self) -> &R {

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -57,7 +57,9 @@ pub use context::MultiWith;
 #[cfg(feature = "futures")]
 #[cfg_attr(feature = "doc-cfg", doc(cfg(feature = "futures")))]
 pub use runtime::AsyncRuntime;
-pub use value::{ArrayBuffer, Iterable, IterableFn, JsIterator, TypedArray};
+pub use value::{
+    ArrayBuffer, ArrayBufferDrop, ArrayBufferSource, Iterable, IterableFn, JsIterator, TypedArray,
+};
 
 //#[doc(hidden)]
 pub mod qjs {

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -57,9 +57,7 @@ pub use context::MultiWith;
 #[cfg(feature = "futures")]
 #[cfg_attr(feature = "doc-cfg", doc(cfg(feature = "futures")))]
 pub use runtime::AsyncRuntime;
-pub use value::{
-    ArrayBuffer, ArrayBufferDrop, ArrayBufferSource, Iterable, IterableFn, JsIterator, TypedArray,
-};
+pub use value::{ArrayBuffer, ArrayBufferSource, Iterable, IterableFn, JsIterator, TypedArray};
 
 //#[doc(hidden)]
 pub mod qjs {

--- a/core/src/value.rs
+++ b/core/src/value.rs
@@ -31,7 +31,7 @@ pub mod array_buffer;
 pub mod iterable;
 pub mod typed_array;
 
-pub use array_buffer::ArrayBuffer;
+pub use array_buffer::{ArrayBuffer, ArrayBufferDrop, ArrayBufferSource};
 pub use iterable::{Iterable, IterableFn, JsIterator};
 pub use typed_array::TypedArray;
 

--- a/core/src/value.rs
+++ b/core/src/value.rs
@@ -31,7 +31,7 @@ pub mod array_buffer;
 pub mod iterable;
 pub mod typed_array;
 
-pub use array_buffer::{ArrayBuffer, ArrayBufferDrop, ArrayBufferSource};
+pub use array_buffer::{ArrayBuffer, ArrayBufferSource};
 pub use iterable::{Iterable, IterableFn, JsIterator};
 pub use typed_array::TypedArray;
 

--- a/core/src/value/array_buffer.rs
+++ b/core/src/value/array_buffer.rs
@@ -1,4 +1,6 @@
 use crate::{qjs, Ctx, Error, FromJs, IntoJs, JsLifetime, Object, Result, Value};
+use alloc::boxed::Box;
+use alloc::sync::Arc;
 use alloc::vec::Vec;
 use core::{
     ffi::c_void,
@@ -11,6 +13,65 @@ use core::{
 };
 
 use super::typed_array::TypedArrayItem;
+
+/// The drop callback invoked when an externally backed `ArrayBuffer` is
+/// garbage-collected (or when construction fails).
+#[cfg(not(feature = "parallel"))]
+pub type ArrayBufferDrop = Box<dyn FnOnce() + 'static>;
+/// The drop callback invoked when an externally backed `ArrayBuffer` is
+/// garbage-collected (or when construction fails).
+#[cfg(feature = "parallel")]
+pub type ArrayBufferDrop = Box<dyn FnOnce() + Send + 'static>;
+
+/// Marker bound used by the `from_source*` APIs so that the captured source
+/// satisfies the `Send` requirement only when the `parallel` feature is
+/// enabled.
+#[cfg(not(feature = "parallel"))]
+pub trait DropSend {}
+#[cfg(not(feature = "parallel"))]
+impl<T> DropSend for T {}
+#[cfg(feature = "parallel")]
+pub trait DropSend: Send {}
+#[cfg(feature = "parallel")]
+impl<T: Send> DropSend for T {}
+
+/// A contiguous byte region owned by `self` and usable as the backing store
+/// of an [`ArrayBuffer`].
+///
+/// # Safety
+///
+/// * `as_ptr()` must return a pointer that is valid for reads (and writes,
+///   when used via [`ArrayBuffer::from_source`] / [`ArrayBuffer::from_source_shared`])
+///   of `len()` bytes.
+/// * The returned pointer must remain valid until `self` is dropped, including
+///   across moves of `self`.
+pub unsafe trait ArrayBufferSource {
+    fn as_ptr(&self) -> *mut u8;
+    fn len(&self) -> usize;
+    fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+}
+
+macro_rules! impl_array_buffer_source {
+    ($($t:ty),* $(,)?) => {
+        $(
+            unsafe impl ArrayBufferSource for $t {
+                fn as_ptr(&self) -> *mut u8 {
+                    <[u8]>::as_ptr(self) as *mut u8
+                }
+                fn len(&self) -> usize {
+                    <[u8]>::len(self)
+                }
+            }
+        )*
+    };
+}
+
+impl_array_buffer_source!(Vec<u8>, alloc::boxed::Box<[u8]>, Arc<[u8]>, Arc<Vec<u8>>);
+
+#[cfg(feature = "bytes")]
+impl_array_buffer_source!(bytes::Bytes);
 
 pub struct RawArrayBuffer {
     pub len: usize,
@@ -88,6 +149,135 @@ impl<'js> ArrayBuffer<'js> {
             ctx.handle_exception(val)?;
             Value::from_js_value(ctx.clone(), val)
         })))
+    }
+
+    /// Create an `ArrayBuffer` backed by an external buffer.
+    ///
+    /// `drop` is invoked exactly once: when the buffer is garbage-collected,
+    /// or synchronously if construction fails. It should release whatever
+    /// backing storage it captures.
+    ///
+    /// # Safety
+    ///
+    /// `ptr` must point to `len` bytes of valid memory for the entire lifetime
+    /// of the returned buffer and any views of it. The `drop` closure must
+    /// release that memory correctly.
+    pub unsafe fn from_raw_parts(
+        ctx: Ctx<'js>,
+        ptr: *mut u8,
+        len: usize,
+        drop: ArrayBufferDrop,
+    ) -> Result<Self> {
+        unsafe { Self::from_raw_parts_inner(ctx, ptr, len, drop, false, false) }
+    }
+
+    /// Create a JS `SharedArrayBuffer` backed by an external buffer.
+    ///
+    /// Same semantics as [`from_raw_parts`] but produces a JS `SharedArrayBuffer`,
+    /// which supports `Atomics` and can be shared across workers.
+    ///
+    /// # Safety
+    ///
+    /// See [`from_raw_parts`].
+    pub unsafe fn from_raw_parts_shared(
+        ctx: Ctx<'js>,
+        ptr: *mut u8,
+        len: usize,
+        drop: ArrayBufferDrop,
+    ) -> Result<Self> {
+        unsafe { Self::from_raw_parts_inner(ctx, ptr, len, drop, true, false) }
+    }
+
+    /// Create an `ArrayBuffer` that JS sees as immutable.
+    ///
+    /// Same semantics as [`from_raw_parts`] but any JS-side write throws,
+    /// which makes it sound to back the buffer with a shared-immutable
+    /// Rust value (`Arc<[u8]>`, `bytes::Bytes`, …) that is still accessible
+    /// from Rust as `&[u8]` after this call returns.
+    ///
+    /// # Safety
+    ///
+    /// See [`from_raw_parts`].
+    pub unsafe fn from_raw_parts_immutable(
+        ctx: Ctx<'js>,
+        ptr: *mut u8,
+        len: usize,
+        drop: ArrayBufferDrop,
+    ) -> Result<Self> {
+        unsafe { Self::from_raw_parts_inner(ctx, ptr, len, drop, false, true) }
+    }
+
+    unsafe fn from_raw_parts_inner(
+        ctx: Ctx<'js>,
+        ptr: *mut u8,
+        len: usize,
+        drop: ArrayBufferDrop,
+        is_shared: bool,
+        immutable: bool,
+    ) -> Result<Self> {
+        extern "C" fn shim(_rt: *mut qjs::JSRuntime, opaque: *mut c_void, _ptr: *mut c_void) {
+            unsafe {
+                let boxed: Box<ArrayBufferDrop> = Box::from_raw(opaque as *mut ArrayBufferDrop);
+                (*boxed)();
+            }
+        }
+
+        let opaque = Box::into_raw(Box::new(drop)) as *mut c_void;
+
+        Ok(Self(Object(unsafe {
+            let val =
+                qjs::JS_NewArrayBuffer(ctx.as_ptr(), ptr, len as _, Some(shim), opaque, is_shared);
+            if let Err(e) = ctx.handle_exception(val) {
+                shim(qjs::JS_GetRuntime(ctx.as_ptr()), opaque, ptr as *mut c_void);
+                return Err(e);
+            }
+            if immutable {
+                qjs::JS_SetImmutableArrayBuffer(val, true);
+            }
+            Value::from_js_value(ctx, val)
+        })))
+    }
+
+    /// Create an `ArrayBuffer` from a source that owns its backing bytes.
+    ///
+    /// The source is moved into the buffer; JS has exclusive mutable access
+    /// until the buffer is collected, at which point the source is dropped.
+    /// Using this with a shared-immutable source (`Arc<[u8]>`, `bytes::Bytes`,
+    /// …) is unsound; use [`from_source_immutable`] for those.
+    pub fn from_source<S>(ctx: Ctx<'js>, src: S) -> Result<Self>
+    where
+        S: ArrayBufferSource + DropSend + 'static,
+    {
+        let ptr = src.as_ptr();
+        let len = src.len();
+        unsafe { Self::from_raw_parts(ctx, ptr, len, Box::new(move || drop(src))) }
+    }
+
+    /// Create a `SharedArrayBuffer` from a source that owns its backing bytes.
+    ///
+    /// See [`from_source`] for ownership semantics.
+    pub fn from_source_shared<S>(ctx: Ctx<'js>, src: S) -> Result<Self>
+    where
+        S: ArrayBufferSource + DropSend + 'static,
+    {
+        let ptr = src.as_ptr();
+        let len = src.len();
+        unsafe { Self::from_raw_parts_shared(ctx, ptr, len, Box::new(move || drop(src))) }
+    }
+
+    /// Create an `ArrayBuffer` that JS sees as immutable, backed by a
+    /// possibly shared-immutable source.
+    ///
+    /// JS writes throw, so it is sound for the caller to keep holding
+    /// shared-immutable references to the backing store (`Arc<[u8]>`,
+    /// `bytes::Bytes`, …).
+    pub fn from_source_immutable<S>(ctx: Ctx<'js>, src: S) -> Result<Self>
+    where
+        S: ArrayBufferSource + DropSend + 'static,
+    {
+        let ptr = src.as_ptr();
+        let len = src.len();
+        unsafe { Self::from_raw_parts_immutable(ctx, ptr, len, Box::new(move || drop(src))) }
     }
 
     /// Get the length of the array buffer in bytes.
@@ -253,6 +443,7 @@ impl<'js> Object<'js> {
 #[cfg(test)]
 mod test {
     use crate::*;
+    use alloc::sync::Arc;
 
     #[test]
     fn from_javascript_i8() {
@@ -345,6 +536,201 @@ mod test {
             res[4..].copy_from_slice(&bytes_1);
 
             assert_eq!(val.as_bytes().unwrap(), &res)
+        });
+    }
+
+    #[test]
+    fn from_raw_parts_external_buffer() {
+        use core::sync::atomic::{AtomicBool, Ordering};
+
+        static DROPPED: AtomicBool = AtomicBool::new(false);
+
+        let rt = crate::Runtime::new().unwrap();
+        let c = crate::Context::full(&rt).unwrap();
+        c.with(|ctx| {
+            let buf: alloc::boxed::Box<[u8]> = alloc::vec![1u8, 2, 3, 4].into_boxed_slice();
+            let ptr = buf.as_ptr();
+            let len = buf.len();
+            let ab = unsafe {
+                ArrayBuffer::from_raw_parts(
+                    ctx.clone(),
+                    ptr,
+                    len,
+                    Box::new(move || {
+                        drop(buf);
+                        DROPPED.store(true, Ordering::SeqCst);
+                    }),
+                )
+                .unwrap()
+            };
+            assert_eq!(ab.len(), 4);
+            assert_eq!(ab.as_bytes().unwrap(), &[1, 2, 3, 4]);
+        });
+        rt.run_gc();
+        assert!(DROPPED.load(Ordering::SeqCst));
+    }
+
+    #[test]
+    fn from_raw_parts_error_invokes_drop_fn() {
+        use core::sync::atomic::{AtomicBool, Ordering};
+
+        static DROPPED: AtomicBool = AtomicBool::new(false);
+
+        let rt = crate::Runtime::new().unwrap();
+        let c = crate::Context::full(&rt).unwrap();
+        c.with(|ctx| {
+            let buf: alloc::boxed::Box<[u8]> = alloc::vec![1u8, 2, 3, 4].into_boxed_slice();
+            let ptr = buf.as_ptr();
+            let err = unsafe {
+                ArrayBuffer::from_raw_parts(
+                    ctx.clone(),
+                    ptr,
+                    i64::MAX as usize,
+                    Box::new(move || {
+                        drop(buf);
+                        DROPPED.store(true, Ordering::SeqCst);
+                    }),
+                )
+            };
+            assert!(err.is_err());
+        });
+        assert!(DROPPED.load(Ordering::SeqCst));
+    }
+
+    #[test]
+    fn from_raw_parts_immutable_arc_slices() {
+        let buf: Arc<Vec<u8>> = Arc::new((0u8..16).collect());
+        let weak = Arc::downgrade(&buf);
+
+        let rt = crate::Runtime::new().unwrap();
+        let c = crate::Context::full(&rt).unwrap();
+        c.with(|ctx| {
+            let mk = |offset: usize, len: usize| -> ArrayBuffer<'_> {
+                let clone = buf.clone();
+                let ptr = unsafe { clone.as_ptr().add(offset) };
+                unsafe {
+                    ArrayBuffer::from_raw_parts_immutable(
+                        ctx.clone(),
+                        ptr,
+                        len,
+                        Box::new(move || drop(clone)),
+                    )
+                    .unwrap()
+                }
+            };
+            let full = mk(0, 16);
+            let head = mk(0, 4);
+            let tail = mk(12, 4);
+            let middle = mk(4, 8);
+
+            assert_eq!(full.as_bytes().unwrap(), (0u8..16).collect::<Vec<_>>());
+            assert_eq!(head.as_bytes().unwrap(), &[0, 1, 2, 3]);
+            assert_eq!(tail.as_bytes().unwrap(), &[12, 13, 14, 15]);
+            assert_eq!(middle.as_bytes().unwrap(), (4u8..12).collect::<Vec<_>>());
+            assert_eq!(Arc::strong_count(&buf), 5);
+
+            ctx.globals().set("buf", full).unwrap();
+
+            let after: u8 = ctx
+                .eval::<u8, _>(
+                    r#"
+                        const arr = new Uint8Array(buf);
+                        arr[0] = 99;
+                        arr[0];
+                    "#,
+                )
+                .unwrap();
+            assert_eq!(after, 0, "immutable ArrayBuffer must not accept writes");
+
+            let writer = ctx.eval::<(), _>(
+                r#"
+                    "use strict";
+                    new DataView(buf).setUint8(0, 99);
+                "#,
+            );
+            assert!(
+                writer.is_err(),
+                "DataView write on immutable buffer must throw"
+            );
+        });
+
+        drop(buf);
+        rt.run_gc();
+        drop(c);
+        drop(rt);
+        assert!(weak.upgrade().is_none());
+    }
+
+    #[test]
+    fn from_source_vec() {
+        let rt = crate::Runtime::new().unwrap();
+        let c = crate::Context::full(&rt).unwrap();
+        c.with(|ctx| {
+            let ab = ArrayBuffer::from_source(ctx.clone(), alloc::vec![1u8, 2, 3, 4]).unwrap();
+            assert_eq!(ab.as_bytes().unwrap(), &[1, 2, 3, 4]);
+        });
+    }
+
+    #[test]
+    fn from_source_immutable_arc() {
+        let arc: Arc<[u8]> = Arc::from((0u8..8).collect::<Vec<_>>().into_boxed_slice());
+        let weak = Arc::downgrade(&arc);
+        assert_eq!(Arc::strong_count(&arc), 1);
+
+        let rt = crate::Runtime::new().unwrap();
+        let c = crate::Context::full(&rt).unwrap();
+
+        // Case 1: JS drops first while Rust keeps its Arc clone.
+        c.with(|ctx| {
+            let _ab = ArrayBuffer::from_source_immutable(ctx.clone(), arc.clone()).unwrap();
+            assert_eq!(Arc::strong_count(&arc), 2, "Arc cloned into drop closure");
+            // _ab drops at end of block; shim runs; closure drops its Arc clone.
+        });
+        assert_eq!(
+            Arc::strong_count(&arc),
+            1,
+            "drop closure must release its Arc clone when ArrayBuffer is freed"
+        );
+        assert!(
+            weak.upgrade().is_some(),
+            "allocation must stay alive while Rust still holds the Arc"
+        );
+
+        // Case 2: Rust drops first, JS keeps the buffer (stored in globals).
+        c.with(|ctx| {
+            let ab = ArrayBuffer::from_source_immutable(ctx.clone(), arc.clone()).unwrap();
+            ctx.globals().set("buf", ab).unwrap();
+            assert_eq!(Arc::strong_count(&arc), 2);
+        });
+        drop(arc);
+        assert!(
+            weak.upgrade().is_some(),
+            "allocation must stay alive: JS still holds the buffer via the Arc clone in the closure"
+        );
+        assert_eq!(
+            weak.strong_count(),
+            1,
+            "only the closure's Arc clone should remain"
+        );
+
+        // Drop the context: JS buffer is freed, shim runs, Arc clone released.
+        drop(c);
+        drop(rt);
+        assert!(
+            weak.upgrade().is_none(),
+            "allocation must be freed after both Rust and JS release their handles"
+        );
+    }
+
+    #[cfg(feature = "bytes")]
+    #[test]
+    fn from_source_immutable_bytes() {
+        let data: bytes::Bytes = (0u8..8).collect::<Vec<_>>().into();
+        let rt = crate::Runtime::new().unwrap();
+        let c = crate::Context::full(&rt).unwrap();
+        c.with(|ctx| {
+            let ab = ArrayBuffer::from_source_immutable(ctx.clone(), data.clone()).unwrap();
+            assert_eq!(ab.as_bytes().unwrap(), (0u8..8).collect::<Vec<_>>());
         });
     }
 }

--- a/core/src/value/array_buffer.rs
+++ b/core/src/value/array_buffer.rs
@@ -1,4 +1,6 @@
-use crate::{qjs, Ctx, Error, FromJs, IntoJs, JsLifetime, Object, Result, Value};
+use crate::{
+    markers::ParallelSend, qjs, Ctx, Error, FromJs, IntoJs, JsLifetime, Object, Result, Value,
+};
 use alloc::boxed::Box;
 use alloc::sync::Arc;
 use alloc::vec::Vec;
@@ -13,27 +15,6 @@ use core::{
 };
 
 use super::typed_array::TypedArrayItem;
-
-/// The drop callback invoked when an externally backed `ArrayBuffer` is
-/// garbage-collected (or when construction fails).
-#[cfg(not(feature = "parallel"))]
-pub type ArrayBufferDrop = Box<dyn FnOnce() + 'static>;
-/// The drop callback invoked when an externally backed `ArrayBuffer` is
-/// garbage-collected (or when construction fails).
-#[cfg(feature = "parallel")]
-pub type ArrayBufferDrop = Box<dyn FnOnce() + Send + 'static>;
-
-/// Marker bound used by the `from_source*` APIs so that the captured source
-/// satisfies the `Send` requirement only when the `parallel` feature is
-/// enabled.
-#[cfg(not(feature = "parallel"))]
-pub trait DropSend {}
-#[cfg(not(feature = "parallel"))]
-impl<T> DropSend for T {}
-#[cfg(feature = "parallel")]
-pub trait DropSend: Send {}
-#[cfg(feature = "parallel")]
-impl<T: Send> DropSend for T {}
 
 /// A contiguous byte region owned by `self` and usable as the backing store
 /// of an [`ArrayBuffer`].
@@ -151,118 +132,31 @@ impl<'js> ArrayBuffer<'js> {
         })))
     }
 
-    /// Create an `ArrayBuffer` backed by an external buffer.
-    ///
-    /// `drop` is invoked exactly once: when the buffer is garbage-collected,
-    /// or synchronously if construction fails. It should release whatever
-    /// backing storage it captures.
-    ///
-    /// # Safety
-    ///
-    /// `ptr` must point to `len` bytes of valid memory for the entire lifetime
-    /// of the returned buffer and any views of it. The `drop` closure must
-    /// release that memory correctly.
-    pub unsafe fn from_raw_parts(
-        ctx: Ctx<'js>,
-        ptr: *mut u8,
-        len: usize,
-        drop: ArrayBufferDrop,
-    ) -> Result<Self> {
-        unsafe { Self::from_raw_parts_inner(ctx, ptr, len, drop, false, false) }
-    }
-
-    /// Create a JS `SharedArrayBuffer` backed by an external buffer.
-    ///
-    /// Same semantics as [`from_raw_parts`] but produces a JS `SharedArrayBuffer`,
-    /// which supports `Atomics` and can be shared across workers.
-    ///
-    /// # Safety
-    ///
-    /// See [`from_raw_parts`].
-    pub unsafe fn from_raw_parts_shared(
-        ctx: Ctx<'js>,
-        ptr: *mut u8,
-        len: usize,
-        drop: ArrayBufferDrop,
-    ) -> Result<Self> {
-        unsafe { Self::from_raw_parts_inner(ctx, ptr, len, drop, true, false) }
-    }
-
-    /// Create an `ArrayBuffer` that JS sees as immutable.
-    ///
-    /// Same semantics as [`from_raw_parts`] but any JS-side write throws,
-    /// which makes it sound to back the buffer with a shared-immutable
-    /// Rust value (`Arc<[u8]>`, `bytes::Bytes`, …) that is still accessible
-    /// from Rust as `&[u8]` after this call returns.
-    ///
-    /// # Safety
-    ///
-    /// See [`from_raw_parts`].
-    pub unsafe fn from_raw_parts_immutable(
-        ctx: Ctx<'js>,
-        ptr: *mut u8,
-        len: usize,
-        drop: ArrayBufferDrop,
-    ) -> Result<Self> {
-        unsafe { Self::from_raw_parts_inner(ctx, ptr, len, drop, false, true) }
-    }
-
-    unsafe fn from_raw_parts_inner(
-        ctx: Ctx<'js>,
-        ptr: *mut u8,
-        len: usize,
-        drop: ArrayBufferDrop,
-        is_shared: bool,
-        immutable: bool,
-    ) -> Result<Self> {
-        extern "C" fn shim(_rt: *mut qjs::JSRuntime, opaque: *mut c_void, _ptr: *mut c_void) {
-            unsafe {
-                let boxed: Box<ArrayBufferDrop> = Box::from_raw(opaque as *mut ArrayBufferDrop);
-                (*boxed)();
-            }
-        }
-
-        let opaque = Box::into_raw(Box::new(drop)) as *mut c_void;
-
-        Ok(Self(Object(unsafe {
-            let val =
-                qjs::JS_NewArrayBuffer(ctx.as_ptr(), ptr, len as _, Some(shim), opaque, is_shared);
-            if let Err(e) = ctx.handle_exception(val) {
-                shim(qjs::JS_GetRuntime(ctx.as_ptr()), opaque, ptr as *mut c_void);
-                return Err(e);
-            }
-            if immutable {
-                qjs::JS_SetImmutableArrayBuffer(val, true);
-            }
-            Value::from_js_value(ctx, val)
-        })))
-    }
-
     /// Create an `ArrayBuffer` from a source that owns its backing bytes.
     ///
     /// The source is moved into the buffer; JS has exclusive mutable access
     /// until the buffer is collected, at which point the source is dropped.
     /// Using this with a shared-immutable source (`Arc<[u8]>`, `bytes::Bytes`,
-    /// …) is unsound; use [`from_source_immutable`] for those.
+    /// …) is unsound; use [`from_source_immutable`](Self::from_source_immutable) for those.
     pub fn from_source<S>(ctx: Ctx<'js>, src: S) -> Result<Self>
     where
-        S: ArrayBufferSource + DropSend + 'static,
+        S: ArrayBufferSource + ParallelSend + 'static,
     {
         let ptr = src.as_ptr();
         let len = src.len();
-        unsafe { Self::from_raw_parts(ctx, ptr, len, Box::new(move || drop(src))) }
+        unsafe { Self::from_external(ctx, ptr, len, false, false, move || drop(src)) }
     }
 
     /// Create a `SharedArrayBuffer` from a source that owns its backing bytes.
     ///
-    /// See [`from_source`] for ownership semantics.
+    /// See [`from_source`](Self::from_source) for ownership semantics.
     pub fn from_source_shared<S>(ctx: Ctx<'js>, src: S) -> Result<Self>
     where
-        S: ArrayBufferSource + DropSend + 'static,
+        S: ArrayBufferSource + ParallelSend + 'static,
     {
         let ptr = src.as_ptr();
         let len = src.len();
-        unsafe { Self::from_raw_parts_shared(ctx, ptr, len, Box::new(move || drop(src))) }
+        unsafe { Self::from_external(ctx, ptr, len, true, false, move || drop(src)) }
     }
 
     /// Create an `ArrayBuffer` that JS sees as immutable, backed by a
@@ -273,11 +167,63 @@ impl<'js> ArrayBuffer<'js> {
     /// `bytes::Bytes`, …).
     pub fn from_source_immutable<S>(ctx: Ctx<'js>, src: S) -> Result<Self>
     where
-        S: ArrayBufferSource + DropSend + 'static,
+        S: ArrayBufferSource + ParallelSend + 'static,
     {
         let ptr = src.as_ptr();
         let len = src.len();
-        unsafe { Self::from_raw_parts_immutable(ctx, ptr, len, Box::new(move || drop(src))) }
+        unsafe { Self::from_external(ctx, ptr, len, false, true, move || drop(src)) }
+    }
+
+    /// Internal helper backing the safe `from_source*` constructors.
+    ///
+    /// `drop_fn` is invoked exactly once: when the buffer is garbage-collected,
+    /// or synchronously if construction fails.
+    ///
+    /// # Safety
+    ///
+    /// `ptr` must point to `len` bytes of valid memory until `drop_fn` runs.
+    unsafe fn from_external<F>(
+        ctx: Ctx<'js>,
+        ptr: *mut u8,
+        len: usize,
+        is_shared: bool,
+        immutable: bool,
+        drop_fn: F,
+    ) -> Result<Self>
+    where
+        F: FnOnce() + ParallelSend + 'static,
+    {
+        extern "C" fn shim<F: FnOnce()>(
+            _rt: *mut qjs::JSRuntime,
+            opaque: *mut c_void,
+            _ptr: *mut c_void,
+        ) {
+            unsafe {
+                let boxed: Box<F> = Box::from_raw(opaque as *mut F);
+                (*boxed)();
+            }
+        }
+
+        let opaque = Box::into_raw(Box::new(drop_fn)) as *mut c_void;
+
+        Ok(Self(Object(unsafe {
+            let val = qjs::JS_NewArrayBuffer(
+                ctx.as_ptr(),
+                ptr,
+                len as _,
+                Some(shim::<F>),
+                opaque,
+                is_shared,
+            );
+            if let Err(e) = ctx.handle_exception(val) {
+                shim::<F>(qjs::JS_GetRuntime(ctx.as_ptr()), opaque, ptr as *mut c_void);
+                return Err(e);
+            }
+            if immutable {
+                qjs::JS_SetImmutableArrayBuffer(val, true);
+            }
+            Value::from_js_value(ctx, val)
+        })))
     }
 
     /// Get the length of the array buffer in bytes.
@@ -540,29 +486,31 @@ mod test {
     }
 
     #[test]
-    fn from_raw_parts_external_buffer() {
+    fn from_source_external_buffer() {
         use core::sync::atomic::{AtomicBool, Ordering};
 
         static DROPPED: AtomicBool = AtomicBool::new(false);
 
+        struct Tracker(alloc::boxed::Box<[u8]>);
+        unsafe impl ArrayBufferSource for Tracker {
+            fn as_ptr(&self) -> *mut u8 {
+                self.0.as_ptr()
+            }
+            fn len(&self) -> usize {
+                self.0.len()
+            }
+        }
+        impl Drop for Tracker {
+            fn drop(&mut self) {
+                DROPPED.store(true, Ordering::SeqCst);
+            }
+        }
+
         let rt = crate::Runtime::new().unwrap();
         let c = crate::Context::full(&rt).unwrap();
         c.with(|ctx| {
-            let buf: alloc::boxed::Box<[u8]> = alloc::vec![1u8, 2, 3, 4].into_boxed_slice();
-            let ptr = buf.as_ptr();
-            let len = buf.len();
-            let ab = unsafe {
-                ArrayBuffer::from_raw_parts(
-                    ctx.clone(),
-                    ptr,
-                    len,
-                    Box::new(move || {
-                        drop(buf);
-                        DROPPED.store(true, Ordering::SeqCst);
-                    }),
-                )
-                .unwrap()
-            };
+            let src = Tracker(alloc::vec![1u8, 2, 3, 4].into_boxed_slice());
+            let ab = ArrayBuffer::from_source(ctx.clone(), src).unwrap();
             assert_eq!(ab.len(), 4);
             assert_eq!(ab.as_bytes().unwrap(), &[1, 2, 3, 4]);
         });
@@ -571,34 +519,54 @@ mod test {
     }
 
     #[test]
-    fn from_raw_parts_error_invokes_drop_fn() {
+    fn from_source_error_invokes_drop_fn() {
         use core::sync::atomic::{AtomicBool, Ordering};
 
         static DROPPED: AtomicBool = AtomicBool::new(false);
 
+        // A source that lies about its length to force construction failure,
+        // and signals via `Drop` that the source was released exactly once.
+        struct BadSource(#[allow(dead_code)] alloc::boxed::Box<[u8]>);
+        unsafe impl ArrayBufferSource for BadSource {
+            fn as_ptr(&self) -> *mut u8 {
+                self.0.as_ptr()
+            }
+            fn len(&self) -> usize {
+                i64::MAX as usize
+            }
+        }
+        impl Drop for BadSource {
+            fn drop(&mut self) {
+                DROPPED.store(true, Ordering::SeqCst);
+            }
+        }
+
         let rt = crate::Runtime::new().unwrap();
         let c = crate::Context::full(&rt).unwrap();
         c.with(|ctx| {
-            let buf: alloc::boxed::Box<[u8]> = alloc::vec![1u8, 2, 3, 4].into_boxed_slice();
-            let ptr = buf.as_ptr();
-            let err = unsafe {
-                ArrayBuffer::from_raw_parts(
-                    ctx.clone(),
-                    ptr,
-                    i64::MAX as usize,
-                    Box::new(move || {
-                        drop(buf);
-                        DROPPED.store(true, Ordering::SeqCst);
-                    }),
-                )
-            };
+            let src = BadSource(alloc::vec![1u8, 2, 3, 4].into_boxed_slice());
+            let err = ArrayBuffer::from_source(ctx.clone(), src);
             assert!(err.is_err());
         });
         assert!(DROPPED.load(Ordering::SeqCst));
     }
 
     #[test]
-    fn from_raw_parts_immutable_arc_slices() {
+    fn from_source_immutable_arc_slices() {
+        struct ArcSlice {
+            arc: Arc<Vec<u8>>,
+            offset: usize,
+            len: usize,
+        }
+        unsafe impl ArrayBufferSource for ArcSlice {
+            fn as_ptr(&self) -> *mut u8 {
+                unsafe { self.arc.as_ptr().add(self.offset) }
+            }
+            fn len(&self) -> usize {
+                self.len
+            }
+        }
+
         let buf: Arc<Vec<u8>> = Arc::new((0u8..16).collect());
         let weak = Arc::downgrade(&buf);
 
@@ -606,17 +574,15 @@ mod test {
         let c = crate::Context::full(&rt).unwrap();
         c.with(|ctx| {
             let mk = |offset: usize, len: usize| -> ArrayBuffer<'_> {
-                let clone = buf.clone();
-                let ptr = unsafe { clone.as_ptr().add(offset) };
-                unsafe {
-                    ArrayBuffer::from_raw_parts_immutable(
-                        ctx.clone(),
-                        ptr,
+                ArrayBuffer::from_source_immutable(
+                    ctx.clone(),
+                    ArcSlice {
+                        arc: buf.clone(),
+                        offset,
                         len,
-                        Box::new(move || drop(clone)),
-                    )
-                    .unwrap()
-                }
+                    },
+                )
+                .unwrap()
             };
             let full = mk(0, 16);
             let head = mk(0, 4);


### PR DESCRIPTION
### Issue #

N/A

### Description of changes

Adds `ArrayBuffer::from_raw_parts` (plain `ArrayBuffer`) and `ArrayBuffer::from_raw_parts_shared` (`SharedArrayBuffer`) for wrapping caller-owned memory with a custom `JSFreeArrayBufferDataFunc`, enabling zero-copy exposure of Rust-owned byte storage (`Arc<[u8]>`, `bytes::Bytes`, memory maps, …) to JS; `drop_fn` is invoked synchronously on construction failure so the caller's buffer is released exactly once.

### Checklist

- [x] Added change to the changelog
- [x] Created unit tests for my feature if needed