### PR TITLE
Add ArrayBuffer::new_from_bytes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,10 +50,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed iterators to use correct IteratorPrototype chain
 - Fixed a latent ABI layout vulnerability in `JS_NewPromiseCapability` FFI boundary by replacing tuple with strictly compatible array
 - `#[rquickjs::class]` now rejects fields whose type implements `JsClass` with a clear compile error; such fields silently dropped nested mutations because the generated getter cloned the value. Wrap the field in `Class<'js, T>` instead #[532](https://github.com/DelSkayn/rquickjs/issues/532)
-  <<<<<<< fix/missing-trace-impls
 - # Added missing `Trace` implementations for `Constructor`, `Promise`, `Proxy`, `ArrayBuffer`, and `TypedArray`; added `JsLifetime` for `Proxy`; re-exported `Constructor` at the crate root
 - Fixed `#[qjs(static, rename = PredefinedAtom::...)]` methods failing when the target symbol exists as a non-writable property on `Function.prototype` (e.g. `Symbol.hasInstance`) by defining properties directly on the constructor instead of going through the prototype chain #[315](https://github.com/DelSkayn/rquickjs/issues/315)
-  > > > > > > > master
 - Fixed `#[qjs(static, get/set)]` accessors being placed on the class prototype instead of the constructor #[478](https://github.com/DelSkayn/rquickjs/issues/478)
 - Fixed `Runtime::set_max_stack_size` crashing on large values (e.g. `usize::MAX`) by clamping to avoid a pointer underflow inside QuickJS's stack limit check #[437](https://github.com/DelSkayn/rquickjs/issues/437)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `RQUICKJS_SYS_NO_WASI_SDK` env variable that skips downloading and setting up the WASI SDK when set to `1` #[648](https://github.com/DelSkayn/rquickjs/pull/648)
 - Added `Object::new_proto` for creating objects with a custom or null prototype #[572](https://github.com/DelSkayn/rquickjs/issues/572)
 - Added `Symbol::new`, `Symbol::with_description`, and `Symbol::new_global` for creating local and global symbols from Rust #[672](https://github.com/DelSkayn/rquickjs/pull/672)
+- Added `ArrayBuffer::new_from_bytes` for creating `ArrayBuffer` from `bytes::Bytes`
 
 ### Changed
 
@@ -49,11 +50,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed iterators to use correct IteratorPrototype chain
 - Fixed a latent ABI layout vulnerability in `JS_NewPromiseCapability` FFI boundary by replacing tuple with strictly compatible array
 - `#[rquickjs::class]` now rejects fields whose type implements `JsClass` with a clear compile error; such fields silently dropped nested mutations because the generated getter cloned the value. Wrap the field in `Class<'js, T>` instead #[532](https://github.com/DelSkayn/rquickjs/issues/532)
-<<<<<<< fix/missing-trace-impls
-- Added missing `Trace` implementations for `Constructor`, `Promise`, `Proxy`, `ArrayBuffer`, and `TypedArray`; added `JsLifetime` for `Proxy`; re-exported `Constructor` at the crate root
-=======
+  <<<<<<< fix/missing-trace-impls
+- # Added missing `Trace` implementations for `Constructor`, `Promise`, `Proxy`, `ArrayBuffer`, and `TypedArray`; added `JsLifetime` for `Proxy`; re-exported `Constructor` at the crate root
 - Fixed `#[qjs(static, rename = PredefinedAtom::...)]` methods failing when the target symbol exists as a non-writable property on `Function.prototype` (e.g. `Symbol.hasInstance`) by defining properties directly on the constructor instead of going through the prototype chain #[315](https://github.com/DelSkayn/rquickjs/issues/315)
->>>>>>> master
+  > > > > > > > master
 - Fixed `#[qjs(static, get/set)]` accessors being placed on the class prototype instead of the constructor #[478](https://github.com/DelSkayn/rquickjs/issues/478)
 - Fixed `Runtime::set_max_stack_size` crashing on large values (e.g. `usize::MAX`) by clamping to avoid a pointer underflow inside QuickJS's stack limit check #[437](https://github.com/DelSkayn/rquickjs/issues/437)
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -105,6 +105,9 @@ macro = ["rquickjs-macro"]
 # Enable hallf (f16) support
 half = ["rquickjs-core/half"]
 
+# Enable zero-copy ArrayBuffer creation from bytes::Bytes
+bytes = ["rquickjs-core/bytes"]
+
 # Enable interop between Rust futures and JS Promises
 futures = ["rquickjs-core/futures"]
 

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -26,6 +26,7 @@ relative-path = { version = "2.0", optional = true, default-features = false, fe
   "alloc",
 ] }
 half = { version = "2.7.1", optional = true }
+bytes = { version = "1", optional = true, default-features = false }
 
 [dev-dependencies]
 futures-rs = { package = "futures", version = "0.3" }
@@ -75,6 +76,9 @@ rust-alloc = []
 # Enable half (f16) support
 
 half = ["dep:half"]
+
+# Enable zero-copy ArrayBuffer creation from bytes::Bytes
+bytes = ["dep:bytes"]
 
 # Enable interop between Rust futures and JS Promises
 futures = ["dep:async-lock"]

--- a/core/src/value/array_buffer.rs
+++ b/core/src/value/array_buffer.rs
@@ -1,4 +1,6 @@
 use crate::{qjs, Ctx, Error, FromJs, IntoJs, JsLifetime, Object, Result, Value};
+#[cfg(feature = "bytes")]
+use alloc::boxed::Box;
 use alloc::vec::Vec;
 use core::{
     ffi::c_void,
@@ -73,6 +75,38 @@ impl<'js> ArrayBuffer<'js> {
                 // don't forget to free data when error occurred
                 Vec::from_raw_parts(ptr, capacity, capacity);
             })?;
+            Value::from_js_value(ctx, val)
+        })))
+    }
+
+    /// Create an immutable array buffer from a [`bytes::Bytes`] instance without copying.
+    ///
+    /// The resulting `ArrayBuffer` is marked immutable via `JS_SetImmutableArrayBuffer`,
+    /// so JavaScript code cannot write to it. The `Bytes` reference count is held for the
+    /// lifetime of the buffer, ensuring the underlying data outlives the JS object.
+    #[cfg(feature = "bytes")]
+    pub fn new_from_bytes(ctx: Ctx<'js>, bytes: bytes::Bytes) -> Result<Self> {
+        let ptr = bytes.as_ptr() as *mut u8;
+        let len = bytes.len();
+        let opaque = Box::into_raw(Box::new(bytes)) as *mut c_void;
+
+        extern "C" fn free_bytes(_rt: *mut qjs::JSRuntime, opaque: *mut c_void, _ptr: *mut c_void) {
+            unsafe { drop(Box::from_raw(opaque as *mut bytes::Bytes)) };
+        }
+
+        Ok(Self(Object(unsafe {
+            let val = qjs::JS_NewArrayBuffer(
+                ctx.as_ptr(),
+                ptr,
+                len as _,
+                Some(free_bytes),
+                opaque,
+                false,
+            );
+            ctx.handle_exception(val).inspect_err(|_| {
+                drop(Box::from_raw(opaque as *mut bytes::Bytes));
+            })?;
+            qjs::JS_SetImmutableArrayBuffer(val, true);
             Value::from_js_value(ctx, val)
         })))
     }
@@ -229,6 +263,13 @@ impl<'js> IntoJs<'js> for ArrayBuffer<'js> {
     }
 }
 
+#[cfg(feature = "bytes")]
+impl<'js> IntoJs<'js> for bytes::Bytes {
+    fn into_js(self, ctx: &Ctx<'js>) -> Result<Value<'js>> {
+        ArrayBuffer::new_from_bytes(ctx.clone(), self).map(|ab| ab.into_value())
+    }
+}
+
 impl<'js> Object<'js> {
     /// Returns whether the object is an instance of [`ArrayBuffer`].
     pub fn is_array_buffer(&self) -> bool {
@@ -326,6 +367,61 @@ mod test {
                 .unwrap();
             assert_eq!(res, 0);
         })
+    }
+
+    #[cfg(feature = "bytes")]
+    #[test]
+    fn from_bytes_zero_copy() {
+        test_with(|ctx| {
+            let b = bytes::Bytes::from_static(b"\x01\x02\x03\x04");
+            let val = ArrayBuffer::new_from_bytes(ctx.clone(), b).unwrap();
+            assert_eq!(val.len(), 4);
+            assert_eq!(val.as_bytes().unwrap(), &[1u8, 2, 3, 4]);
+        });
+    }
+
+    #[cfg(feature = "bytes")]
+    #[test]
+    fn from_bytes_is_immutable() {
+        test_with(|ctx| {
+            let b = bytes::Bytes::from_static(b"\x01\x02\x03\x04");
+            let val = ArrayBuffer::new_from_bytes(ctx.clone(), b).unwrap();
+            ctx.globals().set("buf", val).unwrap();
+            // Writes to an immutable ArrayBuffer are silently ignored
+            let res: u32 = ctx
+                .eval(
+                    r#"
+                        let v = new Uint8Array(buf);
+                        v[0] = 99;
+                        v[0]
+                    "#,
+                )
+                .unwrap();
+            assert_eq!(res, 1, "write to immutable buffer should be ignored");
+        });
+    }
+
+    #[cfg(feature = "bytes")]
+    #[test]
+    fn bytes_into_js() {
+        test_with(|ctx| {
+            let b = bytes::Bytes::copy_from_slice(b"\xCA\xFE\xBE\xEF");
+            ctx.globals().set("buf", b).unwrap();
+            let res: i8 = ctx
+                .eval(
+                    r#"
+                        let v = new Uint8Array(buf);
+                        v.length != 4 ? 1 :
+                        v[0] != 0xCA ? 2 :
+                        v[1] != 0xFE ? 3 :
+                        v[2] != 0xBE ? 4 :
+                        v[3] != 0xEF ? 5 :
+                        0
+                    "#,
+                )
+                .unwrap();
+            assert_eq!(res, 0);
+        });
     }
 
     #[test]


### PR DESCRIPTION
### Issue # (if available)

<!--  **Please post the link to the resolved issue** -->

### Description of changes

<!-- **Please explain what your changes does** -->

Adds the ability to construct an ArrayBuffer from a Bytes object, allowing exposing zero-copy bytes to Javascript.

### Checklist

- [x] Added change to the changelog
- [x] Created unit tests for my feature if needed
