### PR TITLE
Add DOMException bindings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added `Exception::throw_dom`, `PredefinedAtom::DOMException`, and `intrinsic::DOMException`.
+
 ### Changed
 
 ### Deprecated

--- a/core/src/context/builder.rs
+++ b/core/src/context/builder.rs
@@ -75,6 +75,8 @@ pub mod intrinsic {
         Performance JS_AddPerformance,
         /// Add WeakRef support
         WeakRef JS_AddIntrinsicWeakRef,
+        /// Add DOMException
+        DOMException JS_AddIntrinsicDOMException,
     }
 
     /// Add none intrinsics
@@ -93,6 +95,7 @@ pub mod intrinsic {
         Promise,
         Performance,
         WeakRef,
+        DOMException,
     );
 }
 

--- a/core/src/value/atom/predefined.rs
+++ b/core/src/value/atom/predefined.rs
@@ -394,6 +394,8 @@ pub enum PredefinedAtom {
     URIError = qjs::JS_ATOM_URIError as u32,
     /// "InternalError"
     InternalError = qjs::JS_ATOM_InternalError as u32,
+    /// "DOMException"
+    DOMException = qjs::JS_ATOM_DOMException as u32,
     /// "Symbol.asyncIterator"
     SymbolAsyncIterator = qjs::JS_ATOM_Symbol_asyncIterator as u32,
     /// "Symbol.iterator"
@@ -636,6 +638,7 @@ impl PredefinedAtom {
             PredefinedAtom::TypeError => "TypeError",
             PredefinedAtom::URIError => "URIError",
             PredefinedAtom::InternalError => "InternalError",
+            PredefinedAtom::DOMException => "DOMException",
             PredefinedAtom::SymbolAsyncIterator => "Symbol.asyncIterator",
             PredefinedAtom::SymbolIterator => "Symbol.iterator",
             PredefinedAtom::SymbolMatch => "Symbol.match",
@@ -850,6 +853,7 @@ mod test {
             PredefinedAtom::TypeError,
             PredefinedAtom::URIError,
             PredefinedAtom::InternalError,
+            PredefinedAtom::DOMException,
             PredefinedAtom::SymbolAsyncIterator,
             PredefinedAtom::SymbolIterator,
             PredefinedAtom::SymbolMatch,

--- a/core/src/value/exception.rs
+++ b/core/src/value/exception.rs
@@ -194,7 +194,25 @@ impl<'js> Exception<'js> {
         Error::Exception
     }
 
-    /// Sets the exception as the current error an returns `Error::Exception`
+    /// Throws a new DOMException.
+    pub fn throw_dom(ctx: &Ctx<'js>, name: &str, message: &str) -> Error {
+        let mut name_buffer = [MaybeUninit::uninit(); 256];
+        truncate_cstr_into(&mut name_buffer, name);
+        let mut message_buffer = [MaybeUninit::uninit(); 256];
+        truncate_cstr_into(&mut message_buffer, message);
+        unsafe {
+            let res = qjs::JS_ThrowDOMException(
+                ctx.as_ptr(),
+                name_buffer.as_ptr().cast(),
+                ERROR_FORMAT_STR.as_ptr(),
+                message_buffer.as_mut_ptr(),
+            );
+            debug_assert_eq!(qjs::JS_VALUE_GET_NORM_TAG(res), qjs::JS_TAG_EXCEPTION);
+        }
+        Error::Exception
+    }
+
+    /// Sets the exception as the current error and returns `Error::Exception`
     pub fn throw(self) -> Error {
         let ctx = self.ctx().clone();
         ctx.throw(self.0.into_value())
@@ -213,5 +231,33 @@ impl fmt::Display for Exception<'_> {
             stack.fmt(f)?;
         }
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::{
+        atom::PredefinedAtom, context::intrinsic, Context, Error, Exception, Object, Runtime,
+    };
+
+    #[test]
+    fn test_throw_dom() {
+        let rt = Runtime::new().unwrap();
+        let ctx = Context::custom::<intrinsic::DOMException>(&rt).unwrap();
+        ctx.with(|ctx| {
+            let e = Exception::throw_dom(&ctx, "SyntaxError", "oh no");
+            assert!(matches!(e, Error::Exception), "{e}");
+            let exception = ctx.catch().into_object().unwrap();
+            assert!(exception.is_instance_of(
+                ctx.globals()
+                    .get::<_, Object>(PredefinedAtom::DOMException)
+                    .unwrap()
+            ));
+            assert_eq!(
+                exception.get::<_, i32>("code").unwrap(),
+                // SyntaxError's legacy code
+                12
+            );
+        });
     }
 }


### PR DESCRIPTION
### Description of changes

Adds bindings for `JS_ThrowDOMException`, `JS_ATOM_DOMException`, `JS_AddIntrinsicDOMException`.

### Checklist

- [x] Added change to the changelog
- [x] Created unit tests for my feature if needed
