### PR TITLE
Release 0.12.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,9 +19,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Fixed `rquickjs-sys` host build failing during cross-compilation by reusing bundled bindings for the host target instead of running bindgen with a mismatched `libclang` #[709](https://github.com/DelSkayn/rquickjs/issues/709)
-
 ### Security
+
+## [0.12.2] - 2026-07-27
+
+### Added
+
+- Added `TypedArray<U8Clamped>` support for `Uint8ClampedArray`, obtainable via `TypedArray::from_object` and matched by `is_typed_array` like other typed array classes
+
+### Fixed
+
+- Fixed `rquickjs-sys` host build failing during cross-compilation by reusing bundled bindings for the host target instead of running bindgen with a mismatched `libclang` #[709](https://github.com/DelSkayn/rquickjs/issues/709)
 
 ## [0.12.1] - 2026-06-29
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rquickjs"
-version = "0.12.1"
+version = "0.12.2"
 authors = ["Mees Delzenne <mees.delzenne@gmail.com>", "K. <kayo@illumium.org>"]
 edition = "2021"
 rust-version = "1.87"
@@ -26,10 +26,10 @@ members = [
 ]
 
 [workspace.dependencies]
-rquickjs-core = { version = "0.12.1", path = "core", default-features = false }
-rquickjs-macro = { version = "0.12.1", path = "macro", default-features = false }
-rquickjs-sys = { version = "0.12.1", path = "sys", default-features = false }
-rquickjs = { version = "0.12.1", path = "./", default-features = false }
+rquickjs-core = { version = "0.12.2", path = "core", default-features = false }
+rquickjs-macro = { version = "0.12.2", path = "macro", default-features = false }
+rquickjs-sys = { version = "0.12.2", path = "sys", default-features = false }
+rquickjs = { version = "0.12.2", path = "./", default-features = false }
 
 [dependencies]
 indexmap-rs = { package = "indexmap", version = "2", optional = true }

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rquickjs-core"
-version = "0.12.1"
+version = "0.12.2"
 authors = ["Mees Delzenne <mees.delzenne@gmail.com>", "K. <kayo@illumium.org>"]
 edition = "2021"
 license = "MIT"

--- a/examples/class-methods/Cargo.toml
+++ b/examples/class-methods/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "class-methods"
-version = "0.12.1"
+version = "0.12.2"
 authors = ["Emile Fugulin <code@efugulin.com>"]
 edition = "2018"
 publish = false

--- a/examples/exotic/Cargo.toml
+++ b/examples/exotic/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "exotic"
-version = "0.12.1"
+version = "0.12.2"
 authors = ["K. <kayo@illumium.org>"]
 edition = "2018"
 publish = false

--- a/examples/import-attributes/Cargo.toml
+++ b/examples/import-attributes/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "import-attributes"
-version = "0.12.1"
+version = "0.12.2"
 authors = ["K. <kayo@illumium.org>"]
 edition = "2021"
 publish = false

--- a/examples/module-loader/Cargo.toml
+++ b/examples/module-loader/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "module-loader"
-version = "0.12.1"
+version = "0.12.2"
 authors = ["K. <kayo@illumium.org>"]
 edition = "2018"
 publish = false

--- a/examples/native-module/Cargo.toml
+++ b/examples/native-module/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "native-module"
-version = "0.12.1"
+version = "0.12.2"
 authors = ["K. <kayo@illumium.org>"]
 edition = "2018"
 publish = false

--- a/examples/rquickjs-cli/Cargo.toml
+++ b/examples/rquickjs-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rquickjs-cli"
-version = "0.12.1"
+version = "0.12.2"
 authors = ["K. <kayo@illumium.org>"]
 edition = "2018"
 publish = false

--- a/macro/Cargo.toml
+++ b/macro/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rquickjs-macro"
-version = "0.12.1"
+version = "0.12.2"
 authors = ["K. <kayo@illumium.org>", "Mees Delzenne <mees.delzenne@gmail.com>"]
 edition = "2021"
 license = "MIT"

--- a/sys/Cargo.toml
+++ b/sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rquickjs-sys"
-version = "0.12.1"
+version = "0.12.2"
 authors = ["Mees Delzenne <mees.delzenne@gmail.com>"]
 edition = "2021"
 license = "MIT"


### PR DESCRIPTION
Patch release: adds `TypedArray<U8Clamped>` support for `Uint8ClampedArray` and fixes rquickjs-sys host build failing during cross-compilation.

See CHANGELOG.md for details.