### PR TITLE
fix: safely read unaligned FFI arguments in defer_call_job and Params for LLP64 systems

### DIFF
--- a/core/src/value/function/ffi.rs
+++ b/core/src/value/function/ffi.rs
@@ -14,8 +14,8 @@ pub unsafe extern "C" fn defer_call_job(
     argc: qjs::c_int,
     argv: *mut qjs::JSValue,
 ) -> qjs::JSValue {
-    let func = *argv.offset((argc - 1) as _);
-    let this = *argv.offset((argc - 2) as _);
+    let func = argv.offset((argc - 1) as _).read_unaligned();
+    let this = argv.offset((argc - 2) as _).read_unaligned();
     let argc = argc - 2;
     qjs::JS_Call(ctx, func, this, argc, argv)
 }

--- a/core/src/value/function/params.rs
+++ b/core/src/value/function/params.rs
@@ -2,8 +2,8 @@ use crate::{
     function::{Exhaustive, Flat, FuncArg, Opt, Rest, This},
     qjs, Ctx, FromJs, Result, Value,
 };
-use alloc::vec::Vec;
-use core::slice;
+use alloc::{borrow::Cow, vec::Vec};
+use core::{mem::size_of, slice};
 
 /// A struct which contains the values a callback is called with.
 ///
@@ -12,7 +12,7 @@ pub struct Params<'a, 'js> {
     ctx: Ctx<'js>,
     function: qjs::JSValue,
     this: qjs::JSValue,
-    args: &'a [qjs::JSValue],
+    args: Cow<'a, [qjs::JSValue]>,
     is_constructor: bool,
 }
 
@@ -26,15 +26,30 @@ impl<'a, 'js> Params<'a, 'js> {
         argv: *mut qjs::JSValue,
         _flags: qjs::c_int,
     ) -> Self {
-        let args = if argv.is_null() {
+        let args: Cow<'a, [qjs::JSValue]> = if argv.is_null() {
             assert_eq!(
                 argc, 0,
                 "got a null pointer from quickjs for a non-zero number of args"
             );
-            [].as_slice()
+            Cow::Borrowed(&[])
         } else {
             let argc = usize::try_from(argc).expect("invalid argument number");
-            slice::from_raw_parts(argv, argc)
+            if argv.is_aligned() {
+                Cow::Borrowed(slice::from_raw_parts(argv, argc))
+            } else {
+                // QuickJS only guarantees four-byte alignment here on 32-bit MSVC.
+                let bytes = argv.cast::<u8>();
+                Cow::Owned(
+                    (0..argc)
+                        .map(|index| {
+                            bytes
+                                .add(index * size_of::<qjs::JSValue>())
+                                .cast::<qjs::JSValue>()
+                                .read_unaligned()
+                        })
+                        .collect(),
+                )
+            }
         };
 
         Self {
@@ -380,3 +395,48 @@ impl_from_params!(A, B, C, D);
 impl_from_params!(A, B, C, D, E);
 impl_from_params!(A, B, C, D, E, F);
 impl_from_params!(A, B, C, D, E, F, G);
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use core::mem::{align_of, size_of};
+
+    #[test]
+    fn misaligned_ffi_arguments_are_read_safely() {
+        crate::test_with(|ctx| {
+            let values = [
+                qjs::JS_MKVAL(qjs::JS_TAG_INT, 17),
+                qjs::JS_MKVAL(qjs::JS_TAG_INT, 42),
+            ];
+            let mut storage = vec![0_u8; size_of_val(&values) + 2 * align_of::<qjs::JSValue>()];
+            let offset = storage.as_ptr().align_offset(align_of::<qjs::JSValue>())
+                + align_of::<qjs::JSValue>() / 2;
+            let argv = unsafe { storage.as_mut_ptr().add(offset).cast::<qjs::JSValue>() };
+
+            for (index, value) in values.into_iter().enumerate() {
+                unsafe {
+                    storage
+                        .as_mut_ptr()
+                        .add(offset + index * size_of::<qjs::JSValue>())
+                        .cast::<qjs::JSValue>()
+                        .write_unaligned(value);
+                }
+            }
+
+            assert!(!argv.is_aligned());
+            let params = unsafe {
+                Params::from_ffi_class(
+                    ctx.as_ptr(),
+                    qjs::JS_UNDEFINED,
+                    qjs::JS_UNDEFINED,
+                    values.len() as _,
+                    argv,
+                    0,
+                )
+            };
+
+            assert_eq!(unsafe { qjs::JS_VALUE_GET_INT(params.args[0]) }, 17);
+            assert_eq!(unsafe { qjs::JS_VALUE_GET_INT(params.args[1]) }, 42);
+        });
+    }
+}


### PR DESCRIPTION
### Issue # (if available)

I noticed this error doing a refactor for [Den](https://github.com/stevefan1999-personal/den/actions/runs/33332686280/job/99313998437) on i686-pc-windows-msvc. It turns out, while QuickJS represents JSValue struct as uint64_t, on 32-bit Windows environment (aka LLP64 system), is only four-byte aligned and values larger than four bytes are not guaranteed to be aligned to eight bytes across stack, due to some gimmick backward compatibility to preserve MSVC int pointer alignment, hence it only happens on LLP64 system (while you can configure it to require 8-byte alignment, but the default behavior in MSVC is _preferred_ instead of mandatory). But Rust requires u64 to be eight-byte aligned. 

Nonetheless, on a proper 64-bit system with 64-bit machine word, this is not really an issue since everything is aligned correctly, including the JSValue itself and pointer to JSValue are both having same size.

### Description of changes

Do not assume FFI argc and argv read is always 8-byte/machine-word aligned and use unaligned read to prevent unaligned access violation.

On compilers that guarantees corrected alignment, this is effectively a no-op. Otherwise the scalar values are heap-copied rather than having direct pointer access. Hence the use of Cow.

### Checklist

- [ ] Added change to the changelog
- [x] Created unit tests for my feature if needed

### References
https://github.com/quickjs-ng/quickjs/issues/802
https://github.com/rust-lang/rust/issues/112480