### PR TITLE
Fix Params::is_constructor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fixed `Params::is_constructor` to return the suggested value instead of `false`.
+
 ### Security
 
 ## [0.13.0] - 2026-09-07

--- a/core/src/value/function/params.rs
+++ b/core/src/value/function/params.rs
@@ -24,7 +24,7 @@ impl<'a, 'js> Params<'a, 'js> {
         this: qjs::JSValue,
         argc: qjs::c_int,
         argv: *mut qjs::JSValue,
-        _flags: qjs::c_int,
+        flags: qjs::c_int,
     ) -> Self {
         let args: Cow<'a, [qjs::JSValue]> = if argv.is_null() {
             assert_eq!(
@@ -52,12 +52,14 @@ impl<'a, 'js> Params<'a, 'js> {
             }
         };
 
+        let is_constructor = (flags & qjs::JS_CALL_FLAG_CONSTRUCTOR as qjs::c_int) != 0;
+
         Self {
             ctx: Ctx::from_ptr(ctx),
             function,
             this,
             args,
-            is_constructor: false,
+            is_constructor,
         }
     }
 
@@ -398,6 +400,8 @@ impl_from_params!(A, B, C, D, E, F, G);
 
 #[cfg(test)]
 mod tests {
+    use crate::{function::IntoJsFunc, Function, IntoJs};
+
     use super::*;
     use core::mem::{align_of, size_of};
 
@@ -437,6 +441,30 @@ mod tests {
 
             assert_eq!(unsafe { qjs::JS_VALUE_GET_INT(params.args[0]) }, 17);
             assert_eq!(unsafe { qjs::JS_VALUE_GET_INT(params.args[1]) }, 42);
+        });
+    }
+
+    #[test]
+    fn is_constructor() {
+        crate::test_with(|ctx| {
+            struct ReturnIsConstructor;
+            impl<'js> IntoJsFunc<'js, ()> for ReturnIsConstructor {
+                fn param_requirements() -> ParamRequirement {
+                    ParamRequirement::any()
+                }
+                fn call<'a>(&self, params: Params<'a, 'js>) -> Result<Value<'js>> {
+                    params.is_constructor().into_js(params.ctx())
+                }
+            }
+            let f = Function::new(ctx, ReturnIsConstructor)
+                .unwrap()
+                .with_constructor(true);
+            assert!(!f.call::<(), bool>(()).unwrap());
+            assert!(f
+                .as_constructor()
+                .unwrap()
+                .construct::<(), bool>(())
+                .unwrap());
         });
     }
 }


### PR DESCRIPTION
### Description of changes

`is_constructor()` always returned false. It should presumably return whether `flags` contained `JS_CALL_FLAG_CONSTRUCTOR`.

### Checklist

- [x] Added change to the changelog
- [x] Created unit tests for my feature if needed
