### PR TITLE
Update native module examples to the current module macro

### DIFF
--- a/examples/module-loader/src/bundle.rs
+++ b/examples/module-loader/src/bundle.rs
@@ -1,14 +1,14 @@
-//#[cfg(not(feature = "macro"))]
+#[cfg(not(feature = "macro"))]
 mod hand_written;
 
-//#[cfg(feature = "macro")]
-//mod using_macro;
+#[cfg(feature = "macro")]
+mod using_macro;
 
-//#[cfg(not(feature = "macro"))]
+#[cfg(not(feature = "macro"))]
 pub use hand_written::NativeModule;
 
-//#[cfg(feature = "macro")]
-//pub use using_macro::NativeModule;
+#[cfg(feature = "macro")]
+pub use using_macro::NativeModule;
 
 pub const SCRIPT_MODULE: &str = r#"
 export const n = 123;

--- a/examples/module-loader/src/bundle/using_macro.rs
+++ b/examples/module-loader/src/bundle/using_macro.rs
@@ -1,10 +1,13 @@
-#[rquickjs::bind(module, public)]
-#[quickjs(bare)]
+#[rquickjs::module]
 #[allow(non_upper_case_globals)]
 pub mod native_module {
     pub const n: i32 = 123;
     pub const s: &str = "abc";
+
+    #[rquickjs::function]
     pub fn f(a: f64, b: f64) -> f64 {
         (a + b) * 0.5
     }
 }
+
+pub use js_native_module as NativeModule;

--- a/examples/native-module/src/lib.rs
+++ b/examples/native-module/src/lib.rs
@@ -1,13 +1,13 @@
-//#[cfg(not(feature = "macro"))]
+#[cfg(not(feature = "macro"))]
 mod hand_written;
 
-//#[cfg(not(feature = "macro"))]
+#[cfg(not(feature = "macro"))]
 use hand_written::NativeModule;
 
-//#[cfg(feature = "macro")]
-//mod using_macro;
+#[cfg(feature = "macro")]
+mod using_macro;
 
-//#[cfg(feature = "macro")]
-//use using_macro::NativeModule;
+#[cfg(feature = "macro")]
+use using_macro::NativeModule;
 
 rquickjs::module_init!(NativeModule);

--- a/examples/native-module/src/using_macro.rs
+++ b/examples/native-module/src/using_macro.rs
@@ -1,10 +1,13 @@
-#[rquickjs::bind(module, public)]
-#[quickjs(bare)]
+#[rquickjs::module]
 #[allow(non_upper_case_globals)]
-mod native_module {
+pub mod native_module {
     pub const n: i32 = 123;
     pub const s: &str = "abc";
+
+    #[rquickjs::function]
     pub fn f(a: f64, b: f64) -> f64 {
         (a + b) * 0.5
     }
 }
+
+pub use js_native_module as NativeModule;


### PR DESCRIPTION
The `using_macro` example files still used the `rquickjs::bind` macro that was removed back in 0.4.0, so they were left commented out of the build and only the hand written path was ever exercised. This ports them to the current `#[rquickjs::module]` macro and re-enables the macro feature toggle so both examples run through the macro path again, and I confirmed `module-loader` prints the expected output with and without the macro feature. Closes #483.