### PR TITLE
Release 0.12.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,17 +13,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Updated `phf`, `phf_shared` and `phf_generator` to 0.14
-
 ### Deprecated
 
 ### Removed
 
 ### Fixed
 
-- Fixed `Constructor::new_prototype` leaking a reference cycle that aborted `JS_FreeRuntime` with a `gc_obj_list` assertion failure
-
 ### Security
+
+## [0.12.1] - 2026-06-29
+
+### Changed
+
+- Updated `phf`, `phf_shared` and `phf_generator` to 0.14
+
+### Fixed
+
+- Fixed `Constructor::new_prototype` leaking a reference cycle that aborted `JS_FreeRuntime` with a `gc_obj_list` assertion failure
 
 ## [0.12.0] - 2026-05-26
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rquickjs"
-version = "0.12.0"
+version = "0.12.1"
 authors = ["Mees Delzenne <mees.delzenne@gmail.com>", "K. <kayo@illumium.org>"]
 edition = "2021"
 rust-version = "1.87"
@@ -26,10 +26,10 @@ members = [
 ]
 
 [workspace.dependencies]
-rquickjs-core = { version = "0.12.0", path = "core", default-features = false }
-rquickjs-macro = { version = "0.12.0", path = "macro", default-features = false }
-rquickjs-sys = { version = "0.12.0", path = "sys", default-features = false }
-rquickjs = { version = "0.12.0", path = "./", default-features = false }
+rquickjs-core = { version = "0.12.1", path = "core", default-features = false }
+rquickjs-macro = { version = "0.12.1", path = "macro", default-features = false }
+rquickjs-sys = { version = "0.12.1", path = "sys", default-features = false }
+rquickjs = { version = "0.12.1", path = "./", default-features = false }
 
 [dependencies]
 indexmap-rs = { package = "indexmap", version = "2", optional = true }

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rquickjs-core"
-version = "0.12.0"
+version = "0.12.1"
 authors = ["Mees Delzenne <mees.delzenne@gmail.com>", "K. <kayo@illumium.org>"]
 edition = "2021"
 license = "MIT"

--- a/examples/class-methods/Cargo.toml
+++ b/examples/class-methods/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "class-methods"
-version = "0.12.0"
+version = "0.12.1"
 authors = ["Emile Fugulin <code@efugulin.com>"]
 edition = "2018"
 publish = false

--- a/examples/exotic/Cargo.toml
+++ b/examples/exotic/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "exotic"
-version = "0.12.0"
+version = "0.12.1"
 authors = ["K. <kayo@illumium.org>"]
 edition = "2018"
 publish = false

--- a/examples/import-attributes/Cargo.toml
+++ b/examples/import-attributes/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "import-attributes"
-version = "0.12.0"
+version = "0.12.1"
 authors = ["K. <kayo@illumium.org>"]
 edition = "2021"
 publish = false

--- a/examples/module-loader/Cargo.toml
+++ b/examples/module-loader/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "module-loader"
-version = "0.12.0"
+version = "0.12.1"
 authors = ["K. <kayo@illumium.org>"]
 edition = "2018"
 publish = false

--- a/examples/native-module/Cargo.toml
+++ b/examples/native-module/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "native-module"
-version = "0.12.0"
+version = "0.12.1"
 authors = ["K. <kayo@illumium.org>"]
 edition = "2018"
 publish = false

--- a/examples/rquickjs-cli/Cargo.toml
+++ b/examples/rquickjs-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rquickjs-cli"
-version = "0.12.0"
+version = "0.12.1"
 authors = ["K. <kayo@illumium.org>"]
 edition = "2018"
 publish = false

--- a/macro/Cargo.toml
+++ b/macro/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rquickjs-macro"
-version = "0.12.0"
+version = "0.12.1"
 authors = ["K. <kayo@illumium.org>", "Mees Delzenne <mees.delzenne@gmail.com>"]
 edition = "2021"
 license = "MIT"

--- a/sys/Cargo.toml
+++ b/sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rquickjs-sys"
-version = "0.12.0"
+version = "0.12.1"
 authors = ["Mees Delzenne <mees.delzenne@gmail.com>"]
 edition = "2021"
 license = "MIT"


### PR DESCRIPTION
### Issue # (if available)

<!--  **Please post the link to the resolved issue** -->

### Description of changes

Patch release **0.12.1**. Stamps `0.12.1` across the workspace (published crates `rquickjs`, `rquickjs-core`, `rquickjs-macro`, `rquickjs-sys`, the workspace dependency table, and every example) and dates the changelog section.

Included since 0.12.0:

- **Fixed:** `Constructor::new_prototype` leaking a reference cycle that aborted `JS_FreeRuntime` with a `gc_obj_list` assertion failure (#706)
- **Changed:** Updated `phf`, `phf_shared` and `phf_generator` to 0.14 (#707)

### Checklist

- [x] Added change to the changelog
- [x] Created unit tests for my feature if needed
