### PR TITLE
Release 0.12.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Breaking Changes
 
-- Added import attributes to the Loader trait #[601](https://github.com/DelSkayn/rquickjs/pull/601)\
+### Added
+
+### Changed
+
+### Deprecated
+
+### Removed
+
+### Fixed
+
+### Security
+
+## [0.12.0] - 2026-05-26
+
+### Breaking Changes
+
+- Added import attributes to the Loader trait #[601](https://github.com/DelSkayn/rquickjs/pull/601)
 - Added half support (f16) for Float16Array # [662](https://github.com/DelSkayn/rquickjs/pull/662)
 - `Value::new_big_int` now returns `Result<Value>` so QuickJS allocation failures are surfaced to the caller #[585](https://github.com/DelSkayn/rquickjs/issues/585)
 
@@ -25,6 +41,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `Object::new_proto` for creating objects with a custom or null prototype #[572](https://github.com/DelSkayn/rquickjs/issues/572)
 - Added `Symbol::new`, `Symbol::with_description`, and `Symbol::new_global` for creating local and global symbols from Rust #[672](https://github.com/DelSkayn/rquickjs/pull/672)
 - Added `ArrayBufferSource` trait and `ArrayBuffer::from_source` / `from_source_shared` / `from_source_immutable` safe constructors for wrapping external, caller-owned buffers, with built-in impls for `Vec<u8>`, `Box<[u8]>`, `Arc<[u8]>`, `Arc<Vec<u8>>`, and (behind the `bytes` feature) `bytes::Bytes`
+- Add pre-generated bindings for `armv7-unknown-linux-gnueabihf`
+- Add pre-generated bindings for `powerpc64-unknown-linux-gnu`
 
 ### Changed
 
@@ -34,11 +52,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Deprecated
 
 - Deprecated `async_with!` macro #[602](https://github.com/DelSkayn/rquickjs/pull/602)
-
-### Added
-
-- Add pre-generated bindings for `armv7-unknown-linux-gnueabihf`
-- Add pre-generated bindings for `powerpc64-unknown-linux-gnu`
 
 ### Fixed
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rquickjs"
-version = "0.11.0"
+version = "0.12.0"
 authors = ["Mees Delzenne <mees.delzenne@gmail.com>", "K. <kayo@illumium.org>"]
 edition = "2021"
 rust-version = "1.87"
@@ -26,10 +26,10 @@ members = [
 ]
 
 [workspace.dependencies]
-rquickjs-core = { version = "0.11.0", path = "core", default-features = false }
-rquickjs-macro = { version = "0.11.0", path = "macro", default-features = false }
-rquickjs-sys = { version = "0.11.0", path = "sys", default-features = false }
-rquickjs = { version = "0.11.0", path = "./", default-features = false }
+rquickjs-core = { version = "0.12.0", path = "core", default-features = false }
+rquickjs-macro = { version = "0.12.0", path = "macro", default-features = false }
+rquickjs-sys = { version = "0.12.0", path = "sys", default-features = false }
+rquickjs = { version = "0.12.0", path = "./", default-features = false }
 
 [dependencies]
 indexmap-rs = { package = "indexmap", version = "2", optional = true }

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rquickjs-core"
-version = "0.11.0"
+version = "0.12.0"
 authors = ["Mees Delzenne <mees.delzenne@gmail.com>", "K. <kayo@illumium.org>"]
 edition = "2021"
 license = "MIT"

--- a/examples/class-methods/Cargo.toml
+++ b/examples/class-methods/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "class-methods"
-version = "0.11.0"
+version = "0.12.0"
 authors = ["Emile Fugulin <code@efugulin.com>"]
 edition = "2018"
 publish = false

--- a/examples/exotic/Cargo.toml
+++ b/examples/exotic/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "exotic"
-version = "0.10.0"
+version = "0.12.0"
 authors = ["K. <kayo@illumium.org>"]
 edition = "2018"
 publish = false

--- a/examples/import-attributes/Cargo.toml
+++ b/examples/import-attributes/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "import-attributes"
-version = "0.11.0"
+version = "0.12.0"
 authors = ["K. <kayo@illumium.org>"]
 edition = "2021"
 publish = false

--- a/examples/module-loader/Cargo.toml
+++ b/examples/module-loader/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "module-loader"
-version = "0.11.0"
+version = "0.12.0"
 authors = ["K. <kayo@illumium.org>"]
 edition = "2018"
 publish = false

--- a/examples/native-module/Cargo.toml
+++ b/examples/native-module/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "native-module"
-version = "0.11.0"
+version = "0.12.0"
 authors = ["K. <kayo@illumium.org>"]
 edition = "2018"
 publish = false

--- a/examples/rquickjs-cli/Cargo.toml
+++ b/examples/rquickjs-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rquickjs-cli"
-version = "0.11.0"
+version = "0.12.0"
 authors = ["K. <kayo@illumium.org>"]
 edition = "2018"
 publish = false

--- a/macro/Cargo.toml
+++ b/macro/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rquickjs-macro"
-version = "0.11.0"
+version = "0.12.0"
 authors = ["K. <kayo@illumium.org>", "Mees Delzenne <mees.delzenne@gmail.com>"]
 edition = "2021"
 license = "MIT"

--- a/sys/Cargo.toml
+++ b/sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rquickjs-sys"
-version = "0.11.0"
+version = "0.12.0"
 authors = ["Mees Delzenne <mees.delzenne@gmail.com>"]
 edition = "2021"
 license = "MIT"


### PR DESCRIPTION
Cuts the 0.12.0 release.

## Changelog

## [0.12.0] - 2026-05-26

### Breaking Changes

- Added import attributes to the Loader trait #[601](https://github.com/DelSkayn/rquickjs/pull/601)
- Added half support (f16) for Float16Array # [662](https://github.com/DelSkayn/rquickjs/pull/662)
- `Value::new_big_int` now returns `Result<Value>` so QuickJS allocation failures are surfaced to the caller #[585](https://github.com/DelSkayn/rquickjs/issues/585)

### Added

- Added `#[qjs(prop)]` method attribute to declare a JS data property on a class prototype.
  Unlike `#[qjs(get)]`, which generates an accessor and requires a `FromJs<Self>` receiver,
  `prop` is evaluated at class registration time and emits a plain data descriptor (matching
  Web IDL semantics for `@@toStringTag`, `@@species`, etc.). Honours `rename`, `configurable`,
  `enumerable`, and a new `writable` flag (which also gates `writable` on `prop`).
- Added `FromJs` and `IntoJs` derive macros for plain-data structs
- Added `RQUICKJS_SYS_NO_WASI_SDK` env variable that skips downloading and setting up the WASI SDK when set to `1` #[648](https://github.com/DelSkayn/rquickjs/pull/648)
- Added `Object::new_proto` for creating objects with a custom or null prototype #[572](https://github.com/DelSkayn/rquickjs/issues/572)
- Added `Symbol::new`, `Symbol::with_description`, and `Symbol::new_global` for creating local and global symbols from Rust #[672](https://github.com/DelSkayn/rquickjs/pull/672)
- Added `ArrayBufferSource` trait and `ArrayBuffer::from_source` / `from_source_shared` / `from_source_immutable` safe constructors for wrapping external, caller-owned buffers, with built-in impls for `Vec<u8>`, `Box<[u8]>`, `Arc<[u8]>`, `Arc<Vec<u8>>`, and (behind the `bytes` feature) `bytes::Bytes`
- Add pre-generated bindings for `armv7-unknown-linux-gnueabihf`
- Add pre-generated bindings for `powerpc64-unknown-linux-gnu`

### Changed

- Bump MSRV to 1.87
- Updated `AsyncContext::async_with` to use async closure syntax #[602](https://github.com/DelSkayn/rquickjs/pull/602)

### Deprecated

- Deprecated `async_with!` macro #[602](https://github.com/DelSkayn/rquickjs/pull/602)

### Fixed

- Fixed `Property::configurable()` / `.writable()` / `.enumerable()` not emitting `JS_PROP_HAS_*` flags, so redefining an existing property silently kept its old attributes #[693](https://github.com/DelSkayn/rquickjs/issues/693)
- Fixed QuickJS rope strings (`JS_TAG_STRING_ROPE`) not being recognized as strings, causing `type_of()`, `is_string()`, and `as_string()` to fail on large concatenated strings
- Fixed interrupt handler causing GC assertion failure due to missing `JS_DupContext` on error context from `JS_ExecutePendingJob` #[664](https://github.com/DelSkayn/rquickjs/pull/664)
- Fixed cross-thread stack overflow false positives in parallel mode by updating stack baseline before QuickJS C entry points
- Fixed promise polling not returning Ready variant when exception occurs
- Fixed promise future aborting on stale pending exceptions by only bailing on uncatchable errors (e.g. interrupt handler)
- Fixed iterators to use correct IteratorPrototype chain
- Fixed a latent ABI layout vulnerability in `JS_NewPromiseCapability` FFI boundary by replacing tuple with strictly compatible array
- `#[rquickjs::class]` now rejects fields whose type implements `JsClass` with a clear compile error; such fields silently dropped nested mutations because the generated getter cloned the value. Wrap the field in `Class<'js, T>` instead #[532](https://github.com/DelSkayn/rquickjs/issues/532)
- Added missing `Trace` implementations for `Constructor`, `Promise`, `Proxy`, `ArrayBuffer`, and `TypedArray`; added `JsLifetime` for `Proxy`; re-exported `Constructor` at the crate root
- Fixed `#[qjs(static, rename = PredefinedAtom::...)]` methods failing when the target symbol exists as a non-writable property on `Function.prototype` (e.g. `Symbol.hasInstance`) by defining properties directly on the constructor instead of going through the prototype chain #[315](https://github.com/DelSkayn/rquickjs/issues/315)
- Fixed `#[qjs(static, get/set)]` accessors being placed on the class prototype instead of the constructor #[478](https://github.com/DelSkayn/rquickjs/issues/478)
- Fixed `Runtime::set_max_stack_size` crashing on large values (e.g. `usize::MAX`) by clamping to avoid a pointer underflow inside QuickJS's stack limit check #[437](https://github.com/DelSkayn/rquickjs/issues/437)

