### PR TITLE
Fix rquickjs-sys host build failing when cross-compiling to Android

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fixed `rquickjs-sys` host build failing during cross-compilation by reusing bundled bindings for the host target instead of running bindgen with a mismatched `libclang` #[709](https://github.com/DelSkayn/rquickjs/issues/709)
+
 ### Security
 
 ## [0.12.1] - 2026-06-29

--- a/sys/build.rs
+++ b/sys/build.rs
@@ -304,6 +304,28 @@ where
     let out_dir = out_dir.as_ref();
     let header_file = header_file.as_ref();
 
+    let target = env::var("TARGET").unwrap();
+    let host = env::var("HOST").unwrap();
+
+    // When cross-compiling with the `macro` feature, sys also gets built for the host.
+    // If LIBCLANG_PATH points at the cross toolchain (e.g. Android NDK), that host build
+    // generates mismatched bindings, so reuse the bundled binding for the host instead.
+    // `update-bindings` still regenerates.
+    if target == host && env::var("CARGO_FEATURE_UPDATE_BINDINGS").is_err() {
+        let bundled = Path::new("src")
+            .join("bindings")
+            .join(format!("{}.rs", target));
+        if bundled.exists() {
+            println!(
+                "cargo:warning=using bundled bindings for host target `{}` instead of running bindgen (enable the `update-bindings` feature to regenerate)",
+                target
+            );
+            fs::copy(&bundled, out_dir.join("bindings.rs"))
+                .expect("Unable to copy bundled bindings");
+            return;
+        }
+    }
+
     let mut cflags = add_cflags;
 
     //format!("-I{}", out_dir.parent().display()),


### PR DESCRIPTION
### Issue # (if available)

https://github.com/DelSkayn/rquickjs/issues/709

### Description of changes

When cross-compiling with the `macro` feature, sys gets built for the host too, and if `LIBCLANG_PATH` points at the cross toolchain (e.g. Android NDK) that host build generates mismatched bindings. This makes the host build reuse the bundled binding when one exists instead of running bindgen, avoiding the mismatch.

### Checklist

- [x] Added change to the changelog
- [ ] Created unit tests for my feature if needed
