### PR TITLE
Support Uint8ClampedArray as TypedArray<U8Clamped>

### DIFF
--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -57,7 +57,9 @@ pub use context::MultiWith;
 #[cfg(feature = "futures")]
 #[cfg_attr(feature = "doc-cfg", doc(cfg(feature = "futures")))]
 pub use runtime::AsyncRuntime;
-pub use value::{ArrayBuffer, ArrayBufferSource, Iterable, IterableFn, JsIterator, TypedArray};
+pub use value::{
+    ArrayBuffer, ArrayBufferSource, Iterable, IterableFn, JsIterator, TypedArray, U8Clamped,
+};
 
 //#[doc(hidden)]
 pub mod qjs {

--- a/core/src/value.rs
+++ b/core/src/value.rs
@@ -33,7 +33,7 @@ pub mod typed_array;
 
 pub use array_buffer::{ArrayBuffer, ArrayBufferSource};
 pub use iterable::{Iterable, IterableFn, JsIterator};
-pub use typed_array::TypedArray;
+pub use typed_array::{TypedArray, U8Clamped};
 
 /// Any JavaScript value
 pub struct Value<'js> {

--- a/core/src/value/typed_array.rs
+++ b/core/src/value/typed_array.rs
@@ -47,6 +47,36 @@ typedarray_items! {
     BigUint64Array: u64, qjs::JSTypedArrayEnum_JS_TYPED_ARRAY_BIG_UINT64,
 }
 
+/// Element type for [`TypedArray`] over a `Uint8ClampedArray`.
+///
+/// `Uint8ClampedArray` stores `u8` values but is a distinct class from
+/// `Uint8Array`. This one-byte marker lets it be represented as
+/// `TypedArray<U8Clamped>`, since a bare `u8` already maps to `Uint8Array`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
+#[repr(transparent)]
+pub struct U8Clamped(pub u8);
+
+impl TypedArrayItem for U8Clamped {
+    const CLASS_NAME: PredefinedAtom = PredefinedAtom::Uint8ClampedArray;
+    const ARRAY_TYPE: qjs::JSTypedArrayEnum = qjs::JSTypedArrayEnum_JS_TYPED_ARRAY_UINT8C;
+}
+
+unsafe impl<'js> JsLifetime<'js> for U8Clamped {
+    type Changed<'to> = U8Clamped;
+}
+
+impl From<u8> for U8Clamped {
+    fn from(value: u8) -> Self {
+        Self(value)
+    }
+}
+
+impl From<U8Clamped> for u8 {
+    fn from(value: U8Clamped) -> Self {
+        value.0
+    }
+}
+
 #[cfg(feature = "half")]
 typedarray_items! {
     Float16Array: half::f16, qjs::JSTypedArrayEnum_JS_TYPED_ARRAY_FLOAT16,
@@ -62,6 +92,7 @@ typedarray_items! {
 /// | `Uint16Array`      | [`TypedArray<u16>`]   |
 /// | `Int32Array`       | [`TypedArray<i32>`]   |
 /// | `Uint32Array`      | [`TypedArray<u32>`]   |
+/// | `Uint8ClampedArray` | [`TypedArray<U8Clamped>`] |
 /// | `Float32Array`     | [`TypedArray<f32>`]   |
 /// | `Float64Array`     | [`TypedArray<f64>`]   |
 /// | `BigInt64Array`    | [`TypedArray<i64>`]   |
@@ -467,6 +498,42 @@ mod test {
 
             let obj = Object::new(ctx).unwrap();
             assert!(!obj.is_typed_array::<u8>());
+        });
+    }
+
+    #[test]
+    fn clamped_array() {
+        test_with(|ctx| {
+            // Uint8ClampedArray is a distinct class from Uint8Array.
+            let val: TypedArray<U8Clamped> =
+                ctx.eval("new Uint8ClampedArray([0, 300, 11])").unwrap();
+            assert_eq!(val.len(), 3);
+            // Values are clamped to the 0..=255 range by the engine.
+            assert_eq!(
+                AsRef::<[U8Clamped]>::as_ref(&val),
+                &[U8Clamped(0), U8Clamped(255), U8Clamped(11)]
+            );
+
+            let obj: Object = ctx.eval("new Uint8ClampedArray(1)").unwrap();
+            assert!(obj.is_typed_array::<U8Clamped>());
+            assert!(!obj.is_typed_array::<u8>());
+
+            let plain: Object = ctx.eval("new Uint8Array(1)").unwrap();
+            assert!(!plain.is_typed_array::<U8Clamped>());
+            assert!(plain.is_typed_array::<u8>());
+        });
+    }
+
+    #[test]
+    fn clamped_array_roundtrip() {
+        test_with(|ctx| {
+            let ta = TypedArray::new(ctx.clone(), [U8Clamped(1), U8Clamped(2)]).unwrap();
+            assert_eq!(ta.len(), 2);
+            assert_eq!(
+                AsRef::<[U8Clamped]>::as_ref(&ta),
+                &[U8Clamped(1), U8Clamped(2)]
+            );
+            assert!(ta.as_object().is_typed_array::<U8Clamped>());
         });
     }
 


### PR DESCRIPTION
`Uint8ClampedArray` is currently unreachable through the `TypedArray` API. It has no `TypedArrayItem` impl because it shares its element type (`u8`) with `Uint8Array`, so `TypedArray::<u8>::from_object` resolves to `Uint8Array` and `is_typed_array::<u8>()` returns `false` for a clamped array. There was no way to obtain or identify one without dropping to the raw `qjs` bindings.

This adds a one-byte `U8Clamped` marker type that implements `TypedArrayItem` (class `Uint8ClampedArray`, array type `JS_TYPED_ARRAY_UINT8C`). `Uint8ClampedArray` can now be used as `TypedArray<U8Clamped>` with all the existing machinery: `from_object`, `new`, `is_typed_array`, `as_ref`, `arraybuffer`, and so on.

`U8Clamped` derives the usual scalar traits and converts to/from `u8`. Added unit tests covering construction, engine-side clamping, and that it is kept distinct from `Uint8Array`.