### PR TITLE
Gate QuickJS C flavor behind a feature (quickjs-ng / quickjs-og)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,8 +61,34 @@ jobs:
         with:
           toolchain: nightly
           components: clippy
-      - name: Cargo clippy
+      - name: Cargo clippy (quickjs-ng)
         run: cargo clippy --all --all-targets --features full-async,bindgen
+      - name: Cargo clippy (quickjs-og)
+        run: cargo clippy --all --all-targets --no-default-features --features full-async,bindgen,quickjs-og
+
+  # Run the full workspace test suite against both QuickJS C flavors in
+  # parallel. The original flavor requires `bindgen` (no bundled bindings are
+  # shipped for it) and is selected with `--no-default-features` so the default
+  # `quickjs-ng` is not also pulled in.
+  flavor:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        flavor: [quickjs-ng, quickjs-og]
+    name: flavor / ${{ matrix.flavor }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          submodules: true
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          toolchain: stable
+      - name: Cargo test (${{ matrix.flavor }})
+        # The original QuickJS uses C assertions during runtime teardown; run
+        # single-threaded so a deliberate abort in one test cannot interleave
+        # with another.
+        run: cargo test --workspace --no-default-features --features full-async,bindgen,${{ matrix.flavor }} -- --test-threads=1
 
   msrv:
     # Check to see if rquickjs builds on minimal supported Rust version.
@@ -102,7 +128,7 @@ jobs:
         if: hashFiles('Cargo.lock') == ''
         run: cargo generate-lockfile
       - name: cargo llvm-cov
-        run: cargo llvm-cov --locked --no-default-features --features full-async,compile-tests,bindgen --workspace --lcov --output-path lcov.info
+        run: cargo llvm-cov --locked --no-default-features --features full-async,compile-tests,bindgen,quickjs-ng --workspace --lcov --output-path lcov.info
       - name: Record Rust version
         run: echo "RUST=$(rustc --version)" >> "$GITHUB_ENV"
       - name: Upload to codecov.io
@@ -128,11 +154,11 @@ jobs:
         if: hashFiles('Cargo.lock') == ''
         run: cargo generate-lockfile
       - name: Run tests with address sanitizer
-        run: CC=clang RUSTFLAGS=-Zsanitizer=address cargo test --tests --workspace -Zbuild-std --target x86_64-unknown-linux-gnu --locked --no-default-features --features full-async,bindgen
+        run: CC=clang RUSTFLAGS=-Zsanitizer=address cargo test --tests --workspace -Zbuild-std --target x86_64-unknown-linux-gnu --locked --no-default-features --features full-async,bindgen,quickjs-ng
       - name: Run tests with thread sanitizer
-        run: CC=clang RUSTFLAGS=-Zsanitizer=thread cargo test --tests --workspace -Zbuild-std --target x86_64-unknown-linux-gnu --locked --no-default-features --features full-async,bindgen
+        run: CC=clang RUSTFLAGS=-Zsanitizer=thread cargo test --tests --workspace -Zbuild-std --target x86_64-unknown-linux-gnu --locked --no-default-features --features full-async,bindgen,quickjs-ng
       - name: Run tests with memory sanitizer
-        run: CC=clang RUSTFLAGS=-Zsanitizer=memory cargo test --tests --workspace -Zbuild-std --target x86_64-unknown-linux-gnu --locked --no-default-features --features full-async,bindgen
+        run: CC=clang RUSTFLAGS=-Zsanitizer=memory cargo test --tests --workspace -Zbuild-std --target x86_64-unknown-linux-gnu --locked --no-default-features --features full-async,bindgen,quickjs-ng
 
   examples:
     runs-on: ubuntu-latest
@@ -153,6 +179,7 @@ jobs:
       - format
       - doc
       - check
+      - flavor
       - msrv
       - coverage
     strategy:
@@ -531,7 +558,7 @@ jobs:
           BUILD_TARGET: ${{ matrix.target }}
           TARGET: ${{ matrix.target }}
         run: |
-          cargo build ${{ matrix.optimization && '--release' || '' }} --target ${{ matrix.target }} --no-default-features --features ${{ matrix.features }}
+          cargo build ${{ matrix.optimization && '--release' || '' }} --target ${{ matrix.target }} --no-default-features --features ${{ matrix.features }},quickjs-ng
       - name: Test
         if: ${{ !matrix.no-build && !matrix.no-test }}
         timeout-minutes: 12
@@ -541,7 +568,7 @@ jobs:
           # Limit test threads to 1 for QEMU-emulated targets to work around an intermittent
           # QEMU user-mode emulation bug: "QEMU internal SIGSEGV {code=MAPERR, addr=0x20}"
           # This is a race condition in QEMU's thread emulation, not a bug in rquickjs.
-          ${{ (startsWith(matrix.target, 'loongarch64') || startsWith(matrix.target, 'riscv64') || startsWith(matrix.target, 'aarch64-unknown-linux') || startsWith(matrix.target, 'armv7') || startsWith(matrix.target, 'powerpc64')) && 'RUST_TEST_THREADS=1' || '' }} ${{ matrix.target == 'wasm32-wasip1' && 'CARGO_TARGET_WASM32_WASIP1_RUNNER=wasmtime' || '' }} ${{ matrix.target == 'wasm32-wasip2' && 'CARGO_TARGET_WASM32_WASIP2_RUNNER=wasmtime' || '' }} cargo test ${{ matrix.optimization && '--release' || '' }} --all ${{ (matrix.target == 'wasm32-wasip1' || matrix.target == 'wasm32-wasip2') && '--exclude module-loader' || ''  }} --target ${{ matrix.target }} --no-default-features --features ${{ matrix.features }}
+          ${{ (startsWith(matrix.target, 'loongarch64') || startsWith(matrix.target, 'riscv64') || startsWith(matrix.target, 'aarch64-unknown-linux') || startsWith(matrix.target, 'armv7') || startsWith(matrix.target, 'powerpc64')) && 'RUST_TEST_THREADS=1' || '' }} ${{ matrix.target == 'wasm32-wasip1' && 'CARGO_TARGET_WASM32_WASIP1_RUNNER=wasmtime' || '' }} ${{ matrix.target == 'wasm32-wasip2' && 'CARGO_TARGET_WASM32_WASIP2_RUNNER=wasmtime' || '' }} cargo test ${{ matrix.optimization && '--release' || '' }} --all ${{ (matrix.target == 'wasm32-wasip1' || matrix.target == 'wasm32-wasip2') && '--exclude module-loader' || ''  }} --target ${{ matrix.target }} --no-default-features --features ${{ matrix.features }},quickjs-ng
 
   update-bindings:
     if: ${{ github.event_name != 'pull_request' && !startsWith(github.ref, 'refs/tags/') }}

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "rquickjs-sys/quickjs"]
 	path = sys/quickjs
 	url = https://github.com/quickjs-ng/quickjs.git
+[submodule "sys/quickjs-original"]
+	path = sys/quickjs-original
+	url = https://github.com/bellard/quickjs.git

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,7 @@ rquickjs-macro = { workspace = true, optional = true }
 
 
 [features]
-default = ["std"]
+default = ["std", "quickjs-ng"]
 
 # Almost all features excluding "parallel" and support for async runtimes
 full = [
@@ -64,6 +64,12 @@ full-async-wasi = ["full-wasi", "futures"]
 
 # Enable use of the rust standard library
 std = ["rquickjs-core/std"]
+
+# Select which QuickJS C flavor to build against (mutually exclusive).
+# `quickjs-ng` (default) builds the quickjs-ng fork; `quickjs-og` builds
+# Fabrice Bellard's original QuickJS. The latter requires the `bindgen` feature.
+quickjs-ng = ["rquickjs-core/quickjs-ng"]
+quickjs-og = ["rquickjs-core/quickjs-og"]
 
 # Chrono support.
 chrono = ["rquickjs-core/chrono"]

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -36,14 +36,20 @@ tokio = { version = "1", default-features = false, features = [
   "macros",
   "sync",
 ] }
-rquickjs.path = "../"
+rquickjs = { path = "../", default-features = false, features = ["std"] }
 approx = "0.5"
 trybuild = "1"
 
 [features]
-default = ["std"]
+default = ["std", "quickjs-ng"]
 
 std = ["relative-path?/std"]
+
+# Select which QuickJS C flavor to build against (mutually exclusive).
+# `quickjs-ng` (default) builds the quickjs-ng fork; `quickjs-og` builds
+# Fabrice Bellard's original QuickJS. The latter requires `bindgen`.
+quickjs-ng = ["rquickjs-sys/quickjs-ng", "rquickjs/quickjs-ng"]
+quickjs-og = ["rquickjs-sys/quickjs-og", "rquickjs/quickjs-og"]
 
 # Almost all features excluding "parallel" and support for async runtimes
 full = ["std", "chrono", "loader", "dyn-load", "either", "indexmap", "half"]

--- a/core/src/allocator.rs
+++ b/core/src/allocator.rs
@@ -69,12 +69,27 @@ impl AllocatorHolder {
     where
         A: Allocator,
     {
-        qjs::JSMallocFunctions {
-            js_calloc: Some(Self::calloc::<A>),
-            js_malloc: Some(Self::malloc::<A>),
-            js_free: Some(Self::free::<A>),
-            js_realloc: Some(Self::realloc::<A>),
-            js_malloc_usable_size: Some(Self::malloc_usable_size::<A>),
+        #[cfg(not(feature = "quickjs-og"))]
+        {
+            qjs::JSMallocFunctions {
+                js_calloc: Some(Self::calloc::<A>),
+                js_malloc: Some(Self::malloc::<A>),
+                js_free: Some(Self::free::<A>),
+                js_realloc: Some(Self::realloc::<A>),
+                js_malloc_usable_size: Some(Self::malloc_usable_size::<A>),
+            }
+        }
+        // The original QuickJS uses a different allocator ABI: callbacks receive
+        // a `*mut JSMallocState` (whose `opaque` field carries the user
+        // pointer), there is no `calloc`, and no `usable_size` hook.
+        #[cfg(feature = "quickjs-og")]
+        {
+            qjs::JSMallocFunctions {
+                js_malloc: Some(Self::malloc_orig::<A>),
+                js_free: Some(Self::free_orig::<A>),
+                js_realloc: Some(Self::realloc_orig::<A>),
+                js_malloc_usable_size: Some(Self::malloc_usable_size::<A>),
+            }
         }
     }
 
@@ -89,6 +104,7 @@ impl AllocatorHolder {
         self.0
     }
 
+    #[cfg(not(feature = "quickjs-og"))]
     unsafe extern "C" fn calloc<A>(
         opaque: *mut qjs::c_void,
         count: qjs::size_t,
@@ -103,6 +119,7 @@ impl AllocatorHolder {
         allocator.calloc(rust_count, rust_size) as *mut qjs::c_void
     }
 
+    #[cfg(not(feature = "quickjs-og"))]
     unsafe extern "C" fn malloc<A>(opaque: *mut qjs::c_void, size: qjs::size_t) -> *mut qjs::c_void
     where
         A: Allocator,
@@ -112,6 +129,7 @@ impl AllocatorHolder {
         allocator.alloc(rust_size) as *mut qjs::c_void
     }
 
+    #[cfg(not(feature = "quickjs-og"))]
     unsafe extern "C" fn free<A>(opaque: *mut qjs::c_void, ptr: *mut qjs::c_void)
     where
         A: Allocator,
@@ -126,6 +144,7 @@ impl AllocatorHolder {
         allocator.dealloc(ptr as _);
     }
 
+    #[cfg(not(feature = "quickjs-og"))]
     unsafe extern "C" fn realloc<A>(
         opaque: *mut qjs::c_void,
         ptr: *mut qjs::c_void,
@@ -139,6 +158,7 @@ impl AllocatorHolder {
         allocator.realloc(ptr as _, rust_size) as *mut qjs::c_void
     }
 
+    // `malloc_usable_size` has the same signature in both flavors.
     unsafe extern "C" fn malloc_usable_size<A>(ptr: *const qjs::c_void) -> qjs::size_t
     where
         A: Allocator,
@@ -148,5 +168,50 @@ impl AllocatorHolder {
             return 0;
         }
         A::usable_size(ptr as _).try_into().unwrap()
+    }
+
+    // ---- original-flavor allocator callbacks ----
+    //
+    // The original QuickJS passes a `*mut JSMallocState` whose `opaque` field
+    // holds the user pointer set via `JS_NewRuntime2`.
+
+    #[cfg(feature = "quickjs-og")]
+    unsafe extern "C" fn malloc_orig<A>(
+        s: *mut qjs::JSMallocState,
+        size: qjs::size_t,
+    ) -> *mut qjs::c_void
+    where
+        A: Allocator,
+    {
+        let allocator = &mut *((*s).opaque as *mut DynAllocator);
+        let rust_size: usize = size.try_into().expect(qjs::SIZE_T_ERROR);
+        allocator.alloc(rust_size) as *mut qjs::c_void
+    }
+
+    #[cfg(feature = "quickjs-og")]
+    unsafe extern "C" fn free_orig<A>(s: *mut qjs::JSMallocState, ptr: *mut qjs::c_void)
+    where
+        A: Allocator,
+    {
+        // simulate the default behavior of libc::free
+        if ptr.is_null() {
+            return;
+        }
+        let allocator = &mut *((*s).opaque as *mut DynAllocator);
+        allocator.dealloc(ptr as _);
+    }
+
+    #[cfg(feature = "quickjs-og")]
+    unsafe extern "C" fn realloc_orig<A>(
+        s: *mut qjs::JSMallocState,
+        ptr: *mut qjs::c_void,
+        size: qjs::size_t,
+    ) -> *mut qjs::c_void
+    where
+        A: Allocator,
+    {
+        let rust_size: usize = size.try_into().expect(qjs::SIZE_T_ERROR);
+        let allocator = &mut *((*s).opaque as *mut DynAllocator);
+        allocator.realloc(ptr as _, rust_size) as *mut qjs::c_void
     }
 }

--- a/core/src/allocator/rust.rs
+++ b/core/src/allocator/rust.rs
@@ -170,6 +170,14 @@ mod test {
     }
 
     #[test]
+    #[cfg_attr(
+        feature = "quickjs-og",
+        ignore = "asserts quickjs-ng's automatic GC threshold behavior: ng collects the \
+                  recursive closures during the allocation loop, while the original QuickJS \
+                  uses a different gc_threshold heuristic and only collects on an explicit \
+                  run_gc() (verified: delta is 0 after a manual GC, so this is an engine \
+                  auto-GC difference, not a leak)"
+    )]
     fn test_gc_working_correctly() {
         let rt = Runtime::new_with_alloc(TestAllocator).unwrap();
         let context = Context::full(&rt).unwrap();

--- a/core/src/class/ffi.rs
+++ b/core/src/class/ffi.rs
@@ -455,7 +455,14 @@ impl VTable {
                     }
                     for (i, name) in names.into_iter().enumerate() {
                         let entry = tab.add(i);
-                        (*entry).is_enumerable = name.is_enumerable;
+                        #[cfg(feature = "quickjs-og")]
+                        {
+                            (*entry).is_enumerable = name.is_enumerable as ::core::ffi::c_int;
+                        }
+                        #[cfg(not(feature = "quickjs-og"))]
+                        {
+                            (*entry).is_enumerable = name.is_enumerable;
+                        }
                         // Dup the atom for QuickJS ownership; Rust Atom drop will free the original
                         (*entry).atom = qjs::JS_DupAtom(ctx.as_ptr(), name.atom.atom);
                     }

--- a/core/src/context/base.rs
+++ b/core/src/context/base.rs
@@ -265,9 +265,9 @@ mod test {
 
     // Will be improved by https://github.com/quickjs-ng/quickjs/pull/406
     #[test]
-    #[should_panic(
-        expected = "Error: invalid first character of private name\n    at eval_script:1:1\n"
-    )]
+    // Both flavors raise the same SyntaxError; they differ only in the reported
+    // column (original `1:5` vs quickjs-ng `1:1`), so match on the message text.
+    #[should_panic(expected = "Error: invalid first character of private name")]
     fn exception() {
         test_with(|ctx| {
             let val = ctx.eval::<(), _>("bla?#@!@ ").catch(&ctx);

--- a/core/src/context/ctx.rs
+++ b/core/src/context/ctx.rs
@@ -572,7 +572,10 @@ mod test {
     }
 
     #[test]
-    #[should_panic(expected = "foo is not defined")]
+    // Both flavors throw a ReferenceError; the original phrases it as
+    // `'foo' is not defined` and quickjs-ng as `foo is not defined`, so we
+    // match on the common substring.
+    #[should_panic(expected = "is not defined")]
     fn eval_with_sloppy_code() {
         use crate::{CatchResultExt, Context, Runtime};
 
@@ -624,7 +627,9 @@ mod test {
     }
 
     #[test]
-    #[should_panic(expected = "foo is not defined")]
+    // Both flavors throw a ReferenceError; match on the common substring (see
+    // `eval_with_sloppy_code`).
+    #[should_panic(expected = "is not defined")]
     fn eval_with_options_strict_sloppy_code() {
         use crate::{context::EvalOptions, CatchResultExt, Context, Runtime};
 

--- a/core/src/loader.rs
+++ b/core/src/loader.rs
@@ -132,14 +132,31 @@ impl LoaderHolder {
 
     pub(crate) fn set_to_runtime(&self, rt: *mut qjs::JSRuntime) {
         unsafe {
-            qjs::JS_SetModuleLoaderFunc2(
-                rt,
-                None,
-                Some(Self::load_raw),
-                None, // No attribute validation
-                self.0 as _,
-            );
-            qjs::JS_SetModuleNormalizeFunc2(rt, Some(Self::normalize_raw));
+            // quickjs-ng exposes a separate attributes-aware normalizer via
+            // `JS_SetModuleNormalizeFunc2`; the original QuickJS only has the
+            // v1 normalizer, passed as the second argument to
+            // `JS_SetModuleLoaderFunc2`.
+            #[cfg(not(feature = "quickjs-og"))]
+            {
+                qjs::JS_SetModuleLoaderFunc2(
+                    rt,
+                    None,
+                    Some(Self::load_raw),
+                    None, // No attribute validation
+                    self.0 as _,
+                );
+                qjs::JS_SetModuleNormalizeFunc2(rt, Some(Self::normalize_raw));
+            }
+            #[cfg(feature = "quickjs-og")]
+            {
+                qjs::JS_SetModuleLoaderFunc2(
+                    rt,
+                    Some(Self::normalize_raw_v1),
+                    Some(Self::load_raw),
+                    None, // No attribute validation
+                    self.0 as _,
+                );
+            }
         }
     }
 
@@ -170,6 +187,7 @@ impl LoaderHolder {
         Ok(unsafe { qjs::js_strndup(ctx.as_ptr(), name.as_ptr() as _, name.len() as _) })
     }
 
+    #[cfg(not(feature = "quickjs-og"))]
     unsafe extern "C" fn normalize_raw(
         ctx: *mut qjs::JSContext,
         base: *const qjs::c_char,
@@ -183,6 +201,27 @@ impl LoaderHolder {
         let loader = &mut *(opaque as *mut LoaderOpaque);
 
         Self::normalize(loader, &ctx, base, name, attributes).unwrap_or_else(|error| {
+            error.throw(&ctx);
+            ptr::null_mut()
+        })
+    }
+
+    /// v1 normalizer used by the `quickjs-og` flavor, which has no
+    /// attributes-aware normalizer. Import attributes are passed as
+    /// `JS_UNDEFINED`.
+    #[cfg(feature = "quickjs-og")]
+    unsafe extern "C" fn normalize_raw_v1(
+        ctx: *mut qjs::JSContext,
+        base: *const qjs::c_char,
+        name: *const qjs::c_char,
+        opaque: *mut qjs::c_void,
+    ) -> *mut qjs::c_char {
+        let ctx = Ctx::from_ptr(ctx);
+        let base = CStr::from_ptr(base);
+        let name = CStr::from_ptr(name);
+        let loader = &mut *(opaque as *mut LoaderOpaque);
+
+        Self::normalize(loader, &ctx, base, name, qjs::JS_UNDEFINED).unwrap_or_else(|error| {
             error.throw(&ctx);
             ptr::null_mut()
         })

--- a/core/src/runtime/exotic.rs
+++ b/core/src/runtime/exotic.rs
@@ -15,6 +15,16 @@ impl ExoticMethodsHolder {
             has_property: Some(crate::class::ffi::exotic_has_property),
             set_property: Some(crate::class::ffi::exotic_set_property),
             get_property: Some(crate::class::ffi::exotic_get_property),
+            // The original QuickJS exposes additional prototype/extensibility
+            // hooks that quickjs-ng does not; leave them unset.
+            #[cfg(feature = "quickjs-og")]
+            get_prototype: None,
+            #[cfg(feature = "quickjs-og")]
+            set_prototype: None,
+            #[cfg(feature = "quickjs-og")]
+            is_extensible: None,
+            #[cfg(feature = "quickjs-og")]
+            prevent_extensions: None,
         })))
     }
 

--- a/core/src/runtime/opaque.rs
+++ b/core/src/runtime/opaque.rs
@@ -205,6 +205,9 @@ impl<'js> Opaque<'js> {
         unsafe { (*self.promise_hook.get()) = promise_hook }
     }
 
+    // Only invoked from the promise-hook callback, which is quickjs-ng-only
+    // (the original QuickJS has no `JS_SetPromiseHook`).
+    #[cfg_attr(feature = "quickjs-og", allow(dead_code))]
     pub fn run_promise_hook<'a>(
         &self,
         ctx: Ctx<'a>,

--- a/core/src/runtime/raw.rs
+++ b/core/src/runtime/raw.rs
@@ -2,6 +2,7 @@
 use alloc::{boxed::Box, ffi::CString};
 use core::{mem, panic::AssertUnwindSafe, ptr::NonNull, result::Result as StdResult};
 
+#[cfg(not(feature = "quickjs-og"))]
 use rquickjs_sys::JSPromiseHookType;
 
 use crate::allocator::{Allocator, AllocatorHolder};
@@ -291,6 +292,7 @@ impl RawRuntime {
     }
 
     #[allow(clippy::unnecessary_cast)]
+    #[cfg(not(feature = "quickjs-og"))]
     pub unsafe fn set_promise_hook(&mut self, hook: Option<PromiseHook>) {
         unsafe extern "C" fn promise_hook_wrapper(
             ctx: *mut rquickjs_sys::JSContext,
@@ -349,18 +351,36 @@ impl RawRuntime {
         self.get_opaque().set_promise_hook(hook);
     }
 
+    /// Promise hooks are a quickjs-ng feature; the original QuickJS does not
+    /// expose `JS_SetPromiseHook`, so this stores the hook without registering
+    /// a native callback (the hook will never fire).
+    #[cfg(feature = "quickjs-og")]
+    pub unsafe fn set_promise_hook(&mut self, hook: Option<PromiseHook>) {
+        self.get_opaque().set_promise_hook(hook);
+    }
+
     pub unsafe fn set_host_promise_rejection_tracker(&mut self, tracker: Option<RejectionTracker>) {
+        // The original QuickJS uses `int` for the `is_handled` flag, quickjs-ng
+        // uses `bool`.
+        #[cfg(feature = "quickjs-og")]
+        type IsHandled = ::core::ffi::c_int;
+        #[cfg(not(feature = "quickjs-og"))]
+        type IsHandled = bool;
+
         unsafe extern "C" fn rejection_tracker_wrapper(
             ctx: *mut rquickjs_sys::JSContext,
             promise: rquickjs_sys::JSValue,
             reason: rquickjs_sys::JSValue,
-            is_handled: bool,
+            is_handled: IsHandled,
             opaque: *mut ::core::ffi::c_void,
         ) {
             let opaque = NonNull::new_unchecked(opaque).cast::<Opaque>();
 
             let catch_unwind = crate::util::catch_unwind(AssertUnwindSafe(move || {
                 let ctx = Ctx::from_ptr(ctx);
+
+                #[cfg(feature = "quickjs-og")]
+                let is_handled = is_handled != 0;
 
                 opaque.as_ref().run_rejection_tracker(
                     ctx.clone(),

--- a/core/src/value.rs
+++ b/core/src/value.rs
@@ -356,7 +356,14 @@ impl<'js> Value<'js> {
     /// Check if the value is an array
     #[inline]
     pub fn is_array(&self) -> bool {
-        unsafe { qjs::JS_IsArray(self.value) }
+        #[cfg(feature = "quickjs-og")]
+        unsafe {
+            qjs::JS_IsArray(self.ctx.as_ptr(), self.value)
+        }
+        #[cfg(not(feature = "quickjs-og"))]
+        unsafe {
+            qjs::JS_IsArray(self.value)
+        }
     }
 
     /// Check if the value is a function
@@ -374,7 +381,17 @@ impl<'js> Value<'js> {
     /// Check if the value is a promise.
     #[inline]
     pub fn is_promise(&self) -> bool {
-        unsafe { qjs::JS_PromiseState(self.ctx.as_ptr(), self.value) >= 0 }
+        // A promise's state is PENDING/FULFILLED/REJECTED (0/1/2); non-promises
+        // return NOT_A_PROMISE (-1). We test against the valid states rather
+        // than `>= 0` because bindgen may generate `JSPromiseStateEnum` as an
+        // unsigned type (notably for the `quickjs-og` flavor), which would
+        // make `>= 0` always true and misclassify every value as a promise.
+        unsafe {
+            let state = qjs::JS_PromiseState(self.ctx.as_ptr(), self.value);
+            state == qjs::JSPromiseStateEnum_JS_PROMISE_PENDING
+                || state == qjs::JSPromiseStateEnum_JS_PROMISE_FULFILLED
+                || state == qjs::JSPromiseStateEnum_JS_PROMISE_REJECTED
+        }
     }
 
     /// Check if the value is an exception
@@ -386,13 +403,27 @@ impl<'js> Value<'js> {
     /// Check if the value is an error
     #[inline]
     pub fn is_error(&self) -> bool {
-        unsafe { qjs::JS_IsError(self.value) }
+        #[cfg(feature = "quickjs-og")]
+        unsafe {
+            qjs::JS_IsError(self.ctx.as_ptr(), self.value)
+        }
+        #[cfg(not(feature = "quickjs-og"))]
+        unsafe {
+            qjs::JS_IsError(self.value)
+        }
     }
 
     /// Check if the value is an uncatchable error (e.g. from an interrupt handler)
     #[inline]
     pub fn is_uncatchable_error(&self) -> bool {
-        unsafe { qjs::JS_IsUncatchableError(self.value) }
+        #[cfg(feature = "quickjs-og")]
+        unsafe {
+            qjs::JS_IsUncatchableError(self.ctx.as_ptr(), self.value)
+        }
+        #[cfg(not(feature = "quickjs-og"))]
+        unsafe {
+            qjs::JS_IsUncatchableError(self.value)
+        }
     }
 
     /// Check if the value is a BigInt
@@ -404,7 +435,14 @@ impl<'js> Value<'js> {
     /// Check if the value is a proxy
     #[inline]
     pub fn is_proxy(&self) -> bool {
-        unsafe { qjs::JS_IsProxy(self.value) }
+        #[cfg(feature = "quickjs-og")]
+        unsafe {
+            qjs::JS_IsProxy(self.ctx.as_ptr(), self.value)
+        }
+        #[cfg(not(feature = "quickjs-og"))]
+        unsafe {
+            qjs::JS_IsProxy(self.value)
+        }
     }
 
     /// Reference as value
@@ -839,6 +877,13 @@ mod test {
     // `Err(Error::Exception)` rather than returning a `Value` that wraps a
     // `JS_EXCEPTION` sentinel.
     #[test]
+    #[cfg_attr(
+        feature = "quickjs-og",
+        ignore = "on 64-bit targets the original stores i64::MAX as an inline short \
+                  big-int (JS_SHORT_BIG_INT_BITS = 64), so no heap allocation occurs \
+                  and there is no failure to report; quickjs-ng uses 32-bit short \
+                  big-ints and heap-allocates"
+    )]
     fn big_int_oom_is_reported() {
         let rt = crate::Runtime::new().unwrap();
         let ctx = crate::Context::full(&rt).unwrap();

--- a/core/src/value/array_buffer.rs
+++ b/core/src/value/array_buffer.rs
@@ -103,13 +103,17 @@ impl<'js> ArrayBuffer<'js> {
         }
 
         Ok(Self(Object(unsafe {
+            #[cfg(feature = "quickjs-og")]
+            let shared_flag = false as ::core::ffi::c_int;
+            #[cfg(not(feature = "quickjs-og"))]
+            let shared_flag = false;
             let val = qjs::JS_NewArrayBuffer(
                 ctx.as_ptr(),
                 ptr as _,
                 size as _,
                 Some(drop_raw::<T>),
                 capacity as _,
-                false,
+                shared_flag,
             );
             ctx.handle_exception(val).inspect_err(|_| {
                 // don't forget to free data when error occurred
@@ -207,13 +211,17 @@ impl<'js> ArrayBuffer<'js> {
         let opaque = Box::into_raw(Box::new(drop_fn)) as *mut c_void;
 
         Ok(Self(Object(unsafe {
+            #[cfg(feature = "quickjs-og")]
+            let shared_flag = is_shared as ::core::ffi::c_int;
+            #[cfg(not(feature = "quickjs-og"))]
+            let shared_flag = is_shared;
             let val = qjs::JS_NewArrayBuffer(
                 ctx.as_ptr(),
                 ptr,
                 len as _,
                 Some(shim::<F>),
                 opaque,
-                is_shared,
+                shared_flag,
             );
             if let Err(e) = ctx.handle_exception(val) {
                 shim::<F>(qjs::JS_GetRuntime(ctx.as_ptr()), opaque, ptr as *mut c_void);
@@ -552,6 +560,10 @@ mod test {
     }
 
     #[test]
+    #[cfg_attr(
+        feature = "quickjs-og",
+        ignore = "immutable ArrayBuffers are a quickjs-ng feature"
+    )]
     fn from_source_immutable_arc_slices() {
         struct ArcSlice {
             arc: Arc<Vec<u8>>,

--- a/core/src/value/module.rs
+++ b/core/src/value/module.rs
@@ -194,11 +194,49 @@ pub struct Declared;
 pub struct Evaluated;
 
 /// A JavaScript module.
-#[derive(Clone, Debug)]
+///
+/// # Reference counting
+///
+/// A `Module` owns exactly one reference count on the underlying `JSModuleDef`.
+/// `Clone` duplicates that reference and `Drop` releases it.
+///
+/// In quickjs-ng modules are not reference-counted-and-freed the way ordinary
+/// values are (`JS_FreeValue` on a module aborts there); modules are owned by
+/// the runtime and reconciled at teardown. Releasing the reference on drop is
+/// therefore only necessary — and only sound — for the `quickjs-og`
+/// flavor, whose GC treats a module like any other ref-counted object. Under
+/// quickjs-ng both `Clone` and `Drop` are no-ops with respect to the module
+/// reference, matching the engine's ownership model.
+#[derive(Debug)]
 pub struct Module<'js, T = Declared> {
     ptr: NonNull<qjs::JSModuleDef>,
     ctx: Ctx<'js>,
     _type_marker: PhantomData<T>,
+}
+
+impl<'js, T> Clone for Module<'js, T> {
+    fn clone(&self) -> Self {
+        #[cfg(feature = "quickjs-og")]
+        unsafe {
+            let v = qjs::JS_MKPTR(qjs::JS_TAG_MODULE, self.ptr.as_ptr().cast());
+            qjs::JS_DupValue(self.ctx.as_ptr(), v);
+        }
+        Module {
+            ptr: self.ptr,
+            ctx: self.ctx.clone(),
+            _type_marker: PhantomData,
+        }
+    }
+}
+
+impl<'js, T> Drop for Module<'js, T> {
+    fn drop(&mut self) {
+        #[cfg(feature = "quickjs-og")]
+        unsafe {
+            let v = qjs::JS_MKPTR(qjs::JS_TAG_MODULE, self.ptr.as_ptr().cast());
+            qjs::JS_FreeValue(self.ctx.as_ptr(), v);
+        }
+    }
 }
 
 impl<'js, T> Module<'js, T> {
@@ -206,7 +244,37 @@ impl<'js, T> Module<'js, T> {
         self.ptr.as_ptr()
     }
 
+    /// Wrap a module pointer, taking ownership of one existing reference count.
+    ///
+    /// # Safety
+    /// The caller must transfer ownership of exactly one reference count on
+    /// `ptr` to the returned `Module` (which releases it on drop).
     pub(crate) unsafe fn from_ptr(ctx: Ctx<'js>, ptr: NonNull<qjs::JSModuleDef>) -> Module<'js, T> {
+        Module {
+            ptr,
+            ctx,
+            _type_marker: PhantomData,
+        }
+    }
+
+    /// Wrap a runtime-owned module pointer (e.g. one created via
+    /// `JS_NewCModule`, which only holds the `loaded_modules` reference),
+    /// duplicating the reference so the returned `Module` owns exactly one.
+    ///
+    /// This preserves the invariant that every `Module` releases one reference
+    /// on drop.
+    ///
+    /// # Safety
+    /// `ptr` must point to a live module associated with `ctx`.
+    pub(crate) unsafe fn from_ptr_dup(
+        ctx: Ctx<'js>,
+        ptr: NonNull<qjs::JSModuleDef>,
+    ) -> Module<'js, T> {
+        #[cfg(feature = "quickjs-og")]
+        {
+            let v = qjs::JS_MKPTR(qjs::JS_TAG_MODULE, ptr.as_ptr().cast());
+            qjs::JS_DupValue(ctx.as_ptr(), v);
+        }
         Module {
             ptr,
             ctx,
@@ -224,7 +292,9 @@ impl<'js, T> Module<'js, T> {
         let ctx = Ctx::from_ptr(ctx);
         // Should never be null
         let ptr = NonNull::new(ptr).unwrap();
-        let module = unsafe { Module::from_ptr(ctx.clone(), ptr) };
+        // The engine owns this module; take our own reference via `from_ptr_dup`
+        // so the `Module`/`Exports` drop balances correctly.
+        let module = unsafe { Module::from_ptr_dup(ctx.clone(), ptr) };
         let exports = Exports(module);
         match D::evaluate(&ctx, &exports) {
             Ok(_) => 0,
@@ -287,7 +357,7 @@ impl<'js> Module<'js, Declared> {
         let ptr =
             unsafe { qjs::JS_NewCModule(ctx.as_ptr(), name.as_ptr(), Some(Self::eval_fn::<D>)) };
         let ptr = NonNull::new(ptr).ok_or(Error::Unknown)?;
-        let m = unsafe { Module::from_ptr(ctx, ptr) };
+        let m = unsafe { Module::from_ptr_dup(ctx, ptr) };
 
         let decl = Declarations(m);
         D::declare(&decl)?;
@@ -368,7 +438,9 @@ impl<'js> Module<'js, Declared> {
         let name = CString::new(name)?;
         let ptr = (load_fn)(ctx.as_ptr(), name.as_ptr().cast());
         let ptr = NonNull::new(ptr).ok_or(Error::Exception)?;
-        unsafe { Ok(Module::from_ptr(ctx, ptr)) }
+        // `load_fn` returns a runtime-owned (JS_NewCModule) module; take our own
+        // reference so the handle can release it on drop.
+        unsafe { Ok(Module::from_ptr_dup(ctx, ptr)) }
     }
 
     /// Evaluate the module.
@@ -380,17 +452,25 @@ impl<'js> Module<'js, Declared> {
             #[cfg(feature = "parallel")]
             qjs::JS_UpdateStackTop(qjs::JS_GetRuntime(self.ctx.as_ptr()));
 
-            // JS_EvalFunction `free's` the module so we should dup first
+            // `JS_EvalFunction` consumes one reference on the module, so dup
+            // first to keep the reference this handle owns intact.
             let v = qjs::JS_MKPTR(qjs::JS_TAG_MODULE, self.ptr.as_ptr().cast());
             qjs::JS_DupValue(self.ctx.as_ptr(), v);
             qjs::JS_EvalFunction(self.ctx.as_ptr(), v)
         };
         let ret = unsafe { self.ctx.handle_exception(ret)? };
         let promise = unsafe { Promise::from_js_value(self.ctx.clone(), ret) };
+
+        // Transfer this handle's owned reference to the returned `Evaluated`
+        // module without running `self`'s drop (which would release it) and
+        // without leaking `self`'s `Ctx`. Move the fields out by value.
+        let this = core::mem::ManuallyDrop::new(self);
+        let ptr = this.ptr;
+        let ctx = unsafe { core::ptr::read(&this.ctx) };
         Ok((
             Module {
-                ptr: self.ptr,
-                ctx: self.ctx,
+                ptr,
+                ctx,
                 _type_marker: PhantomData,
             },
             promise,
@@ -520,9 +600,14 @@ impl<'js, Evaluated> Module<'js, Evaluated> {
     ///
     /// This is always safe to do since calling eval again on an already evaluated module is safe.
     pub fn into_declared(self) -> Module<'js, Declared> {
+        // Transfer the owned reference to the returned handle without running
+        // `self`'s drop and without leaking `self`'s `Ctx`.
+        let this = core::mem::ManuallyDrop::new(self);
+        let ptr = this.ptr;
+        let ctx = unsafe { core::ptr::read(&this.ctx) };
         Module {
-            ptr: self.ptr,
-            ctx: self.ctx,
+            ptr,
+            ctx,
             _type_marker: PhantomData,
         }
     }

--- a/core/src/value/typed_array.rs
+++ b/core/src/value/typed_array.rs
@@ -329,6 +329,9 @@ impl<'js, T> IntoJs<'js> for TypedArray<'js, T> {
 
 impl<'js> Object<'js> {
     pub fn is_typed_array<T: TypedArrayItem>(&self) -> bool {
+        #[cfg(feature = "quickjs-og")]
+        let array_type = unsafe { qjs::JS_GetTypedArrayType(self.ctx.as_ptr(), self.value) };
+        #[cfg(not(feature = "quickjs-og"))]
         let array_type = unsafe { qjs::JS_GetTypedArrayType(self.value) };
         if array_type < 0 {
             return false;

--- a/examples/class-methods/Cargo.toml
+++ b/examples/class-methods/Cargo.toml
@@ -11,5 +11,7 @@ default-features = false
 features = []
 
 [features]
-default = ["macro"]
+default = ["macro", "quickjs-ng"]
 macro = ["rquickjs/macro"]
+quickjs-ng = ["rquickjs/quickjs-ng"]
+quickjs-og = ["rquickjs/quickjs-og", "rquickjs/bindgen"]

--- a/examples/exotic/Cargo.toml
+++ b/examples/exotic/Cargo.toml
@@ -7,4 +7,10 @@ publish = false
 
 [dependencies.rquickjs]
 path = "../.."
-features = ["macro"]
+default-features = false
+features = ["std", "macro"]
+
+[features]
+default = ["quickjs-ng"]
+quickjs-ng = ["rquickjs/quickjs-ng"]
+quickjs-og = ["rquickjs/quickjs-og", "rquickjs/bindgen"]

--- a/examples/import-attributes/Cargo.toml
+++ b/examples/import-attributes/Cargo.toml
@@ -9,3 +9,8 @@ publish = false
 path = "../.."
 default-features = false
 features = ["rust-alloc", "loader"]
+
+[features]
+default = ["quickjs-ng"]
+quickjs-ng = ["rquickjs/quickjs-ng"]
+quickjs-og = ["rquickjs/quickjs-og", "rquickjs/bindgen"]

--- a/examples/module-loader/Cargo.toml
+++ b/examples/module-loader/Cargo.toml
@@ -11,5 +11,7 @@ default-features = false
 features = ["futures", "rust-alloc", "loader", "dyn-load", "std"]
 
 [features]
-default = ["macro"]
+default = ["macro", "quickjs-ng"]
 macro = ["rquickjs/macro"]
+quickjs-ng = ["rquickjs/quickjs-ng"]
+quickjs-og = ["rquickjs/quickjs-og", "rquickjs/bindgen"]

--- a/examples/native-module/Cargo.toml
+++ b/examples/native-module/Cargo.toml
@@ -14,5 +14,7 @@ default-features = false
 features = ["futures", "rust-alloc", "std"]
 
 [features]
-default = ["macro"]
+default = ["macro", "quickjs-ng"]
 macro = ["rquickjs/macro"]
+quickjs-ng = ["rquickjs/quickjs-ng"]
+quickjs-og = ["rquickjs/quickjs-og", "rquickjs/bindgen"]

--- a/examples/rquickjs-cli/Cargo.toml
+++ b/examples/rquickjs-cli/Cargo.toml
@@ -7,3 +7,10 @@ publish = false
 
 [dependencies.rquickjs]
 path = "../.."
+default-features = false
+features = ["std"]
+
+[features]
+default = ["quickjs-ng"]
+quickjs-ng = ["rquickjs/quickjs-ng"]
+quickjs-og = ["rquickjs/quickjs-og", "rquickjs/bindgen"]

--- a/macro/Cargo.toml
+++ b/macro/Cargo.toml
@@ -27,10 +27,16 @@ phf_shared = { version = "0.14", optional = true }
 phf_generator = { version = "0.14", optional = true }
 
 [dev-dependencies]
-rquickjs = { path = "../", features = ["macro", "futures", "phf"] }
+rquickjs = { path = "../", default-features = false, features = ["macro", "futures", "phf"] }
 difference = "2"
 
 
 [features]
+default = ["quickjs-ng"]
 phf = ["phf_shared", "phf_generator"]
 bindgen = ["rquickjs-core/bindgen"]
+
+# Select which QuickJS C flavor to build against (mutually exclusive). Forwarded
+# to the `rquickjs-core` dependency and the `rquickjs` dev-dependency.
+quickjs-ng = ["rquickjs-core/quickjs-ng", "rquickjs/quickjs-ng"]
+quickjs-og = ["rquickjs-core/quickjs-og", "rquickjs/quickjs-og"]

--- a/sys/Cargo.toml
+++ b/sys/Cargo.toml
@@ -23,6 +23,16 @@ version = "0.5"
 optional = true
 
 [features]
+default = ["quickjs-ng"]
+
+# Select which QuickJS C flavor to build against.
+# These are mutually exclusive; exactly one must be enabled.
+#
+# `quickjs-ng` builds the quickjs-ng fork (sys/quickjs submodule).
+# `quickjs-og` builds Fabrice Bellard's original QuickJS (sys/quickjs-original submodule).
+quickjs-ng = []
+quickjs-og = []
+
 bindgen = ["bindgen-rs"]
 
 # Debug logging

--- a/sys/build.rs
+++ b/sys/build.rs
@@ -118,34 +118,38 @@ fn main() {
     }
     println!("cargo:rerun-if-env-changed=CARGO_CFG_SANITIZE");
 
-    let src_dir = Path::new("quickjs");
+    println!("cargo:rerun-if-changed=compat_original.c");
+    println!("cargo:rerun-if-changed=compat_original.h");
+    println!("cargo:rerun-if-changed=quickjs.bind.h");
+
+    let flavor = Flavor::resolve();
+    let src_dir = flavor.src_dir;
 
     let out_dir = env::var("OUT_DIR").expect("No OUT_DIR env var is set by cargo");
     let out_dir = Path::new(&out_dir);
 
-    let header_files = [
-        "builtin-array-fromasync.h",
-        "builtin-iterator-zip-keyed.h",
-        "builtin-iterator-zip.h",
-        "cutils.h",
-        "dtoa.h",
-        "libregexp-opcode.h",
-        "libregexp.h",
-        "libunicode-table.h",
-        "libunicode.h",
-        "list.h",
-        "quickjs-atom.h",
-        "quickjs-opcode.h",
-        "quickjs-c-atomics.h",
-        "quickjs.h",
-    ];
+    let header_files = flavor.headers;
+    let source_files = flavor.sources;
 
-    let source_files = ["libregexp.c", "libunicode.c", "quickjs.c", "dtoa.c"];
+    // The original QuickJS expects `CONFIG_VERSION` to be defined by the build
+    // system from its `VERSION` file (quickjs-ng defines its version in a
+    // header, so this is only needed for the `quickjs-og` flavor).
+    let config_version = if flavor.original {
+        let version = fs::read_to_string(src_dir.join("VERSION"))
+            .expect("Unable to read quickjs-original VERSION file");
+        Some(format!("\"{}\"", version.trim()))
+    } else {
+        None
+    };
 
     let mut defines: Vec<(String, Option<&str>)> = vec![("_GNU_SOURCE".into(), None)];
 
     #[cfg(feature = "disable-assertions")]
     defines.push(("NDEBUG".into(), None));
+
+    if let Some(config_version) = config_version.as_deref() {
+        defines.push(("CONFIG_VERSION".into(), Some(config_version)));
+    }
 
     let target_os = env::var("CARGO_CFG_TARGET_OS").unwrap();
     let target_env = env::var("CARGO_CFG_TARGET_ENV").unwrap();
@@ -208,6 +212,22 @@ fn main() {
     }
     fs::copy("quickjs.bind.h", out_dir.join("quickjs.bind.h")).expect("Unable to copy source");
 
+    // For the original flavor, compile a small compatibility shim that
+    // re-exports quickjs-ng-style helpers which the original only provides as
+    // `static inline` (and therefore aren't picked up by bindgen). The shim's
+    // declarations are appended to the bindgen header so Rust gets bindings.
+    if flavor.original {
+        fs::copy("compat_original.c", out_dir.join("compat_original.c"))
+            .expect("Unable to copy compat_original.c");
+        fs::copy("compat_original.h", out_dir.join("compat_original.h"))
+            .expect("Unable to copy compat_original.h");
+
+        let bind_header = out_dir.join("quickjs.bind.h");
+        let mut contents = fs::read_to_string(&bind_header).unwrap();
+        contents.push_str("\n#include \"compat_original.h\"\n");
+        fs::write(&bind_header, contents).unwrap();
+    }
+
     if target_os == "wasi" && !matches!(env::var("RQUICKJS_SYS_NO_WASI_SDK").as_deref(), Ok("1")) {
         let wasi_sdk_path = get_wasi_sdk_path();
         if !wasi_sdk_path.try_exists().unwrap() {
@@ -232,17 +252,104 @@ fn main() {
         out_dir.join("quickjs.bind.h"),
         &defines,
         bindgen_cflags,
+        flavor.original,
     );
 
     for (name, value) in &defines {
         builder.define(name, *value);
     }
 
-    for src in &source_files {
+    for src in source_files {
         builder.file(out_dir.join(src));
     }
 
+    if flavor.original {
+        builder.file(out_dir.join("compat_original.c"));
+    }
+
     builder.compile("libquickjs.a");
+}
+
+/// Returns the source directory of the selected QuickJS flavor.
+///
+/// The `quickjs-ng` and `quickjs-og` features are mutually exclusive;
+/// exactly one must be enabled.
+/// Everything that differs between the two QuickJS C flavors, resolved once.
+struct Flavor {
+    /// Whether this is the original (Bellard) flavor. `false` means quickjs-ng.
+    original: bool,
+    /// Submodule directory holding the C sources.
+    src_dir: &'static Path,
+    /// Header files to copy into `OUT_DIR`.
+    headers: &'static [&'static str],
+    /// Source files to compile.
+    sources: &'static [&'static str],
+}
+
+impl Flavor {
+    /// Resolve the selected flavor from cargo features.
+    ///
+    /// The invalid "both" / "neither" cases are reported to the user via
+    /// `compile_error!` in lib.rs (a friendlier diagnostic than a build-script
+    /// panic); if both are somehow enabled we default to quickjs-ng so the
+    /// build proceeds far enough to surface that error.
+    fn resolve() -> Self {
+        const NG_HEADERS: &[&str] = &[
+            "builtin-array-fromasync.h",
+            "builtin-iterator-zip-keyed.h",
+            "builtin-iterator-zip.h",
+            "cutils.h",
+            "dtoa.h",
+            "libregexp-opcode.h",
+            "libregexp.h",
+            "libunicode-table.h",
+            "libunicode.h",
+            "list.h",
+            "quickjs-atom.h",
+            "quickjs-opcode.h",
+            "quickjs-c-atomics.h",
+            "quickjs.h",
+        ];
+        const NG_SOURCES: &[&str] = &["libregexp.c", "libunicode.c", "quickjs.c", "dtoa.c"];
+
+        // The original lacks the `builtin-*` and `quickjs-c-atomics.h` headers
+        // and ships `cutils.c` as a separate translation unit.
+        const ORIG_HEADERS: &[&str] = &[
+            "cutils.h",
+            "dtoa.h",
+            "libregexp-opcode.h",
+            "libregexp.h",
+            "libunicode-table.h",
+            "libunicode.h",
+            "list.h",
+            "quickjs-atom.h",
+            "quickjs-opcode.h",
+            "quickjs.h",
+        ];
+        const ORIG_SOURCES: &[&str] = &[
+            "cutils.c",
+            "libregexp.c",
+            "libunicode.c",
+            "quickjs.c",
+            "dtoa.c",
+        ];
+
+        if cfg!(feature = "quickjs-og") && !cfg!(feature = "quickjs-ng") {
+            Flavor {
+                original: true,
+                src_dir: Path::new("quickjs-original"),
+                headers: ORIG_HEADERS,
+                sources: ORIG_SOURCES,
+            }
+        } else {
+            Flavor {
+                original: false,
+                src_dir: Path::new("quickjs"),
+                headers: NG_HEADERS,
+                sources: NG_SOURCES,
+            }
+        }
+    }
 }
 
 fn feature_to_cargo(name: impl AsRef<str>) -> String {
@@ -254,8 +361,13 @@ fn feature_to_define(name: impl AsRef<str>) -> String {
 }
 
 #[cfg(not(feature = "bindgen"))]
-fn bindgen<'a, D, H, X, K, V>(out_dir: D, _header_file: H, _defines: X, _add_cflags: Vec<String>)
-where
+fn bindgen<'a, D, H, X, K, V>(
+    out_dir: D,
+    _header_file: H,
+    _defines: X,
+    _add_cflags: Vec<String>,
+    _original: bool,
+) where
     D: AsRef<Path>,
     H: AsRef<Path>,
     X: IntoIterator<Item = &'a (K, Option<V>)>,
@@ -293,8 +405,13 @@ where
 }
 
 #[cfg(feature = "bindgen")]
-fn bindgen<'a, D, H, X, K, V>(out_dir: D, header_file: H, defines: X, add_cflags: Vec<String>)
-where
+fn bindgen<'a, D, H, X, K, V>(
+    out_dir: D,
+    header_file: H,
+    defines: X,
+    add_cflags: Vec<String>,
+    original: bool,
+) where
     D: AsRef<Path>,
     H: AsRef<Path>,
     X: IntoIterator<Item = &'a (K, Option<V>)>,
@@ -328,10 +445,30 @@ where
         .allowlist_function("js.*")
         .allowlist_function("JS.*")
         .allowlist_function("__JS.*")
+        .allowlist_function("rquickjs_compat_.*")
         .allowlist_var("JS.*")
         .opaque_type("FILE")
         .blocklist_type("FILE")
         .blocklist_function("JS_DumpMemoryUsage");
+
+    // For the original flavor, block the declarations whose signatures diverge
+    // from quickjs-ng; the compat shim re-exports normalized versions and the
+    // sys crate aliases them back to the quickjs-ng names.
+    if original {
+        for f in [
+            "JS_GetProperty",
+            "JS_SetProperty",
+            "JS_IsArray",
+            "JS_IsError",
+            "JS_IsFunction",
+            "JS_IsConstructor",
+            "JS_NewClassID",
+            "JS_HasException",
+            "JS_SetConstructorBit",
+        ] {
+            builder = builder.blocklist_function(f);
+        }
+    }
 
     if env::var("CARGO_CFG_TARGET_OS").unwrap() == "wasi" {
         builder = builder.clang_arg("-fvisibility=default");

--- a/sys/compat_original.c
+++ b/sys/compat_original.c
@@ -1,0 +1,325 @@
+/* Compatibility shim for the original (Fabrice Bellard) QuickJS.
+ *
+ * quickjs-ng exports a number of helpers as real (non-inline) functions that
+ * the original QuickJS either provides only as `static inline`, or does not
+ * provide at all but which can be emulated from the public API.
+ *
+ * bindgen does not emit bindings for `static inline` functions, so this file
+ * re-exports/emulates the helpers under stable names so rquickjs-core can call
+ * them uniformly across flavors.
+ *
+ * Compiled only for the `quickjs-original` flavor.
+ *
+ * NOTE: A handful of quickjs-ng APIs have no equivalent in the original and
+ * cannot be emulated here (Proxy target/handler introspection, promise hooks).
+ * Those are `#[cfg]`-gated out of rquickjs-core for the `quickjs-original`
+ * flavor instead.
+ */
+#include "quickjs.h"
+#include <string.h>
+
+/* ---- static-inline helpers re-exported as real symbols ---- */
+
+JSValue rquickjs_compat_JS_GetProperty(JSContext *ctx, JSValueConst this_obj, JSAtom prop) {
+    return JS_GetProperty(ctx, this_obj, prop);
+}
+
+int rquickjs_compat_JS_SetProperty(JSContext *ctx, JSValueConst this_obj, JSAtom prop, JSValue val) {
+    return JS_SetProperty(ctx, this_obj, prop, val);
+}
+
+void rquickjs_compat_JS_FreeValue(JSContext *ctx, JSValue v) {
+    JS_FreeValue(ctx, v);
+}
+
+void rquickjs_compat_JS_FreeValueRT(JSRuntime *rt, JSValue v) {
+    JS_FreeValueRT(rt, v);
+}
+
+JSValue rquickjs_compat_JS_DupValue(JSContext *ctx, JSValueConst v) {
+    return JS_DupValue(ctx, v);
+}
+
+JSValue rquickjs_compat_JS_DupValueRT(JSRuntime *rt, JSValueConst v) {
+    return JS_DupValueRT(rt, v);
+}
+
+/* ---- emulated helpers ---- */
+
+/* `Function.prototype`, fetched via the global object. */
+JSValue rquickjs_compat_JS_GetFunctionProto(JSContext *ctx) {
+    JSValue global = JS_GetGlobalObject(ctx);
+    if (JS_IsException(global))
+        return global;
+    JSValue func_ctor = JS_GetPropertyStr(ctx, global, "Function");
+    JS_FreeValue(ctx, global);
+    if (JS_IsException(func_ctor))
+        return func_ctor;
+    JSValue proto = JS_GetPropertyStr(ctx, func_ctor, "prototype");
+    JS_FreeValue(ctx, func_ctor);
+    return proto;
+}
+
+/* `Symbol(description)` / `Symbol.for(description)`. */
+JSValue rquickjs_compat_JS_NewSymbol(JSContext *ctx, const char *description, JS_BOOL is_global) {
+    JSValue global = JS_GetGlobalObject(ctx);
+    if (JS_IsException(global))
+        return global;
+    JSValue symbol_ctor = JS_GetPropertyStr(ctx, global, "Symbol");
+    JS_FreeValue(ctx, global);
+    if (JS_IsException(symbol_ctor))
+        return symbol_ctor;
+
+    JSValue arg = description ? JS_NewString(ctx, description) : JS_UNDEFINED;
+    JSValue result;
+    if (is_global) {
+        JSValue for_fn = JS_GetPropertyStr(ctx, symbol_ctor, "for");
+        if (JS_IsException(for_fn)) {
+            JS_FreeValue(ctx, arg);
+            JS_FreeValue(ctx, symbol_ctor);
+            return for_fn;
+        }
+        result = JS_Call(ctx, for_fn, symbol_ctor, 1, (JSValueConst *)&arg);
+        JS_FreeValue(ctx, for_fn);
+    } else {
+        int argc = description ? 1 : 0;
+        result = JS_Call(ctx, symbol_ctor, JS_UNDEFINED, argc, (JSValueConst *)&arg);
+    }
+    JS_FreeValue(ctx, arg);
+    JS_FreeValue(ctx, symbol_ctor);
+    return result;
+}
+
+/* Create a Proxy via the global `Proxy` constructor. */
+JSValue rquickjs_compat_JS_NewProxy(JSContext *ctx, JSValueConst target, JSValueConst handler) {
+    JSValue global = JS_GetGlobalObject(ctx);
+    if (JS_IsException(global))
+        return global;
+    JSValue proxy_ctor = JS_GetPropertyStr(ctx, global, "Proxy");
+    JS_FreeValue(ctx, global);
+    if (JS_IsException(proxy_ctor))
+        return proxy_ctor;
+    JSValueConst args[2] = { target, handler };
+    JSValue result = JS_CallConstructor(ctx, proxy_ctor, 2, args);
+    JS_FreeValue(ctx, proxy_ctor);
+    return result;
+}
+
+/* ---- Proxy introspection ----
+ *
+ * The original QuickJS keeps Proxy internals private (no JS_GetProxyTarget /
+ * JS_GetProxyHandler / JS_IsProxy in quickjs.h), but the target and handler are
+ * stored in the object's opaque data as a `JSProxyData`, reachable through the
+ * public `JS_GetOpaque(obj, JS_CLASS_PROXY)`.
+ *
+ * `JS_CLASS_PROXY` is an internal, build-stable enum value that is not exported.
+ * Rather than hardcode it, we discover it at runtime: construct a throwaway
+ * Proxy and read its class id via the public `JS_GetClassID`. The result is
+ * cached per runtime.
+ *
+ * This mirrors the layout of `JSProxyData` in quickjs.c. It is validated at
+ * runtime (see below) so a layout change in a future QuickJS would be caught
+ * rather than silently returning garbage.
+ */
+typedef struct RQuickJSProxyData {
+    JSValue target;
+    JSValue handler;
+    uint8_t is_func;
+    uint8_t is_revoked;
+} RQuickJSProxyData;
+
+/* Discovered proxy support state, resolved once per process.
+ *
+ * A single process only ever links one QuickJS build and built-in class ids are
+ * stable for a given build, so a static cache is safe. */
+static JSClassID rquickjs_proxy_class_id = 0; /* 0 = not yet resolved / unavailable */
+static int rquickjs_proxy_layout_ok = 0;      /* 1 once the JSProxyData layout is validated */
+static int rquickjs_proxy_resolved = 0;       /* 1 once discovery has run */
+
+/* Discover the JS_CLASS_PROXY class id and validate that our `RQuickJSProxyData`
+ * mirror matches the engine's actual layout, by constructing a proxy with a
+ * distinctive target/handler and reading them back through the opaque pointer.
+ *
+ * If the layout does not round-trip (e.g. a future QuickJS reordered the
+ * struct), we leave `rquickjs_proxy_layout_ok == 0` so the accessors error out
+ * cleanly instead of returning garbage. */
+static void rquickjs_compat_resolve_proxy(JSContext *ctx) {
+    if (rquickjs_proxy_resolved)
+        return;
+    rquickjs_proxy_resolved = 1;
+
+    JSValue target = JS_NewObject(ctx);
+    JSValue handler = JS_NewObject(ctx);
+    if (JS_IsException(target) || JS_IsException(handler)) {
+        JS_FreeValue(ctx, target);
+        JS_FreeValue(ctx, handler);
+        return;
+    }
+    /* Tag target and handler with unique marker properties so we can confirm we
+     * read the right fields in the right order. */
+    JS_SetPropertyStr(ctx, target, "__rq_marker", JS_NewInt32(ctx, 0x7a11e5));
+    JS_SetPropertyStr(ctx, handler, "__rq_marker", JS_NewInt32(ctx, 0x0dd));
+
+    JSValue proxy = rquickjs_compat_JS_NewProxy(ctx, target, handler);
+    if (JS_IsException(proxy)) {
+        JS_FreeValue(ctx, JS_GetException(ctx));
+        JS_FreeValue(ctx, target);
+        JS_FreeValue(ctx, handler);
+        return;
+    }
+
+    JSClassID id = JS_GetClassID(proxy);
+    int ok = 0;
+    if (id != 0) {
+        RQuickJSProxyData *s = JS_GetOpaque(proxy, id);
+        if (s) {
+            JSValue t_marker = JS_GetPropertyStr(ctx, s->target, "__rq_marker");
+            JSValue h_marker = JS_GetPropertyStr(ctx, s->handler, "__rq_marker");
+            int32_t tv = -1, hv = -1;
+            JS_ToInt32(ctx, &tv, t_marker);
+            JS_ToInt32(ctx, &hv, h_marker);
+            JS_FreeValue(ctx, t_marker);
+            JS_FreeValue(ctx, h_marker);
+            ok = (tv == 0x7a11e5) && (hv == 0x0dd);
+        }
+    }
+
+    JS_FreeValue(ctx, proxy);
+    JS_FreeValue(ctx, target);
+    JS_FreeValue(ctx, handler);
+
+    rquickjs_proxy_class_id = id;
+    rquickjs_proxy_layout_ok = ok;
+}
+
+JS_BOOL rquickjs_compat_JS_IsProxy(JSContext *ctx, JSValueConst val) {
+    rquickjs_compat_resolve_proxy(ctx);
+    /* Class-id detection does not depend on the struct layout, so it is safe
+     * even if layout validation failed. */
+    if (rquickjs_proxy_class_id == 0)
+        return 0;
+    return JS_GetClassID(val) == rquickjs_proxy_class_id;
+}
+
+JSValue rquickjs_compat_JS_GetProxyTarget(JSContext *ctx, JSValueConst proxy) {
+    rquickjs_compat_resolve_proxy(ctx);
+    if (!rquickjs_proxy_layout_ok)
+        return JS_ThrowTypeError(
+            ctx, "Proxy target introspection is unavailable in this QuickJS build");
+    /* JS_GetOpaque returns NULL if the class id does not match. */
+    RQuickJSProxyData *s = JS_GetOpaque(proxy, rquickjs_proxy_class_id);
+    if (!s)
+        return JS_ThrowTypeError(ctx, "not a Proxy");
+    return JS_DupValue(ctx, s->target);
+}
+
+JSValue rquickjs_compat_JS_GetProxyHandler(JSContext *ctx, JSValueConst proxy) {
+    rquickjs_compat_resolve_proxy(ctx);
+    if (!rquickjs_proxy_layout_ok)
+        return JS_ThrowTypeError(
+            ctx, "Proxy handler introspection is unavailable in this QuickJS build");
+    RQuickJSProxyData *s = JS_GetOpaque(proxy, rquickjs_proxy_class_id);
+    if (!s)
+        return JS_ThrowTypeError(ctx, "not a Proxy");
+    return JS_DupValue(ctx, s->handler);
+}
+
+/* Determine the typed-array element type by inspecting the constructor name.
+ * Mirrors quickjs-ng's `JS_GetTypedArrayType` return values; returns -1 if the
+ * value is not a typed array. */
+int rquickjs_compat_JS_GetTypedArrayType(JSContext *ctx, JSValueConst obj) {
+    JSValue ctor = JS_GetPropertyStr(ctx, obj, "constructor");
+    if (JS_IsException(ctor)) {
+        JS_FreeValue(ctx, JS_GetException(ctx));
+        return -1;
+    }
+    JSValue name_val = JS_GetPropertyStr(ctx, ctor, "name");
+    JS_FreeValue(ctx, ctor);
+    if (JS_IsException(name_val)) {
+        JS_FreeValue(ctx, JS_GetException(ctx));
+        return -1;
+    }
+    const char *name = JS_ToCString(ctx, name_val);
+    JS_FreeValue(ctx, name_val);
+    if (!name)
+        return -1;
+
+    int type = -1;
+    if (!strcmp(name, "Uint8ClampedArray")) type = JS_TYPED_ARRAY_UINT8C;
+    else if (!strcmp(name, "Int8Array")) type = JS_TYPED_ARRAY_INT8;
+    else if (!strcmp(name, "Uint8Array")) type = JS_TYPED_ARRAY_UINT8;
+    else if (!strcmp(name, "Int16Array")) type = JS_TYPED_ARRAY_INT16;
+    else if (!strcmp(name, "Uint16Array")) type = JS_TYPED_ARRAY_UINT16;
+    else if (!strcmp(name, "Int32Array")) type = JS_TYPED_ARRAY_INT32;
+    else if (!strcmp(name, "Uint32Array")) type = JS_TYPED_ARRAY_UINT32;
+    else if (!strcmp(name, "BigInt64Array")) type = JS_TYPED_ARRAY_BIG_INT64;
+    else if (!strcmp(name, "BigUint64Array")) type = JS_TYPED_ARRAY_BIG_UINT64;
+    else if (!strcmp(name, "Float16Array")) type = JS_TYPED_ARRAY_FLOAT16;
+    else if (!strcmp(name, "Float32Array")) type = JS_TYPED_ARRAY_FLOAT32;
+    else if (!strcmp(name, "Float64Array")) type = JS_TYPED_ARRAY_FLOAT64;
+
+    JS_FreeCString(ctx, name);
+    return type;
+}
+
+/* The original does not track "uncatchable" errors separately. */
+JS_BOOL rquickjs_compat_JS_IsUncatchableError(JSContext *ctx, JSValueConst val) {
+    (void)ctx;
+    (void)val;
+    return 0;
+}
+
+/* Immutable ArrayBuffers are a quickjs-ng feature; treat as unsupported no-op. */
+int rquickjs_compat_JS_SetImmutableArrayBuffer(JSValueConst obj, JS_BOOL immutable) {
+    (void)obj;
+    (void)immutable;
+    return -1;
+}
+
+/* quickjs-ng runtime dump flags / performance hooks have no original
+ * equivalent; provide no-op stubs so runtime setup can proceed uniformly. */
+void rquickjs_compat_JS_SetDumpFlags(JSRuntime *rt, uint64_t flags) {
+    (void)rt;
+    (void)flags;
+}
+
+int rquickjs_compat_JS_AddPerformance(JSContext *ctx) {
+    (void)ctx;
+    return 0;
+}
+
+/* ---- signature-normalizing wrappers ----
+ *
+ * The original returns `int` (and sometimes takes a context) for several
+ * predicates that quickjs-ng exposes as `bool`-returning (and context-less).
+ * Re-export them with quickjs-ng-compatible signatures so rquickjs-core links
+ * uniformly. bindgen is told to blocklist the original declarations. */
+
+JS_BOOL rquickjs_compat_JS_IsArray(JSContext *ctx, JSValueConst val) {
+    return JS_IsArray(ctx, val) != 0;
+}
+
+JS_BOOL rquickjs_compat_JS_IsError(JSContext *ctx, JSValueConst val) {
+    return JS_IsError(ctx, val) != 0;
+}
+
+JS_BOOL rquickjs_compat_JS_IsFunction(JSContext *ctx, JSValueConst val) {
+    return JS_IsFunction(ctx, val) != 0;
+}
+
+JS_BOOL rquickjs_compat_JS_IsConstructor(JSContext *ctx, JSValueConst val) {
+    return JS_IsConstructor(ctx, val) != 0;
+}
+
+JSClassID rquickjs_compat_JS_NewClassID(JSRuntime *rt, JSClassID *pclass_id) {
+    (void)rt;
+    return JS_NewClassID(pclass_id);
+}
+
+JS_BOOL rquickjs_compat_JS_HasException(JSContext *ctx) {
+    return JS_HasException(ctx) != 0;
+}
+
+JS_BOOL rquickjs_compat_JS_SetConstructorBit(JSContext *ctx, JSValueConst func_obj, JS_BOOL val) {
+    return JS_SetConstructorBit(ctx, func_obj, val) != 0;
+}

--- a/sys/compat_original.h
+++ b/sys/compat_original.h
@@ -1,0 +1,39 @@
+/* Declarations for the original-flavor compatibility shim (see
+ * compat_original.c). Included by quickjs.bind.h only for the
+ * `quickjs-original` flavor. */
+#ifndef RQUICKJS_COMPAT_ORIGINAL_H
+#define RQUICKJS_COMPAT_ORIGINAL_H
+
+#include "quickjs.h"
+
+/* static-inline helpers re-exported as real symbols */
+JSValue rquickjs_compat_JS_GetProperty(JSContext *ctx, JSValueConst this_obj, JSAtom prop);
+int rquickjs_compat_JS_SetProperty(JSContext *ctx, JSValueConst this_obj, JSAtom prop, JSValue val);
+void rquickjs_compat_JS_FreeValue(JSContext *ctx, JSValue v);
+void rquickjs_compat_JS_FreeValueRT(JSRuntime *rt, JSValue v);
+JSValue rquickjs_compat_JS_DupValue(JSContext *ctx, JSValueConst v);
+JSValue rquickjs_compat_JS_DupValueRT(JSRuntime *rt, JSValueConst v);
+
+/* emulated helpers */
+JSValue rquickjs_compat_JS_GetFunctionProto(JSContext *ctx);
+JSValue rquickjs_compat_JS_NewSymbol(JSContext *ctx, const char *description, JS_BOOL is_global);
+JSValue rquickjs_compat_JS_NewProxy(JSContext *ctx, JSValueConst target, JSValueConst handler);
+JS_BOOL rquickjs_compat_JS_IsProxy(JSContext *ctx, JSValueConst val);
+JSValue rquickjs_compat_JS_GetProxyTarget(JSContext *ctx, JSValueConst proxy);
+JSValue rquickjs_compat_JS_GetProxyHandler(JSContext *ctx, JSValueConst proxy);
+int rquickjs_compat_JS_GetTypedArrayType(JSContext *ctx, JSValueConst obj);
+JS_BOOL rquickjs_compat_JS_IsUncatchableError(JSContext *ctx, JSValueConst val);
+int rquickjs_compat_JS_SetImmutableArrayBuffer(JSValueConst obj, JS_BOOL immutable);
+void rquickjs_compat_JS_SetDumpFlags(JSRuntime *rt, uint64_t flags);
+int rquickjs_compat_JS_AddPerformance(JSContext *ctx);
+
+/* signature-normalizing wrappers */
+JS_BOOL rquickjs_compat_JS_IsArray(JSContext *ctx, JSValueConst val);
+JS_BOOL rquickjs_compat_JS_IsError(JSContext *ctx, JSValueConst val);
+JS_BOOL rquickjs_compat_JS_IsFunction(JSContext *ctx, JSValueConst val);
+JS_BOOL rquickjs_compat_JS_IsConstructor(JSContext *ctx, JSValueConst val);
+JSClassID rquickjs_compat_JS_NewClassID(JSRuntime *rt, JSClassID *pclass_id);
+JS_BOOL rquickjs_compat_JS_HasException(JSContext *ctx);
+JS_BOOL rquickjs_compat_JS_SetConstructorBit(JSContext *ctx, JSValueConst func_obj, JS_BOOL val);
+
+#endif /* RQUICKJS_COMPAT_ORIGINAL_H */

--- a/sys/src/inlines/compat_original.rs
+++ b/sys/src/inlines/compat_original.rs
@@ -1,0 +1,158 @@
+// Aliases mapping quickjs-ng-style helper names onto the original-flavor
+// compatibility shim (see compat_original.c / compat_original.h).
+//
+// The original QuickJS provides some helpers only as `static inline`, and
+// others not at all (but emulatable from the public API). The shim exposes them
+// under `rquickjs_compat_*` names; here we alias them back to the names
+// quickjs-ng uses so that rquickjs-core can call them uniformly.
+
+#[inline]
+pub unsafe fn JS_GetProperty(ctx: *mut JSContext, this_obj: JSValue, prop: JSAtom) -> JSValue {
+    rquickjs_compat_JS_GetProperty(ctx, this_obj, prop)
+}
+
+#[inline]
+pub unsafe fn JS_SetProperty(
+    ctx: *mut JSContext,
+    this_obj: JSValue,
+    prop: JSAtom,
+    val: JSValue,
+) -> ::core::ffi::c_int {
+    rquickjs_compat_JS_SetProperty(ctx, this_obj, prop, val)
+}
+
+#[inline]
+pub unsafe fn JS_FreeValue(ctx: *mut JSContext, v: JSValue) {
+    rquickjs_compat_JS_FreeValue(ctx, v)
+}
+
+#[inline]
+pub unsafe fn JS_FreeValueRT(rt: *mut JSRuntime, v: JSValue) {
+    rquickjs_compat_JS_FreeValueRT(rt, v)
+}
+
+#[inline]
+pub unsafe fn JS_DupValue(ctx: *mut JSContext, v: JSValue) -> JSValue {
+    rquickjs_compat_JS_DupValue(ctx, v)
+}
+
+#[inline]
+pub unsafe fn JS_DupValueRT(rt: *mut JSRuntime, v: JSValue) -> JSValue {
+    rquickjs_compat_JS_DupValueRT(rt, v)
+}
+
+#[inline]
+pub unsafe fn JS_GetFunctionProto(ctx: *mut JSContext) -> JSValue {
+    rquickjs_compat_JS_GetFunctionProto(ctx)
+}
+
+#[inline]
+pub unsafe fn JS_NewSymbol(
+    ctx: *mut JSContext,
+    description: *const ::core::ffi::c_char,
+    is_global: bool,
+) -> JSValue {
+    rquickjs_compat_JS_NewSymbol(ctx, description, is_global as _)
+}
+
+#[inline]
+pub unsafe fn JS_NewProxy(ctx: *mut JSContext, target: JSValue, handler: JSValue) -> JSValue {
+    rquickjs_compat_JS_NewProxy(ctx, target, handler)
+}
+
+#[inline]
+pub unsafe fn JS_IsProxy(ctx: *mut JSContext, val: JSValue) -> bool {
+    rquickjs_compat_JS_IsProxy(ctx, val) != 0
+}
+
+#[inline]
+pub unsafe fn JS_GetProxyTarget(ctx: *mut JSContext, proxy: JSValue) -> JSValue {
+    rquickjs_compat_JS_GetProxyTarget(ctx, proxy)
+}
+
+#[inline]
+pub unsafe fn JS_GetProxyHandler(ctx: *mut JSContext, proxy: JSValue) -> JSValue {
+    rquickjs_compat_JS_GetProxyHandler(ctx, proxy)
+}
+
+#[inline]
+pub unsafe fn JS_SetDumpFlags(rt: *mut JSRuntime, flags: u64) {
+    rquickjs_compat_JS_SetDumpFlags(rt, flags)
+}
+
+#[inline]
+pub unsafe fn JS_AddPerformance(ctx: *mut JSContext) -> ::core::ffi::c_int {
+    rquickjs_compat_JS_AddPerformance(ctx)
+}
+
+/// Emulated typed-array-type query for the original flavor.
+///
+/// Unlike quickjs-ng's `JS_GetTypedArrayType` (which takes only the value), the
+/// original has no public class-id API, so the emulation requires a context.
+#[inline]
+pub unsafe fn JS_GetTypedArrayType(ctx: *mut JSContext, obj: JSValue) -> ::core::ffi::c_int {
+    rquickjs_compat_JS_GetTypedArrayType(ctx, obj)
+}
+
+/// Emulated uncatchable-error query for the original flavor (always `false`).
+#[inline]
+pub unsafe fn JS_IsUncatchableError(ctx: *mut JSContext, val: JSValue) -> bool {
+    rquickjs_compat_JS_IsUncatchableError(ctx, val) != 0
+}
+
+/// Emulated immutable-array-buffer setter for the original flavor
+/// (unsupported; returns an error code).
+#[inline]
+pub unsafe fn JS_SetImmutableArrayBuffer(obj: JSValue, immutable: bool) -> ::core::ffi::c_int {
+    rquickjs_compat_JS_SetImmutableArrayBuffer(obj, immutable as _)
+}
+
+// ---- signature-normalizing aliases ----
+//
+// The original returns `int` (and `JS_IsArray`/`JS_IsError` take a context)
+// where quickjs-ng returns `bool`; `JS_NewClassID` takes an extra runtime
+// argument. These aliases present the quickjs-ng-compatible surface.
+
+#[inline]
+pub unsafe fn JS_IsArray(ctx: *mut JSContext, val: JSValue) -> bool {
+    rquickjs_compat_JS_IsArray(ctx, val) != 0
+}
+
+#[inline]
+pub unsafe fn JS_IsError(ctx: *mut JSContext, val: JSValue) -> bool {
+    rquickjs_compat_JS_IsError(ctx, val) != 0
+}
+
+#[inline]
+pub unsafe fn JS_IsFunction(ctx: *mut JSContext, val: JSValue) -> bool {
+    rquickjs_compat_JS_IsFunction(ctx, val) != 0
+}
+
+#[inline]
+pub unsafe fn JS_IsConstructor(ctx: *mut JSContext, val: JSValue) -> bool {
+    rquickjs_compat_JS_IsConstructor(ctx, val) != 0
+}
+
+#[inline]
+pub unsafe fn JS_NewClassID(rt: *mut JSRuntime, pclass_id: *mut JSClassID) -> JSClassID {
+    rquickjs_compat_JS_NewClassID(rt, pclass_id)
+}
+
+#[inline]
+pub unsafe fn JS_HasException(ctx: *mut JSContext) -> bool {
+    rquickjs_compat_JS_HasException(ctx) != 0
+}
+
+#[inline]
+pub unsafe fn JS_SetConstructorBit(
+    ctx: *mut JSContext,
+    func_obj: JSValue,
+    val: bool,
+) -> bool {
+    rquickjs_compat_JS_SetConstructorBit(ctx, func_obj, val as _) != 0
+}
+
+// The original QuickJS has no bytecode source/debug stripping flags; define
+// them as no-op (0) so `Module::write` options compile uniformly.
+pub const JS_WRITE_OBJ_STRIP_SOURCE: u32 = 0;
+pub const JS_WRITE_OBJ_STRIP_DEBUG: u32 = 0;

--- a/sys/src/inlines/ptr_64_original.rs
+++ b/sys/src/inlines/ptr_64_original.rs
@@ -1,0 +1,84 @@
+// Inline helpers for the original (Fabrice Bellard) QuickJS on 64-bit targets.
+//
+// The original QuickJS uses a `JSValueUnion` whose integer payload is stored in
+// a `uint64` field (unlike quickjs-ng which uses an `int32` field), so the
+// accessors below differ from `ptr_64.rs`.
+
+#[inline]
+pub unsafe fn JS_VALUE_GET_TAG(v: JSValue) -> i32 {
+    v.tag as _
+}
+
+#[inline]
+pub unsafe fn JS_VALUE_GET_NORM_TAG(v: JSValue) -> i32 {
+    JS_VALUE_GET_TAG(v)
+}
+
+#[inline]
+pub unsafe fn JS_VALUE_GET_INT(v: JSValue) -> i32 {
+    v.u.uint64 as i32
+}
+
+#[inline]
+pub unsafe fn JS_VALUE_GET_BOOL(v: JSValue) -> bool {
+    (v.u.uint64 as i32) != 0
+}
+
+#[inline]
+pub unsafe fn JS_VALUE_GET_FLOAT64(v: JSValue) -> f64 {
+    v.u.float64
+}
+
+#[inline]
+pub unsafe fn JS_VALUE_GET_PTR(v: JSValue) -> *mut c_void {
+    v.u.ptr
+}
+
+#[inline]
+pub const fn JS_MKVAL(tag: i32, val: i32) -> JSValue {
+    JSValue {
+        u: JSValueUnion {
+            uint64: val as u32 as u64,
+        },
+        tag: tag as _,
+    }
+}
+
+#[inline]
+pub fn JS_MKPTR(tag: i32, ptr: *mut c_void) -> JSValue {
+    JSValue {
+        u: JSValueUnion { ptr },
+        tag: tag as _,
+    }
+}
+
+#[inline]
+pub unsafe fn JS_TAG_IS_FLOAT64(tag: i32) -> bool {
+    tag == JS_TAG_FLOAT64
+}
+
+pub const JS_NAN: JSValue = JSValue {
+    tag: JS_TAG_FLOAT64 as _,
+    u: JSValueUnion { float64: f64::NAN },
+};
+
+#[inline]
+pub fn __JS_NewFloat64(d: f64) -> JSValue {
+    JSValue {
+        tag: JS_TAG_FLOAT64 as _,
+        u: JSValueUnion { float64: d },
+    }
+}
+
+#[inline]
+pub unsafe fn JS_VALUE_IS_NAN(v: JSValue) -> bool {
+    union U {
+        d: f64,
+        u: u64,
+    }
+    if v.tag != JS_TAG_FLOAT64 as _ {
+        return false;
+    }
+    let u = U { d: v.u.float64 };
+    (u.u & 0x7fffffffffffffff) > 0x7ff0000000000000
+}

--- a/sys/src/lib.rs
+++ b/sys/src/lib.rs
@@ -15,13 +15,48 @@ pub const SIZE_T_ERROR: &str =
 
 include!(concat!(env!("OUT_DIR"), "/bindings.rs"));
 
-#[cfg(not(feature = "bindgen"))]
+// The two QuickJS flavors are mutually exclusive because the engines have
+// divergent ABIs and APIs. Enabling both is an error. Enabling neither falls
+// back to quickjs-ng: this keeps flavor selection ergonomic (quickjs-ng is the
+// implicit default) and lets tooling that builds against `rquickjs` with
+// `default-features = false` — e.g. trybuild's generated crates — still resolve
+// a flavor without every consumer having to re-declare one.
+#[cfg(all(feature = "quickjs-ng", feature = "quickjs-og"))]
+compile_error!("features `quickjs-ng` and `quickjs-og` are mutually exclusive; enable only one");
+
+// Pre-generated (bundled) bindings are only shipped for the quickjs-ng flavor.
+// When building against the original QuickJS the `bindgen` feature is required
+// so the bindings match the selected C sources.
+#[cfg(all(feature = "quickjs-og", not(feature = "bindgen")))]
+compile_error!(
+    "the `quickjs-og` flavor requires the `bindgen` feature; \
+     bundled bindings are only provided for `quickjs-ng`"
+);
+
+#[cfg(all(not(feature = "bindgen"), not(feature = "quickjs-og")))]
 include!(concat!("bindings/", bindings_env!("TARGET"), ".rs"));
 
-#[cfg(target_pointer_width = "64")]
+// The flavor-specific inline helpers are gated so that when both flavors are
+// (invalidly) enabled, neither set is pulled in and the `compile_error!` above
+// is the only diagnostic the user sees, rather than a wall of duplicate-symbol
+// errors.
+#[cfg(all(
+    target_pointer_width = "64",
+    not(all(feature = "quickjs-og", not(feature = "quickjs-ng")))
+))]
 include!("inlines/ptr_64.rs");
+
+#[cfg(all(
+    target_pointer_width = "64",
+    feature = "quickjs-og",
+    not(feature = "quickjs-ng")
+))]
+include!("inlines/ptr_64_original.rs");
 
 #[cfg(target_pointer_width = "32")]
 include!("inlines/ptr_32_nan_boxing.rs");
 
 include!("inlines/common.rs");
+
+#[cfg(all(feature = "quickjs-og", not(feature = "quickjs-ng")))]
+include!("inlines/compat_original.rs");


### PR DESCRIPTION
## Summary

Adds support for building against either QuickJS flavor, selected via mutually-exclusive features:

- `quickjs-ng` (default) — the [quickjs-ng](https://github.com/quickjs-ng/quickjs) fork
- `quickjs-og` — Fabrice Bellard's original [QuickJS](https://github.com/bellard/quickjs)

`quickjs-ng` is the implicit default; enabling both at once is a `compile_error!`.

## Changes

**Build / sys**
- New `bellard/quickjs` submodule at `sys/quickjs-original` alongside the existing quickjs-ng submodule.
- `build.rs` resolves the flavor once (a `Flavor` struct) and derives the source dir, file list, and defines from it (including the original's `CONFIG_VERSION`.
- C compatibility shim () for the original flavor: re-exports helpers it only ships as , emulates a few quickjs-ng-only helpers (, ,  constructor, typed-array type), and normalizes signatures that differ ( vs ,  arity, etc.).
- Proxy introspection (//) recovered on the original via  with a **runtime-validated**  layout, so it fails safe if the struct ever changes.
- Flavor-specific Rust inlines for the original's  layout.

**Core**
- Fix a latent  refcount leak:  now owns exactly one module reference with proper / (a no-op under quickjs-ng, which does not ref-count-free modules). Exposed only because the original's stricter GC teardown asserts on it.
- Fix  for the original's unsigned  (the old  was always true there).
- Flavor-gated v1 module normalizer for the original loader ( doesn't exist there).

**Workspace / CI**
- Flavor features propagate through , , and all examples, so the whole workspace is flavor-switchable.
- CI runs clippy and the full workspace test suite for **both flavors in parallel**.

## Testing

- : full workspace suite passes (unchanged behavior).
- : full workspace suite passes; 2 tests d under this flavor for genuine, documented engine differences (immutable ArrayBuffer is quickjs-ng-only;  is an inline short-bigint on 64-bit original so there's no allocation to fail; and a GC test that asserts quickjs-ng's auto-GC threshold — verified as an engine difference, not a leak).
- fmt clean; clippy clean for both flavors apart from pre-existing bindgen-generated  warnings.
- Verified: default build, both-flavors-enabled , and example builds.
EOF
)