### PR TITLE
Add initial support for riscv64gc-unknown-linux-gnu CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -246,6 +246,12 @@ jobs:
             features: full-async
 
           - task: bindings
+            os: ubuntu-24.04
+            rust: stable
+            target: riscv64gc-unknown-linux-gnu
+            features: full-async
+
+          - task: bindings
             os: ubuntu-latest
             rust: stable
             target: wasm32-wasip1
@@ -310,7 +316,7 @@ jobs:
         with:
           submodules: true
       - name: Setup cross linux toolchain
-        if: contains(matrix.target, '-linux-') && !startsWith(matrix.target, 'aarch64') && !startsWith(matrix.target, 'armv7') && !startsWith(matrix.target, 'loongarch64') && !startsWith(matrix.target, 'x86_64-') && !endsWith(matrix.target, '-musl') && !startsWith(matrix.target, 'powerpc64')
+        if: contains(matrix.target, '-linux-') && !startsWith(matrix.target, 'aarch64') && !startsWith(matrix.target, 'armv7') && !startsWith(matrix.target, 'loongarch64') && !startsWith(matrix.target, 'riscv64') && !startsWith(matrix.target, 'x86_64-') && !endsWith(matrix.target, '-musl') && !startsWith(matrix.target, 'powerpc64')
         run: |
           case "${{ matrix.target }}" in
             i686-*) SYSTEM_ARCH=i386 ;;
@@ -455,6 +461,27 @@ jobs:
           echo 'rustflags = ["-C", "linker=loongarch64-linux-gnu-gcc-14"]' >> ~/.cargo/config.toml
 
           echo "/musl/bin" >> $GITHUB_PATH
+
+      - name: Setup cross riscv64
+        if: startsWith(matrix.target, 'riscv64') && contains(matrix.target, '-linux-')
+        run: |
+          sudo apt-get update -y
+          sudo apt-get install -y \
+            clang \
+            crossbuild-essential-riscv64 \
+            qemu-user
+
+          mkdir -p ~/.cargo/
+          cat >> ~/.cargo/config.toml <<EOF
+          [target.riscv64gc-unknown-linux-gnu]
+          linker = "riscv64-linux-gnu-gcc"
+          runner = "qemu-riscv64"
+          rustflags = ["-C", "link-arg=-latomic"]
+          rustdocflags = ["-C", "link-arg=-latomic"]
+          EOF
+
+          echo "LD_LIBRARY_PATH=/usr/riscv64-linux-gnu/lib" >> $GITHUB_ENV
+          sudo ln -s /usr/riscv64-linux-gnu/lib/ld-linux-riscv64-lp64d.so.1 /lib/ld-linux-riscv64-lp64d.so.1
       - name: Setup wasmtime for wasm32-wasip1 and wasm32-wasip2
         if: matrix.target == 'wasm32-wasip1' || matrix.target == 'wasm32-wasip2'
         uses: bytecodealliance/actions/wasmtime/setup@v1
@@ -514,7 +541,7 @@ jobs:
           # Limit test threads to 1 for QEMU-emulated targets to work around an intermittent
           # QEMU user-mode emulation bug: "QEMU internal SIGSEGV {code=MAPERR, addr=0x20}"
           # This is a race condition in QEMU's thread emulation, not a bug in rquickjs.
-          ${{ (startsWith(matrix.target, 'loongarch64') || startsWith(matrix.target, 'aarch64-unknown-linux') || startsWith(matrix.target, 'armv7') || startsWith(matrix.target, 'powerpc64')) && 'RUST_TEST_THREADS=1' || '' }} ${{ matrix.target == 'wasm32-wasip1' && 'CARGO_TARGET_WASM32_WASIP1_RUNNER=wasmtime' || '' }} ${{ matrix.target == 'wasm32-wasip2' && 'CARGO_TARGET_WASM32_WASIP2_RUNNER=wasmtime' || '' }} cargo test ${{ matrix.optimization && '--release' || '' }} --all ${{ (matrix.target == 'wasm32-wasip1' || matrix.target == 'wasm32-wasip2') && '--exclude module-loader' || ''  }} --target ${{ matrix.target }} --no-default-features --features ${{ matrix.features }}
+          ${{ (startsWith(matrix.target, 'loongarch64') || startsWith(matrix.target, 'riscv64') || startsWith(matrix.target, 'aarch64-unknown-linux') || startsWith(matrix.target, 'armv7') || startsWith(matrix.target, 'powerpc64')) && 'RUST_TEST_THREADS=1' || '' }} ${{ matrix.target == 'wasm32-wasip1' && 'CARGO_TARGET_WASM32_WASIP1_RUNNER=wasmtime' || '' }} ${{ matrix.target == 'wasm32-wasip2' && 'CARGO_TARGET_WASM32_WASIP2_RUNNER=wasmtime' || '' }} cargo test ${{ matrix.optimization && '--release' || '' }} --all ${{ (matrix.target == 'wasm32-wasip1' || matrix.target == 'wasm32-wasip2') && '--exclude module-loader' || ''  }} --target ${{ matrix.target }} --no-default-features --features ${{ matrix.features }}
 
   update-bindings:
     if: ${{ github.event_name != 'pull_request' && !startsWith(github.ref, 'refs/tags/') }}

--- a/scripts/gen-bindings.sh
+++ b/scripts/gen-bindings.sh
@@ -25,6 +25,7 @@ copy_bindings x86_64-unknown-linux-gnu aarch64-unknown-linux-gnu
 copy_bindings x86_64-unknown-linux-gnu aarch64-unknown-linux-musl
 copy_bindings x86_64-unknown-linux-gnu loongarch64-unknown-linux-gnu
 copy_bindings x86_64-unknown-linux-gnu loongarch64-unknown-linux-musl
+copy_bindings x86_64-unknown-linux-gnu riscv64gc-unknown-linux-gnu
 copy_bindings wasm32-wasip1 wasm32-wasip1
 copy_bindings x86_64-unknown-linux-gnu wasm32-wasip2
 copy_bindings x86_64-unknown-linux-gnu x86_64-unknown-linux-musl


### PR DESCRIPTION
Hi!
I was trying to port pipeline (https://gitlab.com/schmiddi-on-mobile/pipeline) to riscv64 and discovered that one of the dependencies (rquickjs) does not support riscv64 out of the box yet. So I thought it is a nice opportunity to contribute.

### Issue # (if available)

No issue.
But there is previously cancelled PR https://github.com/DelSkayn/rquickjs/pull/649

### Description of changes

Add initial support for riscv64.
Commands hand-tested on docker `catthehacker/ubuntu:act-22.04`, ci requires detailed review.

### Checklist

- [ ] Added change to the changelog
- [ ] Created unit tests for my feature if needed

Unit tests are not required and changelog should be added after you review/edit this feature since I'm not sure if I implemented CI part correctly.